### PR TITLE
feat：作品感想投稿にリレーションの追加

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -12,6 +12,9 @@ class User extends Authenticatable
 {
     use HasApiTokens, HasFactory, Notifiable;
 
+    // 参照させたいworksを指定
+    protected $table = 'users';
+
     /**
      * The attributes that are mass assignable.
      *
@@ -42,4 +45,10 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
+
+    // WorkReviewに対するリレーション 1対1の関係
+    public function workreview()
+    {
+        return $this->belongsTo(WorkReview::class);
+    }
 }

--- a/app/Models/Work.php
+++ b/app/Models/Work.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Work extends Model
+{
+    use HasFactory;
+
+    // 参照させたいworksを指定
+    protected $table = 'works';
+
+    // WorkReviewに対するリレーション 1対1の関係
+    public function workreview()
+    {
+        return $this->belongsTo(WorkReview::class);
+    }
+}

--- a/app/Models/WorkReview.php
+++ b/app/Models/WorkReview.php
@@ -25,4 +25,16 @@ class WorkReview extends Model
     {
         return $this->orderBy('created_at', 'DESC')->paginate($limit_count);
     }
+
+    // Workに対するリレーション 1対1の関係
+    public function work()
+    {
+        return $this->belongsTo(Work::class);
+    }
+
+    // Userに対するリレーション 1対1の関係
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/WorkReviewCategory.php
+++ b/app/Models/WorkReviewCategory.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class WorkReviewCategory extends Model
+{
+    use HasFactory;
+}

--- a/resources/views/work_reviews/show.blade.php
+++ b/resources/views/work_reviews/show.blade.php
@@ -16,9 +16,9 @@
     <div class="content">
         <div class="content__post">
             <h3>作品名</h3>
-            <p>{{ $post->work_id }}</p>
+            <p>{{ $post->work->name }}</p>
             <h3>投稿者</h3>
-            <p>{{ $post->user_id }}</p>
+            <p>{{ $post->user->name }}</p>
             <h3>本文</h3>
             <p>{{ $post->body }}</p>
             <h3>作成日</h3>

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,5 +38,4 @@ Route::put('/work_reviews/{workreview}', [WorkReviewController::class, 'update']
 // 感想投稿の削除を行うdeleteメソッドを実行
 Route::delete('/work_reviews/{workreview}', [WorkReviewController::class,'delete']);
 
-// 感想投稿詳細画面から削除を行うdeleteメソッドを実行
-//Route::delete('/work_reviews/{workreview}', [WorkReviewController::class,'delete']);
+


### PR DESCRIPTION
### 作品感想投稿にリレーションの追加

・1対1の関係であるWorkReviewsとUsers、WorkReviewsとWorksに関してリレーションを実行。
・感想投稿詳細画面にて作品名と投稿者が確認可能
・現在は感想新規投稿画面で作品名と投稿者を記入する欄があるが、本来、作品名に関しては「作品ページ→感想投稿一覧」に遷移するため記入する必要がなく、さらに投稿者名に関してもログインしているユーザーの名前が自動で表示されるため記入する必要がない。これは後に改善を行う。

・作品名と投稿者が確認可能な感想投稿詳細画面
![スクリーンショット 2024-10-18 184951](https://github.com/user-attachments/assets/d2b493aa-73ed-42dd-ab13-1673bf8b03a0)
