### PR TITLE
Feat：作品一覧画面から感想投稿詳細画面までのルーティング整理

### DIFF
--- a/app/Http/Controllers/WorkController.php
+++ b/app/Http/Controllers/WorkController.php
@@ -12,4 +12,10 @@ class WorkController extends Controller
     {
         return view('works.index')->with(['works' => $work->getPaginateByLimit()]);
     }
+
+    // 詳細な作品情報を表示する
+    public function show(Work $work)
+    {
+        return view('works.show')->with(['work' => $work]);
+    }
 }

--- a/app/Http/Controllers/WorkController.php
+++ b/app/Http/Controllers/WorkController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Work;
+use Illuminate\Http\Request;
+
+class WorkController extends Controller
+{
+    // 作品一覧画面の表示
+    public function index(Work $work)
+    {
+        return view('works.index')->with(['works' => $work->get()]);
+    }
+}

--- a/app/Http/Controllers/WorkController.php
+++ b/app/Http/Controllers/WorkController.php
@@ -10,6 +10,6 @@ class WorkController extends Controller
     // 作品一覧画面の表示
     public function index(Work $work)
     {
-        return view('works.index')->with(['works' => $work->get()]);
+        return view('works.index')->with(['works' => $work->getPaginateByLimit()]);
     }
 }

--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -9,7 +9,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class WorkReviewController extends Controller
 {
     use SoftDeletes;
-    
+
     // インポートしたPostをインスタンス化して$postとして使用。
     public function index(WorkReview $work_reviews)
     {

--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -11,16 +11,17 @@ class WorkReviewController extends Controller
     use SoftDeletes;
 
     // インポートしたPostをインスタンス化して$postとして使用。
-    public function index(WorkReview $work_reviews)
+    public function index(WorkReview $work_reviews, $work_id)
     {
         // blade内の変数postsにインスタンス化した$work_reviewsを代入
-        return view('work_reviews.index')->with(['posts' => $work_reviews->getPaginateByLimit()]);
+        // 指定したidのアニメの投稿のみを表示
+        return view('work_reviews.index')->with(['posts' => $work_reviews->getPaginateByLimit($work_id)]);
     }
 
-    // 'post'はbladeファイルで使う変数。$postはid=1のWorkReviewインスタンス。
-    public function show(WorkReview $workreview)
+    // 'post'はbladeファイルで使う変数。
+    public function show(WorkReview $workreview, $work_id, $post_id)
     {
-        return view('work_reviews.show')->with(['post' => $workreview]);
+        return view('work_reviews.show')->with(['post' => $workreview->getDetailPost($work_id, $post_id)]);
     }
 
     // 新規投稿作成画面を表示する

--- a/app/Models/Work.php
+++ b/app/Models/Work.php
@@ -17,4 +17,10 @@ class Work extends Model
     {
         return $this->belongsTo(WorkReview::class);
     }
+
+    // created_atで降順に並べたあと、limitで件数制限をかける
+    public function getPaginateByLimit(int $limit_count = 5)
+    {
+        return $this->orderBy('id', 'ASC')->paginate($limit_count);
+    }
 }

--- a/app/Models/WorkReview.php
+++ b/app/Models/WorkReview.php
@@ -20,10 +20,21 @@ class WorkReview extends Model
     // 参照させたいwork_reviewsを指定
     protected $table = 'work_reviews';
 
+    // 条件を満たすデータだけを取得する
+
     // created_atで降順に並べたあと、limitで件数制限をかける
-    public function getPaginateByLimit(int $limit_count = 5)
+    public function getPaginateByLimit($work_id, int $limit_count = 5)
     {
-        return $this->orderBy('created_at', 'DESC')->paginate($limit_count);
+        return $this->where('work_id', $work_id)->orderBy('created_at', 'DESC')->paginate($limit_count);
+    }
+
+    // 作品idと投稿idを指定して、投稿の詳細表示を行う
+    public function getDetailPost($work_id, $post_id)
+    {
+        return $this->where([
+            ['work_id', $work_id],
+            ['id', $post_id],
+        ])->first();
     }
 
     // Workに対するリレーション 1対1の関係

--- a/resources/views/work_reviews/index.blade.php
+++ b/resources/views/work_reviews/index.blade.php
@@ -22,7 +22,7 @@
                 <form action="/work_reviews/{{ $post->id }}" id="form_{{ $post->id }}" method="post">
                     @csrf
                     @method('DELETE')
-                    <button type="button" onclick="deletePost({{ $post->id }})">投稿を削除する</button>
+                    <button type="button" data-post-id="{{ $post->id }}" class="delete-button">投稿を削除する</button>
                 </form>
             </div>
             @endforeach
@@ -33,11 +33,23 @@
     </div>
 
     <script>
-        function deletePost(id) {
+        // DOMツリー読み取り完了後にイベント発火
+        document.addEventListener('DOMContentLoaded', function() {
+            // delete-buttonに一致するすべてのHTML要素を取得
+            document.querySelectorAll('.delete-button').forEach(function(button) {
+                button.addEventListener('click', function() {
+                    const postId = button.getAttribute('data-post-id');
+                    deletePost(postId);
+                });
+            });
+        });
+
+        // 削除処理を行う
+        function deletePost(postId) {
             'use strict'
 
             if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
-                document.getElementById(`form_${id}`).submit();
+                document.getElementById(`form_${postId}`).submit();
             }
         }
     </script>

--- a/resources/views/work_reviews/index.blade.php
+++ b/resources/views/work_reviews/index.blade.php
@@ -16,7 +16,7 @@
             @foreach ($posts as $post)
             <div class='post'>
                 <h2 class='title'>
-                    <a href="/work_reviews/{{ $post->id }}">{{ $post->post_title }}</a>
+                    <a href="{{ route('work_reviews.show', ['work_id' => $post->work_id, 'post_id' => $post->id]) }}">{{ $post->post_title }}</a>
                 </h2>
                 <p class='body'>{{ $post->body }}</p>
                 <form action="/work_reviews/{{ $post->id }}" id="form_{{ $post->id }}" method="post">

--- a/resources/views/work_reviews/show.blade.php
+++ b/resources/views/work_reviews/show.blade.php
@@ -32,7 +32,7 @@
         <button type="button" data-post-id="{{ $post->id }}" class="delete-button">投稿を削除する</button>
     </form>
     <div class="footer">
-        <a href="/">戻る</a>
+        <a href="{{ route('work_reviews.index', ['work_id' => $post->work_id]) }}">戻る</a>
     </div>
 
     <script>

--- a/resources/views/work_reviews/show.blade.php
+++ b/resources/views/work_reviews/show.blade.php
@@ -29,18 +29,30 @@
     <form action="/work_reviews/{{ $post->id }}" id="form_{{ $post->id }}" method="post">
         @csrf
         @method('DELETE')
-        <button type="button" onclick="deletePost({{ $post->id }})">投稿を削除する</button>
+        <button type="button" data-post-id="{{ $post->id }}" class="delete-button">投稿を削除する</button>
     </form>
     <div class="footer">
         <a href="/">戻る</a>
     </div>
 
     <script>
-        function deletePost(id) {
+        // DOMツリー読み取り完了後にイベント発火
+        document.addEventListener('DOMContentLoaded', function() {
+            // delete-buttonに一致するすべてのHTML要素を取得
+            document.querySelectorAll('.delete-button').forEach(function(button) {
+                button.addEventListener('click', function() {
+                    const postId = button.getAttribute('data-post-id');
+                    deletePost(postId);
+                });
+            });
+        });
+
+        // 削除処理を行う
+        function deletePost(postId) {
             'use strict'
 
             if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
-                document.getElementById(`form_${id}`).submit();
+                document.getElementById(`form_${postId}`).submit();
             }
         }
     </script>

--- a/resources/views/works/index.blade.php
+++ b/resources/views/works/index.blade.php
@@ -18,6 +18,9 @@
         </div>
         @endforeach
     </div>
+    <div class='paginate'>
+        {{ $works->links() }}
+    </div>
 </body>
 
 </html>

--- a/resources/views/works/index.blade.php
+++ b/resources/views/works/index.blade.php
@@ -13,7 +13,9 @@
     <div class='works'>
         @foreach ($works as $work)
         <div class='work'>
-            <h2 class='title'>{{ $work->name }}</h2>
+            <h2 class='name'>
+                <a href="/works/{{ $work->id }}">{{ $work->name }}</a>
+            </h2>
             <p class='term'>{{ $work->term }}</p>
         </div>
         @endforeach

--- a/resources/views/works/index.blade.php
+++ b/resources/views/works/index.blade.php
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+<head>
+    <meta charset="utf-8">
+    <title>Blog</title>
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+</head>
+
+<body>
+    <h1>作品一覧</h1>
+    <div class='works'>
+        @foreach ($works as $work)
+        <div class='work'>
+            <h2 class='title'>{{ $work->name }}</h2>
+            <p class='term'>{{ $work->term }}</p>
+        </div>
+        @endforeach
+    </div>
+</body>
+
+</html>

--- a/resources/views/works/show.blade.php
+++ b/resources/views/works/show.blade.php
@@ -33,6 +33,7 @@
             <p>{{ $work->wiki_link }}</p>
             <h3>Twitterへのリンク</h3>
             <p>{{ $work->twitter_link }}</p>
+            <a href="{{ route('work_reviews.index', ['work_id' => $work->id]) }}">作品感想一覧</a>
         </div>
     </div>
     <div class="footer">

--- a/resources/views/works/show.blade.php
+++ b/resources/views/works/show.blade.php
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML>
+<html lang="ja">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>作品詳細画面</title>
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+</head>
+
+<body>
+    <h1 class="title">
+        {{ $work->name }}
+    </h1>
+    <div class="content">
+        <div class="content__post">
+            <h3>作品名</h3>
+            <p>{{ $work->name }}</p>
+            <h3>放映期間</h3>
+            <p>{{ $work->term }}</p>
+            <h3>制作会社</h3>
+            <p>{{ $work->creator_id }}</p>
+            <h3>楽曲</h3>
+            <p>{{ $work->music_id }}</p>
+            <h3>登場人物</h3>
+            <p>{{ $work->character_id }}</p>
+            <h3>聖地</h3>
+            <p>{{ $work->anime_pilgrimage_id }}</p>
+            <h3>公式サイトへのリンク</h3>
+            <p>{{ $work->official_site_link }}</p>
+            <h3>Wikipediaへのリンク</h3>
+            <p>{{ $work->wiki_link }}</p>
+            <h3>Twitterへのリンク</h3>
+            <p>{{ $work->twitter_link }}</p>
+        </div>
+    </div>
+    <div class="footer">
+        <a href="/works">戻る</a>
+    </div>
+</body>
+
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\WorkReviewController;
+use App\Http\Controllers\WorkController; 
 
 /*
 |--------------------------------------------------------------------------
@@ -18,6 +19,10 @@ use App\Http\Controllers\WorkReviewController;
     return view('posts.work_review_index');
 });*/
 
+// 作品一覧の表示
+Route::get('/works', [WorkController::class, 'index']);
+
+// 各作品ごとの感想投稿一覧の表示
 Route::get('/', [WorkReviewController::class, 'index']);
 
 // 新規投稿作成ボタン押下で、createメソッドを実行

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,9 @@ use App\Http\Controllers\WorkController;
 // 作品一覧の表示
 Route::get('/works', [WorkController::class, 'index']);
 
+// 各作品の詳細表示
+Route::get('/works/{work}', [WorkController::class ,'show']);
+
 // 各作品ごとの感想投稿一覧の表示
 Route::get('/', [WorkReviewController::class, 'index']);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,7 +26,7 @@ Route::get('/works', [WorkController::class, 'index']);
 Route::get('/works/{work}', [WorkController::class ,'show']);
 
 // 各作品ごとの感想投稿一覧の表示
-Route::get('/', [WorkReviewController::class, 'index']);
+Route::get('/work_reviews/{work_id}', [WorkReviewController::class, 'index'])->name('work_reviews.index');
 
 // 新規投稿作成ボタン押下で、createメソッドを実行
 Route::get('/work_reviews/create', [WorkReviewController::class, 'create']);
@@ -35,7 +35,7 @@ Route::get('/work_reviews/create', [WorkReviewController::class, 'create']);
 Route::post('/work_reviews', [WorkReviewController::class, 'store']);
 
 // '/work_reviews/{対象データのID}'にGetリクエストが来たら、showメソッドを実行
-Route::get('/work_reviews/{workreview}', [WorkReviewController::class ,'show']);
+Route::get('/work_reviews/{work_id}/work_reviews/{post_id}', [WorkReviewController::class ,'show'])->name('work_reviews.show');
 
 // 感想投稿編集画面を表示するeditメソッドを実行
 Route::get('/work_reviews/{workreview}/edit', [WorkReviewController::class, 'edit']);


### PR DESCRIPTION
### 作品一覧画面から感想投稿詳細画面までのルーティング整理

・感想投稿一覧は各作品一覧から遷移するため、作品一覧画面の作成
・作品一覧画面に加えて、各作品の詳細画面の作成
・各作品の詳細画面から感想投稿に遷移するよう、既存の感想投稿一覧のルーティングを整理
・結果、作品一覧画面→各作品の詳細画面→感想投稿一覧→感想投稿詳細画面までの遷移が可能に

ルーティング整理後の新規感想投稿や編集、削除は後のPRで実施予定。

・また、Viewで起きていたJavaScript周りで赤い波線が出る問題を解決

・作品一覧画面
![スクリーンショット 2024-10-20 131436](https://github.com/user-attachments/assets/f143a79b-5306-45dc-bb06-44edba7133bd)

・各作品の詳細画面の例1
![スクリーンショット 2024-10-20 131455](https://github.com/user-attachments/assets/c96e8fb8-b545-4758-b419-0ba26a906880)

・各作品の詳細画面の例2
![スクリーンショット 2024-10-20 131507](https://github.com/user-attachments/assets/1c82b59a-b841-43a9-947c-dd14752ab151)
