### PR TITLE
Feat：作品一覧画面から遷移した場合の感想投稿に関するCUD機能のルーティング整理

### DIFF
--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -25,9 +25,9 @@ class WorkReviewController extends Controller
     }
 
     // 新規投稿作成画面を表示する
-    public function create()
+    public function create(WorkReview $workreview, $work_id)
     {
-        return view('work_reviews.create');
+        return view('work_reviews.create')->with(['workreview' => $workreview->getRestrictedPost('work_id', $work_id)]);
     }
 
     // 新しく記述した内容を保存する

--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -55,9 +55,11 @@ class WorkReviewController extends Controller
     }
 
     // 感想投稿を削除する
-    public function delete(WorkReview $workreview)
+    public function delete(WorkReview $workreview, $work_id, $post_id)
     {
-        $workreview->delete();
-        return redirect('/');
+        // 編集の対象となるデータを取得
+        $targetworkreview = $workreview->getDetailPost($work_id, $post_id);
+        $targetworkreview->delete();
+        return redirect()->route('work_reviews.index', ['work_id' => $work_id]);
     }
 }

--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -15,7 +15,7 @@ class WorkReviewController extends Controller
     {
         // blade内の変数postsにインスタンス化した$work_reviewsを代入
         // 指定したidのアニメの投稿のみを表示
-        return view('work_reviews.index')->with(['posts' => $work_reviews->getPaginateByLimit($work_id)]);
+        return view('work_reviews.index')->with(['posts' => $work_reviews->getPaginateByLimit($work_id), 'work' => $work_reviews->getRestrictedPost('work_id', $work_id)]);
     }
 
     // 'post'はbladeファイルで使う変数。

--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -35,7 +35,7 @@ class WorkReviewController extends Controller
     {
         $input = $request['work_review'];
         $workreview->fill($input)->save();
-        return redirect('/work_reviews/' . $workreview->id);
+        return redirect()->route('work_reviews.show', ['work_id' => $workreview->work_id, 'post_id' => $workreview->id]);
     }
 
     // 感想投稿編集画面を表示する

--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -39,17 +39,19 @@ class WorkReviewController extends Controller
     }
 
     // 感想投稿編集画面を表示する
-    public function edit(WorkReview $workreview)
+    public function edit(WorkReview $workreview, $work_id, $post_id)
     {
-        return view('work_reviews.edit')->with(['post' => $workreview]);
+        return view('work_reviews.edit')->with(['post' => $workreview->getDetailPost($work_id, $post_id)]);
     }
 
     // 感想投稿の編集を実行する
-    public function update(WorkReviewRequest $request, WorkReview $workreview)
+    public function update(WorkReviewRequest $request, WorkReview $workreview, $work_id, $post_id)
     {
         $input_post = $request['work_review'];
-        $workreview->fill($input_post)->save();
-        return redirect('/work_reviews/' . $workreview->id);
+        // 編集の対象となるデータを取得
+        $targetworkreview = $workreview->getDetailPost($work_id, $post_id);
+        $targetworkreview->fill($input_post)->save();
+        return redirect()->route('work_reviews.show', ['work_id' => $targetworkreview->work_id, 'post_id' => $targetworkreview->id]);
     }
 
     // 感想投稿を削除する

--- a/app/Http/Requests/WorkReviewRequest.php
+++ b/app/Http/Requests/WorkReviewRequest.php
@@ -18,7 +18,6 @@ class WorkReviewRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'work_review.user_id' => 'required|integer',
             'work_review.post_title' => 'required|string|max:100',
             'work_review.body' => 'required|string|max:4000',
         ];

--- a/app/Http/Requests/WorkReviewRequest.php
+++ b/app/Http/Requests/WorkReviewRequest.php
@@ -18,7 +18,6 @@ class WorkReviewRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'work_review.work_id' => 'required|integer',
             'work_review.user_id' => 'required|integer',
             'work_review.post_title' => 'required|string|max:100',
             'work_review.body' => 'required|string|max:4000',

--- a/app/Models/WorkReview.php
+++ b/app/Models/WorkReview.php
@@ -12,8 +12,8 @@ class WorkReview extends Model
     // fillを実行するための記述
     protected $fillable = [
         'work_id',
-        'post_title',
         'user_id',
+        'post_title',
         'body',
     ];
 

--- a/app/Models/WorkReview.php
+++ b/app/Models/WorkReview.php
@@ -37,6 +37,12 @@ class WorkReview extends Model
         ])->first();
     }
 
+    // 条件とその値を指定してデータを1件取得する
+    public function getRestrictedPost($condition, $column_name)
+    {
+        return $this->where($condition, $column_name)->first();
+    }
+
     // Workに対するリレーション 1対1の関係
     public function work()
     {

--- a/resources/views/work_reviews/create.blade.php
+++ b/resources/views/work_reviews/create.blade.php
@@ -14,7 +14,6 @@
             <input type="hidden" name="work_review[work_id]" value="{{ $workreview->work_id }}">
         </div>
         <div class="user_id">
-            <h2>投稿者</h2>
             <input type="hidden" name="work_review[user_id]" value="{{ $workreview->user_id }}">
         </div>
         <div class="title">

--- a/resources/views/work_reviews/create.blade.php
+++ b/resources/views/work_reviews/create.blade.php
@@ -1,37 +1,37 @@
 <!DOCTYPE HTML>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
-    <head>
-        <meta charset="utf-8">
-        <title>作品の感想投稿</title>
-    </head>
-    <body>
-        <h1>「{{$workreview->work->name}}」への新規感想投稿</h1>
-        <form action="/work_reviews" method="POST">
-            @csrf
-            <div class="work_id">
-                <h2>作品名</h2>
-                <input type="text" name="work_review[work_id]" placeholder="作品名" value="{{ old('work_review.work_id') }}"/>
-                <p class="id__error" style="color:red">{{ $errors->first('work_review.work_id') }}</p>
-            </div>
-            <div class="title">
-                <h2>タイトル</h2>
-                <input type="text" name="work_review[post_title]" placeholder="タイトル" value="{{ old('work_review.post_title') }}"/>
-                <p class="title__error" style="color:red">{{ $errors->first('work_review.post_title') }}</p>
-            </div>
-            <div class="user_id">
-                <h2>投稿者</h2>
-                <input type="text" name="work_review[user_id]" placeholder="投稿者" value="{{ old('work_review.user_id') }}"/>
-                <p class="user__error" style="color:red">{{ $errors->first('work_review.user_id') }}</p>
-            </div>
-            <div class="body">
-                <h2>内容</h2>
-                <textarea name="work_review[body]" placeholder="内容を記入してください。">{{ old('work_review.body') }}</textarea>
-                <p class="body__error" style="color:red">{{ $errors->first('work_review.body') }}</p>
-            </div>
-            <input type="submit" value="作成する"/>
-        </form>
-        <div class="footer">
-            <a href="/">戻る</a>
+
+<head>
+    <meta charset="utf-8">
+    <title>作品の感想投稿</title>
+</head>
+
+<body>
+    <h1>「{{$workreview->work->name}}」への新規感想投稿</h1>
+    <form action="{{ route('work_reviews.store', ['work_id' => $workreview->work_id]) }}" method="POST">
+        @csrf
+        <div class="work_id">
+            <input type="hidden" name="work_review[work_id]" value="{{ $workreview->work_id }}">
         </div>
-    </body>
+        <div class="user_id">
+            <h2>投稿者</h2>
+            <input type="hidden" name="work_review[user_id]" value="{{ $workreview->user_id }}">
+        </div>
+        <div class="title">
+            <h2>タイトル</h2>
+            <input type="text" name="work_review[post_title]" placeholder="タイトル" value="{{ old('work_review.post_title') }}" />
+            <p class="title__error" style="color:red">{{ $errors->first('work_review.post_title') }}</p>
+        </div>
+        <div class="body">
+            <h2>内容</h2>
+            <textarea name="work_review[body]" placeholder="内容を記入してください。">{{ old('work_review.body') }}</textarea>
+            <p class="body__error" style="color:red">{{ $errors->first('work_review.body') }}</p>
+        </div>
+        <button type="submit">投稿する</button>
+    </form>
+    <div class="footer">
+        <a href="{{ route('work_reviews.index', ['work_id' => $workreview->work_id]) }}">戻る</a>
+    </div>
+</body>
+
 </html>

--- a/resources/views/work_reviews/create.blade.php
+++ b/resources/views/work_reviews/create.blade.php
@@ -5,7 +5,7 @@
         <title>作品の感想投稿</title>
     </head>
     <body>
-        <h1>作品の新規感想投稿</h1>
+        <h1>「{{$workreview->work->name}}」への新規感想投稿</h1>
         <form action="/work_reviews" method="POST">
             @csrf
             <div class="work_id">

--- a/resources/views/work_reviews/edit.blade.php
+++ b/resources/views/work_reviews/edit.blade.php
@@ -9,32 +9,31 @@
 </head>
 
 <body>
-    <h1 class="title">投稿の編集画面</h1>
+    <h1 class="title">{{ $post->work->name }}への投稿編集画面</h1>
     <div class="content">
-        <form action="/work_reviews/{{ $post->id }}" method="POST">
+        <form action="{{ route('work_reviews.update', ['work_id' => $post->work_id, 'post_id' => $post->id]) }}" method="POST">
             @csrf
             @method('PUT')
             <div class="work_id">
-                <h2>作品名</h2>
-                <input type="text" name="work_review[work_id]" placeholder="作品名" value="{{ $post->work_id }}"/>
-                <p class="id__error" style="color:red">{{ $errors->first('work_review.work_id') }}</p>
+                <input type="hidden" name="work_review[work_id]" value="{{ $post->work_id }}">
+            </div>
+            <div class="user_id">
+                <input type="hidden" name="work_review[user_id]" value="{{ $post->user_id }}">
             </div>
             <div class="title">
                 <h2>タイトル</h2>
                 <input type="text" name="work_review[post_title]" placeholder="タイトル" value="{{ $post->post_title }}"/>
                 <p class="title__error" style="color:red">{{ $errors->first('work_review.post_title') }}</p>
             </div>
-            <div class="user_id">
-                <h2>投稿者</h2>
-                <input type="text" name="work_review[user_id]" placeholder="投稿者" value="{{ $post->user_id }}"/>
-                <p class="user__error" style="color:red">{{ $errors->first('work_review.user_id') }}</p>
-            </div>
             <div class="body">
                 <h2>内容</h2>
                 <textarea name="work_review[body]" placeholder="内容を記入してください。">{{ $post->body }}</textarea>
                 <p class="body__error" style="color:red">{{ $errors->first('work_review.body') }}</p>
             </div>
-            <input type="submit" value="保存する">
+            <button type="submit">変更を保存する</button>
         </form>
+    </div>
+    <div class="footer">
+        <a href="{{ route('work_reviews.show', ['work_id' => $post->work_id, 'post_id' => $post->id]) }}">保存しないで戻る</a>
     </div>
 </body>

--- a/resources/views/work_reviews/index.blade.php
+++ b/resources/views/work_reviews/index.blade.php
@@ -19,7 +19,7 @@
                     <a href="{{ route('work_reviews.show', ['work_id' => $post->work_id, 'post_id' => $post->id]) }}">{{ $post->post_title }}</a>
                 </h2>
                 <p class='body'>{{ $post->body }}</p>
-                <form action="/work_reviews/{{ $post->id }}" id="form_{{ $post->id }}" method="post">
+                <form action="{{ route('work_reviews.delete', ['work_id' => $post->work_id, 'post_id' => $post->id]) }}" id="form_{{ $post->id }}" method="post">
                     @csrf
                     @method('DELETE')
                     <button type="button" data-post-id="{{ $post->id }}" class="delete-button">投稿を削除する</button>

--- a/resources/views/work_reviews/index.blade.php
+++ b/resources/views/work_reviews/index.blade.php
@@ -10,7 +10,7 @@
 
 <body>
     <h1>「{{ $work->work->name }}」の感想投稿一覧</h1>
-    <a href='/work_reviews/create'>新規投稿作成</a>
+    <a href="{{ route('work_reviews.create', ['work_id' => $work->work_id]) }}">新規投稿作成</a>
     <div class='posts'>
         <div class='post'>
             @foreach ($posts as $post)

--- a/resources/views/work_reviews/index.blade.php
+++ b/resources/views/work_reviews/index.blade.php
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-    <h1>Blog Name</h1>
+    <h1>「{{ $work->work->name }}」の感想投稿一覧</h1>
     <a href='/work_reviews/create'>新規投稿作成</a>
     <div class='posts'>
         <div class='post'>
@@ -27,6 +27,9 @@
             </div>
             @endforeach
         </div>
+    </div>
+    <div class="footer">
+        <a href="/works/{{ $post->work_id }}">作品詳細画面へ</a>
     </div>
     <div class='paginate'>
         {{ $posts->links() }}

--- a/resources/views/work_reviews/show.blade.php
+++ b/resources/views/work_reviews/show.blade.php
@@ -25,7 +25,9 @@
             <p>{{ $post->created_at }}</p>
         </div>
     </div>
-    <div class="edit"><a href="/work_reviews/{{ $post->id }}/edit">編集する</a></div>
+    <div class="edit">
+        <a href="{{ route('work_reviews.edit', ['work_id' => $post->work_id, 'post_id' => $post->id]) }}">編集する</a>
+    </div>
     <form action="/work_reviews/{{ $post->id }}" id="form_{{ $post->id }}" method="post">
         @csrf
         @method('DELETE')

--- a/resources/views/work_reviews/show.blade.php
+++ b/resources/views/work_reviews/show.blade.php
@@ -28,7 +28,7 @@
     <div class="edit">
         <a href="{{ route('work_reviews.edit', ['work_id' => $post->work_id, 'post_id' => $post->id]) }}">編集する</a>
     </div>
-    <form action="/work_reviews/{{ $post->id }}" id="form_{{ $post->id }}" method="post">
+    <form action="{{ route('work_reviews.delete', ['work_id' => $post->work_id, 'post_id' => $post->id]) }}" id="form_{{ $post->id }}" method="post">
         @csrf
         @method('DELETE')
         <button type="button" data-post-id="{{ $post->id }}" class="delete-button">投稿を削除する</button>

--- a/resources/views/works/show.blade.php
+++ b/resources/views/works/show.blade.php
@@ -37,7 +37,7 @@
         </div>
     </div>
     <div class="footer">
-        <a href="/works">戻る</a>
+        <a href="/works">作品一覧へ</a>
     </div>
 </body>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,10 +38,10 @@ Route::post('/work_reviews/{work_id}/store', [WorkReviewController::class, 'stor
 Route::get('/work_reviews/{work_id}/reviews/{post_id}', [WorkReviewController::class ,'show'])->name('work_reviews.show');
 
 // 感想投稿編集画面を表示するeditメソッドを実行
-Route::get('/work_reviews/{workreview}/edit', [WorkReviewController::class, 'edit']);
+Route::get('/work_reviews/{work_id}/reviews/{post_id}/edit', [WorkReviewController::class, 'edit'])->name('work_reviews.edit');
 
 // 感想投稿の編集を実行するupdateメソッドを実行
-Route::put('/work_reviews/{workreview}', [WorkReviewController::class, 'update']);
+Route::put('/work_reviews/{work_id}/update/{post_id}', [WorkReviewController::class, 'update'])->name('work_reviews.update');
 
 // 感想投稿の削除を行うdeleteメソッドを実行
 Route::delete('/work_reviews/{workreview}', [WorkReviewController::class,'delete']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,7 +35,7 @@ Route::get('/work_reviews/create', [WorkReviewController::class, 'create']);
 Route::post('/work_reviews', [WorkReviewController::class, 'store']);
 
 // '/work_reviews/{対象データのID}'にGetリクエストが来たら、showメソッドを実行
-Route::get('/work_reviews/{work_id}/work_reviews/{post_id}', [WorkReviewController::class ,'show'])->name('work_reviews.show');
+Route::get('/work_reviews/{work_id}/reviews/{post_id}', [WorkReviewController::class ,'show'])->name('work_reviews.show');
 
 // 感想投稿編集画面を表示するeditメソッドを実行
 Route::get('/work_reviews/{workreview}/edit', [WorkReviewController::class, 'edit']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,7 +29,7 @@ Route::get('/works/{work}', [WorkController::class ,'show']);
 Route::get('/work_reviews/{work_id}', [WorkReviewController::class, 'index'])->name('work_reviews.index');
 
 // 新規投稿作成ボタン押下で、createメソッドを実行
-Route::get('/work_reviews/create', [WorkReviewController::class, 'create']);
+Route::get('/work_reviews/{work_id}/create', [WorkReviewController::class, 'create'])->name('work_reviews.create');
 
 // 作成するボタン押下で、storeメソッドを実行
 Route::post('/work_reviews', [WorkReviewController::class, 'store']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,7 +32,7 @@ Route::get('/work_reviews/{work_id}', [WorkReviewController::class, 'index'])->n
 Route::get('/work_reviews/{work_id}/create', [WorkReviewController::class, 'create'])->name('work_reviews.create');
 
 // 作成するボタン押下で、storeメソッドを実行
-Route::post('/work_reviews', [WorkReviewController::class, 'store']);
+Route::post('/work_reviews/{work_id}/store', [WorkReviewController::class, 'store'])->name('work_reviews.store');
 
 // '/work_reviews/{対象データのID}'にGetリクエストが来たら、showメソッドを実行
 Route::get('/work_reviews/{work_id}/reviews/{post_id}', [WorkReviewController::class ,'show'])->name('work_reviews.show');

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,6 +44,6 @@ Route::get('/work_reviews/{work_id}/reviews/{post_id}/edit', [WorkReviewControll
 Route::put('/work_reviews/{work_id}/update/{post_id}', [WorkReviewController::class, 'update'])->name('work_reviews.update');
 
 // 感想投稿の削除を行うdeleteメソッドを実行
-Route::delete('/work_reviews/{workreview}', [WorkReviewController::class,'delete']);
+Route::delete('/work_reviews/{work_id}/reviews/{post_id}/delete', [WorkReviewController::class,'delete'])->name('work_reviews.delete');
 
 


### PR DESCRIPTION
### 作品一覧画面から遷移した場合の感想投稿に関するCUD機能のルーティング整理

#12 

・#14に引き続き、作品一覧画面から遷移した場合のルーティングの整理を実行
・新規投稿画面のタイトルに作品名の追加
・投稿編集画面のタイトルに作品名の追加
・新規投稿/編集において、作品名と投稿者の記入を不必要に修正
・削除機能のルーティング整理

・作品詳細画面（タイトルの修正）
![スクリーンショット 2024-10-21 000748](https://github.com/user-attachments/assets/e51ce1be-4df1-412a-a86d-98618bf5e58a)

・新規投稿画面（タイトルと記入項目の変更）
![スクリーンショット 2024-10-21 000802](https://github.com/user-attachments/assets/b0a1b318-c84c-4eee-a953-885b73037a6f)

・投稿編集画面（タイトルと記入項目の変更）
![スクリーンショット 2024-10-21 000816](https://github.com/user-attachments/assets/530cfb55-9fa5-4e17-89dd-bbb453de29c0)
