### PR TITLE
Feat：作品感想にカテゴリーの表示、登録、編集を行う

### DIFF
--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -35,10 +35,13 @@ class WorkReviewController extends Controller
     // 新しく記述した内容を保存する
     public function store(WorkReview $workreview, WorkReviewRequest $request)
     {
-        $input = $request['work_review'];
+        $input_review = $request['work_review'];
+        $input_categories = $request->categories_array;
         // ログインしているユーザーidの登録
-        $input['user_id'] = Auth::id();
-        $workreview->fill($input)->save();
+        $input_review['user_id'] = Auth::id();
+        $workreview->fill($input_review)->save();
+        // カテゴリーとの中間テーブルにデータを保存
+        $workreview->categories()->attach($input_categories);
         return redirect()->route('work_reviews.show', ['work_id' => $workreview->work_id, 'post_id' => $workreview->id]);
     }
 

--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -55,7 +55,7 @@ class WorkReviewController extends Controller
     public function update(WorkReviewRequest $request, WorkReview $workreview, $work_id, $post_id)
     {
         $input_post = $request['work_review'];
-        $input_categories = $request->categories_array;
+        $input_categories = $request->work_review['categories_array'];
         // 編集の対象となるデータを取得
         $targetworkreview = $workreview->getDetailPost($work_id, $post_id);
         $targetworkreview->fill($input_post)->save();

--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\WorkReview;
+use App\Models\WorkReviewCategory;
 use App\Http\Requests\WorkReviewRequest;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Auth;
@@ -26,9 +27,9 @@ class WorkReviewController extends Controller
     }
 
     // 新規投稿作成画面を表示する
-    public function create(WorkReview $workreview, $work_id)
+    public function create(WorkReview $workreview, WorkReviewCategory $category, $work_id)
     {
-        return view('work_reviews.create')->with(['workreview' => $workreview->getRestrictedPost('work_id', $work_id)]);
+        return view('work_reviews.create')->with(['workreview' => $workreview->getRestrictedPost('work_id', $work_id), 'categories' => $category->get()]);
     }
 
     // 新しく記述した内容を保存する

--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -36,7 +36,7 @@ class WorkReviewController extends Controller
     public function store(WorkReview $workreview, WorkReviewRequest $request)
     {
         $input_review = $request['work_review'];
-        $input_categories = $request->categories_array;
+        $input_categories = $request->work_review['categories_array'];
         // ログインしているユーザーidの登録
         $input_review['user_id'] = Auth::id();
         $workreview->fill($input_review)->save();

--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -13,17 +13,17 @@ class WorkReviewController extends Controller
     use SoftDeletes;
 
     // インポートしたPostをインスタンス化して$postとして使用。
-    public function index(WorkReview $work_reviews, $work_id)
+    public function index(WorkReview $work_reviews, WorkReviewCategory $category, $work_id)
     {
         // blade内の変数postsにインスタンス化した$work_reviewsを代入
         // 指定したidのアニメの投稿のみを表示
-        return view('work_reviews.index')->with(['posts' => $work_reviews->getPaginateByLimit($work_id), 'work' => $work_reviews->getRestrictedPost('work_id', $work_id)]);
+        return view('work_reviews.index')->with(['posts' => $work_reviews->getPaginateByLimit($work_id), 'work' => $work_reviews->getRestrictedPost('work_id', $work_id), 'categories' => $category->get()]);
     }
 
     // 'post'はbladeファイルで使う変数。
-    public function show(WorkReview $workreview, $work_id, $post_id)
+    public function show(WorkReview $workreview, WorkReviewCategory $category, $work_id, $post_id)
     {
-        return view('work_reviews.show')->with(['post' => $workreview->getDetailPost($work_id, $post_id)]);
+        return view('work_reviews.show')->with(['post' => $workreview->getDetailPost($work_id, $post_id), 'categories' => $category->get()]);
     }
 
     // 新規投稿作成画面を表示する

--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -48,7 +48,7 @@ class WorkReviewController extends Controller
     // 感想投稿編集画面を表示する
     public function edit(WorkReview $workreview, WorkReviewCategory $category, $work_id, $post_id)
     {
-        return view('work_reviews.edit')->with(['post' => $workreview->getDetailPost($work_id, $post_id), 'categories' => $category->get()]);
+        return view('work_reviews.edit')->with(['work_review' => $workreview->getDetailPost($work_id, $post_id), 'categories' => $category->get()]);
     }
 
     // 感想投稿の編集を実行する

--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -46,18 +46,22 @@ class WorkReviewController extends Controller
     }
 
     // 感想投稿編集画面を表示する
-    public function edit(WorkReview $workreview, $work_id, $post_id)
+    public function edit(WorkReview $workreview, WorkReviewCategory $category, $work_id, $post_id)
     {
-        return view('work_reviews.edit')->with(['post' => $workreview->getDetailPost($work_id, $post_id)]);
+        return view('work_reviews.edit')->with(['post' => $workreview->getDetailPost($work_id, $post_id), 'categories' => $category->get()]);
     }
 
     // 感想投稿の編集を実行する
     public function update(WorkReviewRequest $request, WorkReview $workreview, $work_id, $post_id)
     {
         $input_post = $request['work_review'];
+        $input_categories = $request->categories_array;
         // 編集の対象となるデータを取得
         $targetworkreview = $workreview->getDetailPost($work_id, $post_id);
         $targetworkreview->fill($input_post)->save();
+        // カテゴリーとの中間テーブルにデータを保存
+        // 中間テーブルへの紐づけと解除を行うsyncメソッドを使用
+        $targetworkreview->categories()->sync($input_categories);
         return redirect()->route('work_reviews.show', ['work_id' => $targetworkreview->work_id, 'post_id' => $targetworkreview->id]);
     }
 

--- a/app/Http/Requests/WorkReviewRequest.php
+++ b/app/Http/Requests/WorkReviewRequest.php
@@ -20,6 +20,7 @@ class WorkReviewRequest extends FormRequest
         return [
             'work_review.post_title' => 'required|string|max:100',
             'work_review.body' => 'required|string|max:4000',
+            'categories_array' => 'required|array|max:3'
         ];
     }
 }

--- a/app/Http/Requests/WorkReviewRequest.php
+++ b/app/Http/Requests/WorkReviewRequest.php
@@ -20,7 +20,7 @@ class WorkReviewRequest extends FormRequest
         return [
             'work_review.post_title' => 'required|string|max:100',
             'work_review.body' => 'required|string|max:4000',
-            'categories_array' => 'required|array|max:3'
+            'work_review.categories_array' => 'required|array|max:3'
         ];
     }
 }

--- a/app/Models/WorkReview.php
+++ b/app/Models/WorkReview.php
@@ -20,8 +20,6 @@ class WorkReview extends Model
     // 参照させたいwork_reviewsを指定
     protected $table = 'work_reviews';
 
-    // 条件を満たすデータだけを取得する
-
     // created_atで降順に並べたあと、limitで件数制限をかける
     public function getPaginateByLimit($work_id, int $limit_count = 5)
     {
@@ -53,5 +51,11 @@ class WorkReview extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    // カテゴリーに対するリレーション 多対多の関係
+    public function categories()
+    {
+        return $this->belongsToMany(WorkReviewCategory::class);
     }
 }

--- a/app/Models/WorkReviewCategory.php
+++ b/app/Models/WorkReviewCategory.php
@@ -8,4 +8,13 @@ use Illuminate\Database\Eloquent\Model;
 class WorkReviewCategory extends Model
 {
     use HasFactory;
+
+    // 参照させたいwork_reviewsを指定
+    protected $table = 'work_review_categories';
+
+    // WorkReviewに対するリレーション 多対多の関係
+    public function workreviews()
+    {
+        return $this->belongsToMany(WorkReview::class);
+    }
 }

--- a/lang/ja/validation.php
+++ b/lang/ja/validation.php
@@ -91,7 +91,7 @@ return [
     ],
     'mac_address' => 'The :attribute field must be a valid MAC address.',
     'max' => [
-        'array' => 'The :attribute field must not have more than :max items.',
+        'array' => ':attributeは3個まで選択できます。',
         'file' => 'The :attribute field must not be greater than :max kilobytes.',
         'numeric' => ':attributeは:max文字以内にしてください。',
         'string' => ':attributeは:max文字以内にしてください。',
@@ -192,6 +192,7 @@ return [
         'work_review.user_id' => '投稿者名',
         'work_review.post_title' => 'タイトル',
         'work_review.body' => '内容',
+        'categories_array' => 'カテゴリー',
     ],
 
 ];

--- a/lang/ja/validation.php
+++ b/lang/ja/validation.php
@@ -192,7 +192,7 @@ return [
         'work_review.user_id' => '投稿者名',
         'work_review.post_title' => 'タイトル',
         'work_review.body' => '内容',
-        'categories_array' => 'カテゴリー',
+        'work_review.categories_array' => 'カテゴリー',
     ],
 
 ];

--- a/resources/views/work_reviews/create.blade.php
+++ b/resources/views/work_reviews/create.blade.php
@@ -22,7 +22,6 @@
             <h2>カテゴリー（3個まで）</h2>
             @foreach($categories as $category)
             <label>
-                {{-- valueを'$subjectのid'に、nameを'配列名[]'に --}}
                 <input type="checkbox" value="{{ $category->id }}" name="categories_array[]">
                 {{$category->name}}
                 </input>

--- a/resources/views/work_reviews/create.blade.php
+++ b/resources/views/work_reviews/create.blade.php
@@ -18,16 +18,11 @@
             <input type="text" name="work_review[post_title]" placeholder="タイトル" value="{{ old('work_review.post_title') }}" />
             <p class="title__error" style="color:red">{{ $errors->first('work_review.post_title') }}</p>
         </div>
-        <div class="a">
-            @foreach($categories as $category)
-            {{ $category->workreviews}}
-            @endforeach
-        </div>
         <div class="category">
             <h2>カテゴリー（3個まで）</h2>
             <select name="work_review[categories_array][]" multiple>
                 @foreach($categories as $category)
-                <option value="{{ $category->id }}" @if($category->id ==old('work_review[categories_array]')) selected @endif>
+                <option value="{{ $category->id }}" @if(in_array($category->id, old('work_review.categories_array', []))) selected @endif>
                     {{$category->name}}
                 </option>
                 @endforeach

--- a/resources/views/work_reviews/create.blade.php
+++ b/resources/views/work_reviews/create.blade.php
@@ -18,11 +18,18 @@
             <input type="text" name="work_review[post_title]" placeholder="タイトル" value="{{ old('work_review.post_title') }}" />
             <p class="title__error" style="color:red">{{ $errors->first('work_review.post_title') }}</p>
         </div>
+        <div class="a">
+            @foreach($categories as $category)
+            {{ $category->workreviews}}
+            @endforeach
+        </div>
         <div class="category">
             <h2>カテゴリー（3個まで）</h2>
             <select name="work_review[categories_array][]" multiple>
                 @foreach($categories as $category)
-                <option value="{{ $category->id }}">{{$category->name}}</option>
+                <option value="{{ $category->id }}" @if($category->id ==old('work_review[categories_array]')) selected @endif>
+                    {{$category->name}}
+                </option>
                 @endforeach
             </select>
             @if ($errors->has('work_review.categories_array'))

--- a/resources/views/work_reviews/create.blade.php
+++ b/resources/views/work_reviews/create.blade.php
@@ -20,13 +20,13 @@
         </div>
         <div class="category">
             <h2>カテゴリー（3個まで）</h2>
-            <select name="categories_array[]" multiple>
+            <select name="work_review[categories_array][]" multiple>
                 @foreach($categories as $category)
                 <option value="{{ $category->id }}">{{$category->name}}</option>
                 @endforeach
             </select>
-            @if ($errors->has('categories_array'))
-            <p class="category__error" style="color:red">{{ $errors->first('categories_array') }}</p>
+            @if ($errors->has('work_review.categories_array'))
+            <p class="category__error" style="color:red">{{ $errors->first('work_review.categories_array') }}</p>
             @endif
         </div>
         <div class="body">

--- a/resources/views/work_reviews/create.blade.php
+++ b/resources/views/work_reviews/create.blade.php
@@ -20,13 +20,14 @@
         </div>
         <div class="category">
             <h2>カテゴリー（3個まで）</h2>
-            @foreach($categories as $category)
-            <label>
-                <input type="checkbox" value="{{ $category->id }}" name="categories_array[]">
-                {{$category->name}}
-                </input>
-            </label>
-            @endforeach
+            <select name="categories_array[]" multiple>
+                @foreach($categories as $category)
+                <option value="{{ $category->id }}">{{$category->name}}</option>
+                @endforeach
+            </select>
+            @if ($errors->has('categories_array'))
+            <p class="category__error" style="color:red">{{ $errors->first('categories_array') }}</p>
+            @endif
         </div>
         <div class="body">
             <h2>内容</h2>

--- a/resources/views/work_reviews/create.blade.php
+++ b/resources/views/work_reviews/create.blade.php
@@ -18,6 +18,17 @@
             <input type="text" name="work_review[post_title]" placeholder="タイトル" value="{{ old('work_review.post_title') }}" />
             <p class="title__error" style="color:red">{{ $errors->first('work_review.post_title') }}</p>
         </div>
+        <div class="category">
+            <h2>カテゴリー（3個まで）</h2>
+            @foreach($categories as $category)
+            <label>
+                {{-- valueを'$subjectのid'に、nameを'配列名[]'に --}}
+                <input type="checkbox" value="{{ $category->id }}" name="categories_array[]">
+                {{$category->name}}
+                </input>
+            </label>
+            @endforeach
+        </div>
         <div class="body">
             <h2>内容</h2>
             <textarea name="work_review[body]" placeholder="内容を記入してください。">{{ old('work_review.body') }}</textarea>

--- a/resources/views/work_reviews/edit.blade.php
+++ b/resources/views/work_reviews/edit.blade.php
@@ -27,14 +27,14 @@
             </div>
             <div class="category">
                 <h2>カテゴリー（3個まで）</h2>
-                @foreach($categories as $category)
-                <label>
-                    <input type="checkbox" value="{{ $category->id }}" name="categories_array[]"
-                    {{ $category->workreviews->contains('id', $post->id) ? 'checked' : ''}} />
-                    {{$category->name}}
-                    </input>
-                </label>
-                @endforeach
+                <select name="work_review[categories_array][]" multiple>
+                    @foreach($categories as $category)
+                    <option value="{{ $category->id }}">{{$category->name}}</option>
+                    @endforeach
+                </select>
+                @if ($errors->has('work_review.categories_array'))
+                <p class="category__error" style="color:red">{{ $errors->first('work_review.categories_array') }}</p>
+                @endif
             </div>
             <div class="body">
                 <h2>内容</h2>

--- a/resources/views/work_reviews/edit.blade.php
+++ b/resources/views/work_reviews/edit.blade.php
@@ -22,8 +22,19 @@
             </div>
             <div class="title">
                 <h2>タイトル</h2>
-                <input type="text" name="work_review[post_title]" placeholder="タイトル" value="{{ $post->post_title }}"/>
+                <input type="text" name="work_review[post_title]" placeholder="タイトル" value="{{ $post->post_title }}" />
                 <p class="title__error" style="color:red">{{ $errors->first('work_review.post_title') }}</p>
+            </div>
+            <div class="category">
+                <h2>カテゴリー（3個まで）</h2>
+                @foreach($categories as $category)
+                <label>
+                    <input type="checkbox" value="{{ $category->id }}" name="categories_array[]"
+                    {{ $category->workreviews->contains('id', $post->id) ? 'checked' : ''}} />
+                    {{$category->name}}
+                    </input>
+                </label>
+                @endforeach
             </div>
             <div class="body">
                 <h2>内容</h2>

--- a/resources/views/work_reviews/edit.blade.php
+++ b/resources/views/work_reviews/edit.blade.php
@@ -9,42 +9,51 @@
 </head>
 
 <body>
-    <h1 class="title">{{ $post->work->name }}への投稿編集画面</h1>
+    <h1 class="title">{{ $work_review->work->name }}への投稿編集画面</h1>
     <div class="content">
-        <form action="{{ route('work_reviews.update', ['work_id' => $post->work_id, 'post_id' => $post->id]) }}" method="POST">
+        <form action="{{ route('work_reviews.update', ['work_id' => $work_review->work_id, 'post_id' => $work_review->id]) }}" method="POST">
             @csrf
             @method('PUT')
             <div class="work_id">
-                <input type="hidden" name="work_review[work_id]" value="{{ $post->work_id }}">
+                <input type="hidden" name="work_review[work_id]" value="{{ $work_review->work_id }}">
             </div>
             <div class="user_id">
-                <input type="hidden" name="work_review[user_id]" value="{{ $post->user_id }}">
+                <input type="hidden" name="work_review[user_id]" value="{{ $work_review->user_id }}">
             </div>
             <div class="title">
                 <h2>タイトル</h2>
-                <input type="text" name="work_review[post_title]" placeholder="タイトル" value="{{ $post->post_title }}" />
+                <input type="text" name="work_review[post_title]" placeholder="タイトル" value="{{ $work_review->post_title }}" />
                 <p class="title__error" style="color:red">{{ $errors->first('work_review.post_title') }}</p>
             </div>
             <div class="category">
                 <h2>カテゴリー（3個まで）</h2>
+                @php
+                // old() が存在すればそれを使用し、なければ過去の保存値を使用
+                $existingCategories = $work_review->categories->pluck('id')->toArray();
+                $selectedCategories = old('work_review.categories_array', $existingCategories);
+                @endphp
                 <select name="work_review[categories_array][]" multiple>
                     @foreach($categories as $category)
-                    <option value="{{ $category->id }}">{{$category->name}}</option>
+                    <option value="{{ $category->id }}"
+                        {{ in_array($category->id, $selectedCategories) ? 'selected' : '' }}>
+                        {{ $category->name }}
+                    </option>
                     @endforeach
                 </select>
+
                 @if ($errors->has('work_review.categories_array'))
                 <p class="category__error" style="color:red">{{ $errors->first('work_review.categories_array') }}</p>
                 @endif
             </div>
             <div class="body">
                 <h2>内容</h2>
-                <textarea name="work_review[body]" placeholder="内容を記入してください。">{{ $post->body }}</textarea>
+                <textarea name="work_review[body]" placeholder="内容を記入してください。">{{ $work_review->body }}</textarea>
                 <p class="body__error" style="color:red">{{ $errors->first('work_review.body') }}</p>
             </div>
             <button type="submit">変更を保存する</button>
         </form>
     </div>
     <div class="footer">
-        <a href="{{ route('work_reviews.show', ['work_id' => $post->work_id, 'post_id' => $post->id]) }}">保存しないで戻る</a>
+        <a href="{{ route('work_reviews.show', ['work_id' => $work_review->work_id, 'post_id' => $work_review->id]) }}">保存しないで戻る</a>
     </div>
 </body>

--- a/resources/views/work_reviews/index.blade.php
+++ b/resources/views/work_reviews/index.blade.php
@@ -18,6 +18,11 @@
                 <h2 class='title'>
                     <a href="{{ route('work_reviews.show', ['work_id' => $post->work_id, 'post_id' => $post->id]) }}">{{ $post->post_title }}</a>
                 </h2>
+                <h5 class='category'>
+                    @foreach($post->categories as $category)
+                    {{ $category->name }}
+                    @endforeach
+                </h5>
                 <p class='body'>{{ $post->body }}</p>
                 <form action="{{ route('work_reviews.delete', ['work_id' => $post->work_id, 'post_id' => $post->id]) }}" id="form_{{ $post->id }}" method="post">
                     @csrf

--- a/resources/views/work_reviews/show.blade.php
+++ b/resources/views/work_reviews/show.blade.php
@@ -19,6 +19,12 @@
             <p>{{ $post->work->name }}</p>
             <h3>投稿者</h3>
             <p>{{ $post->user->name }}</p>
+            <h3>カテゴリー</h3>
+            <h5 class='category'>
+                @foreach($post->categories as $category)
+                {{ $category->name }}
+                @endforeach
+            </h5>
             <h3>本文</h3>
             <p>{{ $post->body }}</p>
             <h3>作成日</h3>


### PR DESCRIPTION
### 作品感想にカテゴリーの表示、登録、編集を行う

・多対多のwork_reviewsテーブルとwork_review_categoriesテーブルのリレーションの設定
・感想投稿一覧と感想投稿詳細画面にカテゴリーの表示
・登録や編集はセレクトボックスで実装
・新規感想登録画面でカテゴリーの登録を可能に
・編集画面やバリデーション表示後も選択した値を保持可能に
・カテゴリーを4個以上選ぶとバリデーションエラーの表示

・カテゴリーの複数選択は、現在Ctrlキーを押しながらでないとできないが、あとでデザインを設定する際、クリックで複数選択できるようにする予定

- #19


・新規感想登録画面（カテゴリー選択可能）
![スクリーンショット 2024-10-23 231715](https://github.com/user-attachments/assets/e5b87f1a-46f3-4e69-bdb0-eac26ff35ff2)

・新規感想登録画面）（バリデーションエラー表示時）
![スクリーンショット 2024-10-23 231820](https://github.com/user-attachments/assets/5deb5318-5d8a-47d5-9692-6e46567b7eeb)

・感想投稿詳細画面
![スクリーンショット 2024-10-23 231840](https://github.com/user-attachments/assets/b1076022-1f61-48e0-9cf3-6d1b37cf89d0)

・感想編集画面（前回の値が保持されている）
![スクリーンショット 2024-10-23 231855](https://github.com/user-attachments/assets/91d119bf-8bf8-4a84-8786-e00c304f2653)

