### PR TITLE
refactor：変数名のpostをwork_reviewに統一

### DIFF
--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -12,18 +12,18 @@ class WorkReviewController extends Controller
 {
     use SoftDeletes;
 
-    // インポートしたPostをインスタンス化して$postとして使用。
+    // インポートしたWorkreviewをインスタンス化して$work_reviewsとして使用。
     public function index(WorkReview $work_reviews, WorkReviewCategory $category, $work_id)
     {
-        // blade内の変数postsにインスタンス化した$work_reviewsを代入
+        // blade内の変数work_reviewsにインスタンス化した$work_reviewsを代入
         // 指定したidのアニメの投稿のみを表示
-        return view('work_reviews.index')->with(['posts' => $work_reviews->getPaginateByLimit($work_id), 'work' => $work_reviews->getRestrictedPost('work_id', $work_id), 'categories' => $category->get()]);
+        return view('work_reviews.index')->with(['work_reviews' => $work_reviews->getPaginateByLimit($work_id), 'work' => $work_reviews->getRestrictedPost('work_id', $work_id), 'categories' => $category->get()]);
     }
 
-    // 'post'はbladeファイルで使う変数。
-    public function show(WorkReview $workreview, WorkReviewCategory $category, $work_id, $post_id)
+    // 'work_review'はbladeファイルで使う変数。
+    public function show(WorkReview $workreview, WorkReviewCategory $category, $work_id, $work_review_id)
     {
-        return view('work_reviews.show')->with(['post' => $workreview->getDetailPost($work_id, $post_id), 'categories' => $category->get()]);
+        return view('work_reviews.show')->with(['work_review' => $workreview->getDetailPost($work_id, $work_review_id), 'categories' => $category->get()]);
     }
 
     // 新規投稿作成画面を表示する
@@ -42,34 +42,34 @@ class WorkReviewController extends Controller
         $workreview->fill($input_review)->save();
         // カテゴリーとの中間テーブルにデータを保存
         $workreview->categories()->attach($input_categories);
-        return redirect()->route('work_reviews.show', ['work_id' => $workreview->work_id, 'post_id' => $workreview->id]);
+        return redirect()->route('work_reviews.show', ['work_id' => $workreview->work_id, 'work_review_id' => $workreview->id]);
     }
 
     // 感想投稿編集画面を表示する
-    public function edit(WorkReview $workreview, WorkReviewCategory $category, $work_id, $post_id)
+    public function edit(WorkReview $workreview, WorkReviewCategory $category, $work_id, $work_review_id)
     {
-        return view('work_reviews.edit')->with(['work_review' => $workreview->getDetailPost($work_id, $post_id), 'categories' => $category->get()]);
+        return view('work_reviews.edit')->with(['work_review' => $workreview->getDetailPost($work_id, $work_review_id), 'categories' => $category->get()]);
     }
 
     // 感想投稿の編集を実行する
-    public function update(WorkReviewRequest $request, WorkReview $workreview, $work_id, $post_id)
+    public function update(WorkReviewRequest $request, WorkReview $workreview, $work_id, $work_review_id)
     {
-        $input_post = $request['work_review'];
+        $input_review = $request['work_review'];
         $input_categories = $request->work_review['categories_array'];
         // 編集の対象となるデータを取得
-        $targetworkreview = $workreview->getDetailPost($work_id, $post_id);
-        $targetworkreview->fill($input_post)->save();
+        $targetworkreview = $workreview->getDetailPost($work_id, $work_review_id);
+        $targetworkreview->fill($input_review)->save();
         // カテゴリーとの中間テーブルにデータを保存
         // 中間テーブルへの紐づけと解除を行うsyncメソッドを使用
         $targetworkreview->categories()->sync($input_categories);
-        return redirect()->route('work_reviews.show', ['work_id' => $targetworkreview->work_id, 'post_id' => $targetworkreview->id]);
+        return redirect()->route('work_reviews.show', ['work_id' => $targetworkreview->work_id, 'work_review_id' => $targetworkreview->id]);
     }
 
     // 感想投稿を削除する
-    public function delete(WorkReview $workreview, $work_id, $post_id)
+    public function delete(WorkReview $workreview, $work_id, $work_review_id)
     {
         // 編集の対象となるデータを取得
-        $targetworkreview = $workreview->getDetailPost($work_id, $post_id);
+        $targetworkreview = $workreview->getDetailPost($work_id, $work_review_id);
         $targetworkreview->delete();
         return redirect()->route('work_reviews.index', ['work_id' => $work_id]);
     }

--- a/app/Models/WorkReview.php
+++ b/app/Models/WorkReview.php
@@ -27,11 +27,11 @@ class WorkReview extends Model
     }
 
     // 作品idと投稿idを指定して、投稿の詳細表示を行う
-    public function getDetailPost($work_id, $post_id)
+    public function getDetailPost($work_id, $work_review_id)
     {
         return $this->where([
             ['work_id', $work_id],
-            ['id', $post_id],
+            ['id', $work_review_id],
         ])->first();
     }
 

--- a/resources/views/work_reviews/edit.blade.php
+++ b/resources/views/work_reviews/edit.blade.php
@@ -11,7 +11,7 @@
 <body>
     <h1 class="title">{{ $work_review->work->name }}への投稿編集画面</h1>
     <div class="content">
-        <form action="{{ route('work_reviews.update', ['work_id' => $work_review->work_id, 'post_id' => $work_review->id]) }}" method="POST">
+        <form action="{{ route('work_reviews.update', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}" method="POST">
             @csrf
             @method('PUT')
             <div class="work_id">
@@ -54,6 +54,6 @@
         </form>
     </div>
     <div class="footer">
-        <a href="{{ route('work_reviews.show', ['work_id' => $work_review->work_id, 'post_id' => $work_review->id]) }}">保存しないで戻る</a>
+        <a href="{{ route('work_reviews.show', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}">保存しないで戻る</a>
     </div>
 </body>

--- a/resources/views/work_reviews/index.blade.php
+++ b/resources/views/work_reviews/index.blade.php
@@ -11,33 +11,33 @@
 <body>
     <h1>「{{ $work->work->name }}」の感想投稿一覧</h1>
     <a href="{{ route('work_reviews.create', ['work_id' => $work->work_id]) }}">新規投稿作成</a>
-    <div class='posts'>
-        <div class='post'>
-            @foreach ($posts as $post)
-            <div class='post'>
+    <div class='work_reviews'>
+        <div class='work_review'>
+            @foreach ($work_reviews as $work_review)
+            <div class='work_review'>
                 <h2 class='title'>
-                    <a href="{{ route('work_reviews.show', ['work_id' => $post->work_id, 'post_id' => $post->id]) }}">{{ $post->post_title }}</a>
+                    <a href="{{ route('work_reviews.show', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}">{{ $work_review->post_title }}</a>
                 </h2>
                 <h5 class='category'>
-                    @foreach($post->categories as $category)
+                    @foreach($work_review->categories as $category)
                     {{ $category->name }}
                     @endforeach
                 </h5>
-                <p class='body'>{{ $post->body }}</p>
-                <form action="{{ route('work_reviews.delete', ['work_id' => $post->work_id, 'post_id' => $post->id]) }}" id="form_{{ $post->id }}" method="post">
+                <p class='body'>{{ $work_review->body }}</p>
+                <form action="{{ route('work_reviews.delete', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}" id="form_{{ $work_review->id }}" method="post">
                     @csrf
                     @method('DELETE')
-                    <button type="button" data-post-id="{{ $post->id }}" class="delete-button">投稿を削除する</button>
+                    <button type="button" data-post-id="{{ $work_review->id }}" class="delete-button">投稿を削除する</button>
                 </form>
             </div>
             @endforeach
         </div>
     </div>
     <div class="footer">
-        <a href="/works/{{ $post->work_id }}">作品詳細画面へ</a>
+        <a href="/works/{{ $work_review->work_id }}">作品詳細画面へ</a>
     </div>
     <div class='paginate'>
-        {{ $posts->links() }}
+        {{ $work_reviews->links() }}
     </div>
 
     <script>

--- a/resources/views/work_reviews/show.blade.php
+++ b/resources/views/work_reviews/show.blade.php
@@ -11,36 +11,36 @@
 
 <body>
     <h1 class="title">
-        {{ $post->post_title }}
+        {{ $work_review->post_title }}
     </h1>
     <div class="content">
-        <div class="content__post">
+        <div class="content__work_review">
             <h3>作品名</h3>
-            <p>{{ $post->work->name }}</p>
+            <p>{{ $work_review->work->name }}</p>
             <h3>投稿者</h3>
-            <p>{{ $post->user->name }}</p>
+            <p>{{ $work_review->user->name }}</p>
             <h3>カテゴリー</h3>
             <h5 class='category'>
-                @foreach($post->categories as $category)
+                @foreach($work_review->categories as $category)
                 {{ $category->name }}
                 @endforeach
             </h5>
             <h3>本文</h3>
-            <p>{{ $post->body }}</p>
+            <p>{{ $work_review->body }}</p>
             <h3>作成日</h3>
-            <p>{{ $post->created_at }}</p>
+            <p>{{ $work_review->created_at }}</p>
         </div>
     </div>
     <div class="edit">
-        <a href="{{ route('work_reviews.edit', ['work_id' => $post->work_id, 'post_id' => $post->id]) }}">編集する</a>
+        <a href="{{ route('work_reviews.edit', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}">編集する</a>
     </div>
-    <form action="{{ route('work_reviews.delete', ['work_id' => $post->work_id, 'post_id' => $post->id]) }}" id="form_{{ $post->id }}" method="post">
+    <form action="{{ route('work_reviews.delete', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}" id="form_{{ $work_review->id }}" method="post">
         @csrf
         @method('DELETE')
-        <button type="button" data-post-id="{{ $post->id }}" class="delete-button">投稿を削除する</button>
+        <button type="button" data-post-id="{{ $work_review->id }}" class="delete-button">投稿を削除する</button>
     </form>
     <div class="footer">
-        <a href="{{ route('work_reviews.index', ['work_id' => $post->work_id]) }}">戻る</a>
+        <a href="{{ route('work_reviews.index', ['work_id' => $work_review->work_id]) }}">戻る</a>
     </div>
 
     <script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,13 +47,13 @@ Route::controller(WorkReviewController::class)->middleware(['auth'])->group(func
     // 作成するボタン押下で、storeメソッドを実行
     Route::post('/work_reviews/{work_id}/store', 'store')->name('work_reviews.store');
     // 各作品の感想投稿一覧ボタン押下で、showメソッドを実行
-    Route::get('/work_reviews/{work_id}/reviews/{post_id}', 'show')->name('work_reviews.show');
+    Route::get('/work_reviews/{work_id}/reviews/{work_review_id}', 'show')->name('work_reviews.show');
     // 感想投稿編集画面を表示するeditメソッドを実行
-    Route::get('/work_reviews/{work_id}/reviews/{post_id}/edit', 'edit')->name('work_reviews.edit');
+    Route::get('/work_reviews/{work_id}/reviews/{work_review_id}/edit', 'edit')->name('work_reviews.edit');
     // 感想投稿の編集を実行するupdateメソッドを実行
-    Route::put('/work_reviews/{work_id}/update/{post_id}', 'update')->name('work_reviews.update');
+    Route::put('/work_reviews/{work_id}/update/{work_review_id}', 'update')->name('work_reviews.update');
     // 感想投稿の削除を行うdeleteメソッドを実行
-    Route::delete('/work_reviews/{work_id}/reviews/{post_id}/delete', 'delete')->name('work_reviews.delete');
+    Route::delete('/work_reviews/{work_id}/reviews/{work_review_id}/delete', 'delete')->name('work_reviews.delete');
 });
 
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
### 変数名のpostを全てwork_reviewに統一

・感想投稿に関する変数名がpostとwork_reviewで定まっていなかったため、全てwork_reviewに統一した。
・統一後、ルーティング等すべての挙動を確認し、問題はなかった。