### PR TITLE
Feat：感想投稿画面に画像のアップロード機能追加

### DIFF
--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -7,6 +7,7 @@ use App\Models\WorkReviewCategory;
 use App\Http\Requests\WorkReviewRequest;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Auth;
+use CloudinaryLabs\CloudinaryLaravel\Facades\Cloudinary;
 
 class WorkReviewController extends Controller
 {
@@ -37,6 +38,12 @@ class WorkReviewController extends Controller
     {
         $input_review = $request['work_review'];
         $input_categories = $request->work_review['categories_array'];
+        //cloudinaryへ画像を送信し、画像のURLを$image_urlに代入
+        //画像ファイルが送られた時だけ処理が実行される
+        if($request->file('image')) {
+            $image_url = Cloudinary::upload($request->file('image')->getRealPath())->getSecurePath();
+            $input_review += ['image1' => $image_url];
+        }
         // ログインしているユーザーidの登録
         $input_review['user_id'] = Auth::id();
         $workreview->fill($input_review)->save();

--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -68,6 +68,17 @@ class WorkReviewController extends Controller
     {
         $input_review = $request['work_review'];
         $input_categories = $request->work_review['categories_array'];
+        //cloudinaryへ画像を送信し、画像のURLを$image_urlに代入
+        //画像ファイルが送られた時だけ処理が実行される
+        if($request->file('images')) {
+            $counter = 1;
+            foreach($request->file('images') as $image) 
+            {
+                $image_url = Cloudinary::upload($image->getRealPath())->getSecurePath();
+                $input_review["image$counter"] = $image_url;
+                $counter++;
+            }
+        }
         // 編集の対象となるデータを取得
         $targetworkreview = $workreview->getDetailPost($work_id, $work_review_id);
         $targetworkreview->fill($input_review)->save();

--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -40,9 +40,14 @@ class WorkReviewController extends Controller
         $input_categories = $request->work_review['categories_array'];
         //cloudinaryへ画像を送信し、画像のURLを$image_urlに代入
         //画像ファイルが送られた時だけ処理が実行される
-        if($request->file('image')) {
-            $image_url = Cloudinary::upload($request->file('image')->getRealPath())->getSecurePath();
-            $input_review += ['image1' => $image_url];
+        if($request->file('images')) {
+            $counter = 1;
+            foreach($request->file('images') as $image) 
+            {
+                $image_url = Cloudinary::upload($image->getRealPath())->getSecurePath();
+                $input_review += ["image$counter" => $image_url];
+                $counter++;
+            }
         }
         // ログインしているユーザーidの登録
         $input_review['user_id'] = Auth::id();

--- a/app/Http/Requests/WorkReviewRequest.php
+++ b/app/Http/Requests/WorkReviewRequest.php
@@ -20,7 +20,8 @@ class WorkReviewRequest extends FormRequest
         return [
             'work_review.post_title' => 'required|string|max:100',
             'work_review.body' => 'required|string|max:4000',
-            'work_review.categories_array' => 'required|array|max:3'
+            'work_review.categories_array' => 'required|array|max:3',
+            'images' => 'array|max:4'
         ];
     }
 }

--- a/app/Models/WorkReview.php
+++ b/app/Models/WorkReview.php
@@ -16,6 +16,9 @@ class WorkReview extends Model
         'post_title',
         'body',
         'image1',
+        'image2',
+        'image3',
+        'image4',
     ];
 
     // 参照させたいwork_reviewsを指定

--- a/app/Models/WorkReview.php
+++ b/app/Models/WorkReview.php
@@ -15,6 +15,7 @@ class WorkReview extends Model
         'user_id',
         'post_title',
         'body',
+        'image1',
     ];
 
     // 参照させたいwork_reviewsを指定

--- a/config/app.php
+++ b/config/app.php
@@ -168,6 +168,7 @@ return [
         // App\Providers\BroadcastServiceProvider::class,
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
+        CloudinaryLabs\CloudinaryLaravel\CloudinaryServiceProvider::class,
     ])->toArray(),
 
     /*

--- a/config/cloudinary.php
+++ b/config/cloudinary.php
@@ -1,52 +1,21 @@
 <?php
 
-/*
- * This file is part of the Laravel Cloudinary package.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 return [
 
-    /*
-    |--------------------------------------------------------------------------
-    | Cloudinary Configuration
-    |--------------------------------------------------------------------------
-    |
-    | An HTTP or HTTPS URL to notify your application (a webhook) when the process of uploads, deletes, and any API
-    | that accepts notification_url has completed.
-    |
-    |
-    */
     'notification_url' => env('CLOUDINARY_NOTIFICATION_URL'),
 
-
-    /*
-    |--------------------------------------------------------------------------
-    | Cloudinary Configuration
-    |--------------------------------------------------------------------------
-    |
-    | Here you may configure your Cloudinary settings. Cloudinary is a cloud hosted
-    | media management service for all file uploads, storage, delivery and transformation needs.
-    |
-    |
-    */
     'cloud_url' => env('CLOUDINARY_URL'),
 
-    /**
-     * Upload Preset From Cloudinary Dashboard
-     *
-     */
     'upload_preset' => env('CLOUDINARY_UPLOAD_PRESET'),
 
-    /**
-     * Route to get cloud_image_url from Blade Upload Widget
-     */
     'upload_route' => env('CLOUDINARY_UPLOAD_ROUTE'),
 
-    /**
-     * Controller action to get cloud_image_url from Blade Upload Widget
-     */
     'upload_action' => env('CLOUDINARY_UPLOAD_ACTION'),
+
+    'cloud_name' => env('CLOUDINARY_CLOUD_NAME'),
+    'api_key'    => env('CLOUDINARY_API_KEY'),
+    'api_secret' => env('CLOUDINARY_API_SECRET'),
+    'curl_options' => [
+        CURLOPT_SSL_VERIFYPEER => false,
+    ],
 ];

--- a/lang/ja/validation.php
+++ b/lang/ja/validation.php
@@ -91,7 +91,7 @@ return [
     ],
     'mac_address' => 'The :attribute field must be a valid MAC address.',
     'max' => [
-        'array' => ':attributeは3個まで選択できます。',
+        'array' => ':attributeは:max個まで選択できます。',
         'file' => 'The :attribute field must not be greater than :max kilobytes.',
         'numeric' => ':attributeは:max文字以内にしてください。',
         'string' => ':attributeは:max文字以内にしてください。',
@@ -193,6 +193,7 @@ return [
         'work_review.post_title' => 'タイトル',
         'work_review.body' => '内容',
         'work_review.categories_array' => 'カテゴリー',
+        'images' => '画像',
     ],
 
 ];

--- a/resources/views/work_reviews/create.blade.php
+++ b/resources/views/work_reviews/create.blade.php
@@ -37,7 +37,8 @@
             <p class="body__error" style="color:red">{{ $errors->first('work_review.body') }}</p>
         </div>
         <div class="image">
-            <input type="file" name="image">
+            <h2>画像（4枚まで）</h2>
+            <input type="file" name="images[]" multiple>
         </div>
         <button type="submit">投稿する</button>
     </form>

--- a/resources/views/work_reviews/create.blade.php
+++ b/resources/views/work_reviews/create.blade.php
@@ -8,7 +8,7 @@
 
 <body>
     <h1>「{{$workreview->work->name}}」への新規感想投稿</h1>
-    <form action="{{ route('work_reviews.store', ['work_id' => $workreview->work_id]) }}" method="POST">
+    <form action="{{ route('work_reviews.store', ['work_id' => $workreview->work_id]) }}" method="POST" enctype="multipart/form-data">
         @csrf
         <div class="work_id">
             <input type="hidden" name="work_review[work_id]" value="{{ $workreview->work_id }}">
@@ -35,6 +35,9 @@
             <h2>内容</h2>
             <textarea name="work_review[body]" placeholder="内容を記入してください。">{{ old('work_review.body') }}</textarea>
             <p class="body__error" style="color:red">{{ $errors->first('work_review.body') }}</p>
+        </div>
+        <div class="image">
+            <input type="file" name="image">
         </div>
         <button type="submit">投稿する</button>
     </form>

--- a/resources/views/work_reviews/create.blade.php
+++ b/resources/views/work_reviews/create.blade.php
@@ -39,6 +39,7 @@
         <div class="image">
             <h2>画像（4枚まで）</h2>
             <input type="file" name="images[]" multiple>
+            <p class="image__error" style="color:red">{{ $errors->first('images') }}</p>
         </div>
         <button type="submit">投稿する</button>
     </form>

--- a/resources/views/work_reviews/create.blade.php
+++ b/resources/views/work_reviews/create.blade.php
@@ -38,14 +38,39 @@
         </div>
         <div class="image">
             <h2>画像（4枚まで）</h2>
-            <input type="file" name="images[]" multiple>
+            <input id="inputElm" type="file" name="images[]" multiple>
             <p class="image__error" style="color:red">{{ $errors->first('images') }}</p>
         </div>
+        <!-- プレビュー画像の表示 -->
+        <div id="preview" style="width: 300px;"></div>
         <button type="submit">投稿する</button>
     </form>
     <div class="footer">
         <a href="{{ route('work_reviews.index', ['work_id' => $workreview->work_id]) }}">戻る</a>
     </div>
 </body>
+<script>
+    // プレビューの表示
+    const inputElm = document.getElementById('inputElm');
+    inputElm.addEventListener('change', (e) => {
+        const file = e.target.files[0];
+
+        const fileReader = new FileReader();
+        // 画像を読み込む
+        fileReader.readAsDataURL(file);
+
+        // 画像読み込み完了時の処理
+        fileReader.addEventListener('load', (e) => {
+            // imgタグ生成
+            const imgElm = document.createElement('img');
+            // e.target.resultに読み込んだ画像のURLを格納
+            imgElm.src = e.target.result;
+
+            // imgタグを挿入
+            const targetElm = document.getElementById('preview');
+            targetElm.appendChild(imgElm);
+        });
+    });
+</script>
 
 </html>

--- a/resources/views/work_reviews/edit.blade.php
+++ b/resources/views/work_reviews/edit.blade.php
@@ -52,9 +52,11 @@
             </div>
             <div class="image">
                 <h2>画像（4枚まで）</h2>
-                <input type="file" name="images[]" multiple>
+                <input id="inputElm" type="file" name="images[]" multiple>
                 <p class="image__error" style="color:red">{{ $errors->first('images') }}</p>
             </div>
+            <!-- プレビュー画像の表示 -->
+            <div id="preview" style="width: 300px;"></div>
             <button type="submit">変更を保存する</button>
         </form>
     </div>
@@ -62,3 +64,28 @@
         <a href="{{ route('work_reviews.show', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}">保存しないで戻る</a>
     </div>
 </body>
+<script>
+    // プレビューの表示
+    const inputElm = document.getElementById('inputElm');
+    inputElm.addEventListener('change', (e) => {
+        const file = e.target.files[0];
+
+        const fileReader = new FileReader();
+        // 画像を読み込む
+        fileReader.readAsDataURL(file);
+
+        // 画像読み込み完了時の処理
+        fileReader.addEventListener('load', (e) => {
+            // imgタグ生成
+            const imgElm = document.createElement('img');
+            // e.target.resultに読み込んだ画像のURLを格納
+            imgElm.src = e.target.result;
+
+            // imgタグを挿入
+            const targetElm = document.getElementById('preview');
+            targetElm.appendChild(imgElm);
+        });
+    });
+</script>
+
+</html>

--- a/resources/views/work_reviews/edit.blade.php
+++ b/resources/views/work_reviews/edit.blade.php
@@ -11,7 +11,7 @@
 <body>
     <h1 class="title">{{ $work_review->work->name }}への投稿編集画面</h1>
     <div class="content">
-        <form action="{{ route('work_reviews.update', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}" method="POST">
+        <form action="{{ route('work_reviews.update', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}" method="POST" enctype="multipart/form-data">
             @csrf
             @method('PUT')
             <div class="work_id">
@@ -49,6 +49,11 @@
                 <h2>内容</h2>
                 <textarea name="work_review[body]" placeholder="内容を記入してください。">{{ $work_review->body }}</textarea>
                 <p class="body__error" style="color:red">{{ $errors->first('work_review.body') }}</p>
+            </div>
+            <div class="image">
+                <h2>画像（4枚まで）</h2>
+                <input type="file" name="images[]" multiple>
+                <p class="image__error" style="color:red">{{ $errors->first('images') }}</p>
             </div>
             <button type="submit">変更を保存する</button>
         </form>

--- a/resources/views/work_reviews/index.blade.php
+++ b/resources/views/work_reviews/index.blade.php
@@ -22,7 +22,10 @@
                     <form action="{{ route('work_reviews.like', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}" name="like" method="POST">
                         @csrf
                         <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
-                        <button class="like-button" data-post-id="{{ $work_review->id }}" type="submit">
+                        <button class="like-button"
+                            data-work-id="{{ $work_review->work_id }}"
+                            data-review-id="{{ $work_review->id }}"
+                            type="submit">
                             {{ $work_review->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
                         </button>
                     </form>
@@ -38,6 +41,11 @@
                     @endforeach
                 </h5>
                 <p class='body'>{{ $work_review->body }}</p>
+                @if($work_review->image1)
+                <div>
+                    <img src="{{ $work_review->image1 }}" alt="画像が読み込めません。">
+                </div>
+                @endif
                 <form action="{{ route('work_reviews.delete', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}" id="form_{{ $work_review->id }}" method="post">
                     @csrf
                     @method('DELETE')
@@ -79,17 +87,15 @@
         //     const likeButtons = document.querySelectorAll('.like-button');
         //     likeButtons.forEach(button => {
         //         button.addEventListener('click', async function() {
-        //             const postId = this.getAttribute('data-post-id');
+        //             const workId = this.getAttribute('data-work-id');
+        //             const reviewId = this.getAttribute('data-review-id');
         //             try {
-        //                 const response = await fetch('/work_reviews/{$work_review->work_id}/reviews/{$work_review->id}/like', {
+        //                 const response = await fetch(`/work_reviews/${workId}/reviews/${reviewId}/like`, {
         //                     method: 'POST',
         //                     headers: {
         //                         'Content-Type': 'application/json',
         //                         'X-CSRF-TOKEN': '{{ csrf_token() }}'
         //                     },
-        //                     body: JSON.stringify({
-        //                         work_review_id: postId
-        //                     })
         //                 });
         //                 const data = await response.json();
         //                 alert(data);

--- a/resources/views/work_reviews/show.blade.php
+++ b/resources/views/work_reviews/show.blade.php
@@ -17,7 +17,10 @@
         <form action="{{ route('work_reviews.like', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}" method="POST">
             @csrf
             <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
-            <button type="submit" class="{{ $work_review->users->contains(auth()->user()) ? 'bg-red-500 hover:bg-red-700' : 'bg-blue-500 hover:bg-blue-700' }} text-white font-bold py-2 px-4 rounded">
+            <button type="submit"
+                data-work-id="{{ $work_review->work_id }}"
+                data-review-id="{{ $work_review->id }}"
+                class="{{ $work_review->users->contains(auth()->user()) ? 'bg-red-500 hover:bg-red-700' : 'bg-blue-500 hover:bg-blue-700' }} text-white font-bold py-2 px-4 rounded">
                 {{ $work_review->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
             </button>
         </form>
@@ -43,6 +46,11 @@
             <p>{{ $work_review->body }}</p>
             <h3>作成日</h3>
             <p>{{ $work_review->created_at }}</p>
+            @if($work_review->image1)
+            <div>
+                <img src="{{ $work_review->image1 }}" alt="画像が読み込めません。">
+            </div>
+            @endif
         </div>
     </div>
     <div class="edit">

--- a/resources/views/work_reviews/show.blade.php
+++ b/resources/views/work_reviews/show.blade.php
@@ -46,11 +46,19 @@
             <p>{{ $work_review->body }}</p>
             <h3>作成日</h3>
             <p>{{ $work_review->created_at }}</p>
-            @if($work_review->image1)
-            <div>
-                <img src="{{ $work_review->image1 }}" alt="画像が読み込めません。">
-            </div>
-            @endif
+            @php
+                $numbers = array(1, 2, 3, 4);
+            @endphp
+            @foreach($numbers as $number)
+                @php
+                    $image = "image".$number;
+                @endphp
+                @if($work_review->$image)
+                <div>
+                    <img src="{{ $work_review->$image }}" alt="画像が読み込めません。">
+                </div>
+                 @endif
+            @endforeach
         </div>
     </div>
     <div class="edit">


### PR DESCRIPTION
### 感想投稿画面に画像のアップロード機能追加

- #25 

・Cloudinaryを使ってアップロード機能の追加
・新規投稿作成画面と編集画面に追加
・画像は4枚までというバリデーションの追加
・プレビュー画像の表示

・詳細画面で画像を確認
![スクリーンショット 2024-11-01 212434](https://github.com/user-attachments/assets/6cefa406-5470-48b1-9f2e-b574a65abfec)

・プレビューの表示
![スクリーンショット 2024-11-01 212512](https://github.com/user-attachments/assets/f016428f-eb7f-4d64-a13e-ac3bd53cb18d)

・バリデーションエラーの表示
![スクリーンショット 2024-11-01 212648](https://github.com/user-attachments/assets/25c2b339-a4d2-4038-bcdb-844ccc820163)
