### PR TITLE
Feat：複数のプレビュー画面表示といいね機能の非同期処理化

### DIFF
--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -113,12 +113,12 @@ class WorkReviewController extends Controller
             // 既にいいねしている感想投稿のidを配列で取得
             $existingwork_review_id = $user->workreviews()->where('work_review_id', $work_review_id)->pluck('work_review_id')->toArray();
             $user->workreviews()->detach($existingwork_review_id);
-            //return response()->json(['status' => 'unliked']);
+            return response()->json(['status' => 'unliked']);
         } else {
             // 初めてのいいねの場合
             $existingwork_review_id = array('0' => $work_review_id);
             $user->workreviews()->attach($existingwork_review_id);
-            //return response()->json(['status' => 'liked']);
+            return response()->json(['status' => 'liked']);
         }
         return back();
     }

--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -101,24 +101,24 @@ class WorkReviewController extends Controller
     public function like(WorkReview $workreview, $work_id, $work_review_id)
     {
         // 投稿が見つからない場合の処理
-        $post = WorkReview::find($work_review_id);
-        if (!$post) {
+        $work_review = WorkReview::find($work_review_id);
+        if (!$work_review) {
             return response()->json(['message' => 'Post not found'], 404);
         }
-        // 現在ログインしているユーザ－の取得
-        $user = Auth::user();
         // 現在ログインしているユーザーが既にいいねしていればtrueを返す
-        $isLiked = $user->workreviews()->where('work_review_id', $work_review_id)->exists();
+        $isLiked = $work_review->users()->where('user_id', Auth::id())->exists();
         if ($isLiked) {
-            // 既にいいねしている感想投稿のidを配列で取得
-            $existingwork_review_id = $user->workreviews()->where('work_review_id', $work_review_id)->pluck('work_review_id')->toArray();
-            $user->workreviews()->detach($existingwork_review_id);
-            return response()->json(['status' => 'unliked']);
+            // 既にいいねしている場合
+            $work_review->users()->detach(Auth::id());
+            // いいねしたユーザー数の取得
+            $count = count($work_review->users()->pluck('work_review_id')->toArray());
+            return response()->json(['status' => 'unliked', 'like_user' => $count]);
         } else {
             // 初めてのいいねの場合
-            $existingwork_review_id = array('0' => $work_review_id);
-            $user->workreviews()->attach($existingwork_review_id);
-            return response()->json(['status' => 'liked']);
+            $work_review->users()->attach(Auth::id());
+            // いいねしたユーザー数の取得
+            $count = count($work_review->users()->pluck('work_review_id')->toArray());
+            return response()->json(['status' => 'liked', 'like_user' => $count]);
         }
         return back();
     }

--- a/resources/views/work_reviews/create.blade.php
+++ b/resources/views/work_reviews/create.blade.php
@@ -38,7 +38,7 @@
         </div>
         <div class="image">
             <h2>画像（4枚まで）</h2>
-            <input id="inputElm" type="file" name="images[]" multiple>
+            <input id="inputElm" type="file" name="images[]" multiple onchange="loadImage(this);">
             <p class="image__error" style="color:red">{{ $errors->first('images') }}</p>
         </div>
         <!-- プレビュー画像の表示 -->
@@ -50,27 +50,39 @@
     </div>
 </body>
 <script>
-    // プレビューの表示
-    const inputElm = document.getElementById('inputElm');
-    inputElm.addEventListener('change', (e) => {
-        const file = e.target.files[0];
+    let key = 0;
 
-        const fileReader = new FileReader();
-        // 画像を読み込む
-        fileReader.readAsDataURL(file);
-
-        // 画像読み込み完了時の処理
-        fileReader.addEventListener('load', (e) => {
-            // imgタグ生成
-            const imgElm = document.createElement('img');
-            // e.target.resultに読み込んだ画像のURLを格納
-            imgElm.src = e.target.result;
-
-            // imgタグを挿入
-            const targetElm = document.getElementById('preview');
-            targetElm.appendChild(imgElm);
+    function loadImage(obj) {
+        // 以前に選択したファイルは保持されないため削除
+        document.querySelectorAll('figure').forEach(function(figure) {
+            figure.remove();
+            key = 0;
         });
-    });
+        // 選択されたファイルの枚数分だけ画像を追加
+        for (i = 0; i < obj.files.length; i++) {
+            var fileReader = new FileReader();
+            fileReader.onload = (function(e) {
+                var field = document.getElementById("preview");
+                var figure = document.createElement("figure");
+                var rmBtn = document.createElement("input");
+                var img = new Image();
+                img.src = e.target.result;
+                rmBtn.type = "button";
+                rmBtn.name = key;
+                rmBtn.value = "削除";
+                // 削除ボタン押下で画像プレビューの削除
+                rmBtn.onclick = (function() {
+                    var element = document.getElementById("img-" + String(rmBtn.name)).remove();
+                });
+                figure.setAttribute("id", "img-" + key);
+                figure.appendChild(img);
+                figure.appendChild(rmBtn)
+                field.appendChild(figure);
+                key++;
+            });
+            fileReader.readAsDataURL(obj.files[i]);
+        }
+    }
 </script>
 
 </html>

--- a/resources/views/work_reviews/edit.blade.php
+++ b/resources/views/work_reviews/edit.blade.php
@@ -52,7 +52,7 @@
             </div>
             <div class="image">
                 <h2>画像（4枚まで）</h2>
-                <input id="inputElm" type="file" name="images[]" multiple>
+                <input id="inputElm" type="file" name="images[]" multiple onchange="loadImage(this);">
                 <p class="image__error" style="color:red">{{ $errors->first('images') }}</p>
             </div>
             <!-- プレビュー画像の表示 -->
@@ -65,27 +65,38 @@
     </div>
 </body>
 <script>
-    // プレビューの表示
-    const inputElm = document.getElementById('inputElm');
-    inputElm.addEventListener('change', (e) => {
-        const file = e.target.files[0];
+    let key = 0;
 
-        const fileReader = new FileReader();
-        // 画像を読み込む
-        fileReader.readAsDataURL(file);
-
-        // 画像読み込み完了時の処理
-        fileReader.addEventListener('load', (e) => {
-            // imgタグ生成
-            const imgElm = document.createElement('img');
-            // e.target.resultに読み込んだ画像のURLを格納
-            imgElm.src = e.target.result;
-
-            // imgタグを挿入
-            const targetElm = document.getElementById('preview');
-            targetElm.appendChild(imgElm);
+    function loadImage(obj) {
+        // 以前に選択したファイルは保持されないため削除
+        document.querySelectorAll('figure').forEach(function(figure) {
+            figure.remove();
+            key = 0;
         });
-    });
+        // 選択されたファイルの枚数分だけ画像を追加
+        for (i = 0; i < obj.files.length; i++) {
+            var fileReader = new FileReader();
+            fileReader.onload = (function(e) {
+                var field = document.getElementById("preview");
+                var figure = document.createElement("figure");
+                var rmBtn = document.createElement("input");
+                var img = new Image();
+                img.src = e.target.result;
+                rmBtn.type = "button";
+                rmBtn.name = key;
+                rmBtn.value = "削除";
+                rmBtn.onclick = (function() {
+                    var element = document.getElementById("img-" + String(rmBtn.name)).remove();
+                });
+                figure.setAttribute("id", "img-" + key);
+                figure.appendChild(img);
+                figure.appendChild(rmBtn)
+                field.appendChild(figure);
+                key++;
+            });
+            fileReader.readAsDataURL(obj.files[i]);
+        }
+    }
 </script>
 
 </html>

--- a/resources/views/work_reviews/index.blade.php
+++ b/resources/views/work_reviews/index.blade.php
@@ -19,16 +19,15 @@
                     <a href="{{ route('work_reviews.show', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}">{{ $work_review->post_title }}</a>
                 </h2>
                 <div class="like">
-                    <form action="{{ route('work_reviews.like', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}" name="like" method="POST">
-                        @csrf
+                    
                         <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
                         <button class="like-button"
                             data-work-id="{{ $work_review->work_id }}"
                             data-review-id="{{ $work_review->id }}"
                             type="submit">
-                            {{ $work_review->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
+                            
                         </button>
-                    </form>
+                    
                     <div class="like_user">
                         <a href="{{ route('work_review_like.index', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}">
                             {{ $work_review->users->count() }}
@@ -83,33 +82,33 @@
             }
         }
 
-        // document.addEventListener('DOMContentLoaded', function() {
-        //     const likeButtons = document.querySelectorAll('.like-button');
-        //     likeButtons.forEach(button => {
-        //         button.addEventListener('click', async function() {
-        //             const workId = this.getAttribute('data-work-id');
-        //             const reviewId = this.getAttribute('data-review-id');
-        //             try {
-        //                 const response = await fetch(`/work_reviews/${workId}/reviews/${reviewId}/like`, {
-        //                     method: 'POST',
-        //                     headers: {
-        //                         'Content-Type': 'application/json',
-        //                         'X-CSRF-TOKEN': '{{ csrf_token() }}'
-        //                     },
-        //                 });
-        //                 const data = await response.json();
-        //                 alert(data);
-        //                 if (data.status === 'liked') {
-        //                     this.innerText = 'Liked';
-        //                 } else if (data.status === 'unliked') {
-        //                     this.innerText = 'Like';
-        //                 }
-        //             } catch (error) {
-        //                 console.error('Error:', error);
-        //             }
-        //         });
-        //     });
-        // });
+        document.addEventListener('DOMContentLoaded', function() {
+            const likeButtons = document.querySelectorAll('.like-button');
+            likeButtons.forEach(button => {
+                button.addEventListener('click', async function() {
+                    const workId = this.getAttribute('data-work-id');
+                    const reviewId = this.getAttribute('data-review-id');
+                    try {
+                        const response = await fetch(`/work_reviews/${workId}/reviews/${reviewId}/like`, {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                            },
+                        });
+                        const data = await response.json();
+                        alert(data);
+                        if (data.status === 'liked') {
+                            this.innerText = 'いいね';
+                        } else if (data.status === 'unliked') {
+                            this.innerText = 'いいね取り消し';
+                        }
+                    } catch (error) {
+                        console.error('Error:', error);
+                    }
+                });
+            });
+        });
     </script>
 </body>
 

--- a/resources/views/work_reviews/index.blade.php
+++ b/resources/views/work_reviews/index.blade.php
@@ -19,18 +19,17 @@
                     <a href="{{ route('work_reviews.show', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}">{{ $work_review->post_title }}</a>
                 </h2>
                 <div class="like">
-                    
-                        <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
-                        <button class="like-button"
-                            data-work-id="{{ $work_review->work_id }}"
-                            data-review-id="{{ $work_review->id }}"
-                            type="submit">
-                            
-                        </button>
-                    
+
+                    <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
+                    <button id="like_button"
+                        data-work-id="{{ $work_review->work_id }}"
+                        data-review-id="{{ $work_review->id }}"
+                        type="submit">
+                        {{ $work_review->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
+                    </button>
                     <div class="like_user">
                         <a href="{{ route('work_review_like.index', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}">
-                            {{ $work_review->users->count() }}
+                            <p id="like_count">{{ $work_review->users->count() }}</p>
                         </a>
                     </div>
                 </div>
@@ -82,12 +81,20 @@
             }
         }
 
+        // いいね処理を非同期で行う
         document.addEventListener('DOMContentLoaded', function() {
-            const likeButtons = document.querySelectorAll('.like-button');
-            likeButtons.forEach(button => {
+            const likeClasses = document.querySelectorAll('.like');
+            likeClasses.forEach(element => {
+                // いいねボタンのクラスの取得
+                let button = element.querySelector('#like_button');
+                // いいねしたユーザー数のクラス取得とpタグの取得
+                let likeClass = element.querySelector('.like_user');
+                let users = likeClass.querySelector('#like_count');
+
+                //いいねボタンクリックによる非同期処理
                 button.addEventListener('click', async function() {
-                    const workId = this.getAttribute('data-work-id');
-                    const reviewId = this.getAttribute('data-review-id');
+                    const workId = button.getAttribute('data-work-id');
+                    const reviewId = button.getAttribute('data-review-id');
                     try {
                         const response = await fetch(`/work_reviews/${workId}/reviews/${reviewId}/like`, {
                             method: 'POST',
@@ -97,11 +104,12 @@
                             },
                         });
                         const data = await response.json();
-                        alert(data);
                         if (data.status === 'liked') {
-                            this.innerText = 'いいね';
+                            button.innerText = 'いいね取り消し';
+                            users.innerText = data.like_user;
                         } else if (data.status === 'unliked') {
-                            this.innerText = 'いいね取り消し';
+                            button.innerText = 'いいね';
+                            users.innerText = data.like_user;
                         }
                     } catch (error) {
                         console.error('Error:', error);


### PR DESCRIPTION
### 複数のプレビュー画面表示といいね機能の非同期処理化

- #23 
- #26 

・新規感想投稿画面や編集画面で、選択した画像のプレビュー表示を複数枚可能にした。
・いいね機能の非同期処理化を行い、いいねボタンを押下しても画面の一番上に移動することがなくなった。
・また、いいねの際にいいねをしたユーザー数の取得もjavascript側で行っている。