### PR TITLE
Feat：作品一覧と作品感想投稿一覧に検索機能の追加

### DIFF
--- a/app/Http/Controllers/WorkController.php
+++ b/app/Http/Controllers/WorkController.php
@@ -10,8 +10,6 @@ class WorkController extends Controller
     // 作品一覧画面の表示
     public function index()
     {
-        // 検索時のキーワードの取得
-        //$keyword = $request->input('keyword');
         $works = Work::orderBy('id', 'ASC')->where(function($query) {
             // キーワード検索がなされた場合
             if($search = request('search')) {

--- a/app/Http/Controllers/WorkController.php
+++ b/app/Http/Controllers/WorkController.php
@@ -8,9 +8,17 @@ use Illuminate\Http\Request;
 class WorkController extends Controller
 {
     // 作品一覧画面の表示
-    public function index(Work $work)
+    public function index()
     {
-        return view('works.index')->with(['works' => $work->getPaginateByLimit()]);
+        // 検索時のキーワードの取得
+        //$keyword = $request->input('keyword');
+        $works = Work::orderBy('id', 'ASC')->where(function($query) {
+            // キーワード検索がなされた場合
+            if($search = request('search')) {
+                $query->where('name', 'LIKE', "%{$search}%");
+            }
+        })->paginate(5);
+        return view('works.index')->with(['works' => $works]);
     }
 
     // 詳細な作品情報を表示する

--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -18,7 +18,15 @@ class WorkReviewController extends Controller
     {
         // blade内の変数work_reviewsにインスタンス化した$work_reviewsを代入
         // 指定したidのアニメの投稿のみを表示
-        return view('work_reviews.index')->with(['work_reviews' => $work_reviews->getPaginateByLimit($work_id), 'work' => $work_reviews->getRestrictedPost('work_id', $work_id), 'categories' => $category->get()]);
+        $work_reviews = WorkReview::where('work_id',$work_id)->orderBy('id', 'ASC')->where(function($query) {
+            // キーワード検索がなされた場合
+            if($search = request('search')) {
+                $query->where('post_title', 'LIKE', "%{$search}%")
+                ->orWhere('body', 'LIKE', "%{$search}%");
+            }
+        })->paginate(5);
+        $work = WorkReview::where('work_id',$work_id)->first();
+        return view('work_reviews.index')->with(['work_reviews' => $work_reviews, 'work' => $work, 'categories' => $category->get()]);
     }
 
     // 'work_review'はbladeファイルで使う変数。

--- a/resources/views/work_reviews/index.blade.php
+++ b/resources/views/work_reviews/index.blade.php
@@ -71,7 +71,7 @@
         <a href="/works/{{ $work->work->id }}">作品詳細画面へ</a>
     </div>
     <div class='paginate'>
-        {{ $work_reviews->links() }}
+        {{ $work_reviews->appends(request()->query())->links() }}
     </div>
 
     <script>

--- a/resources/views/work_reviews/index.blade.php
+++ b/resources/views/work_reviews/index.blade.php
@@ -11,7 +11,20 @@
 <body>
     <h1>「{{ $work->work->name }}」の感想投稿一覧</h1>
     <a href="{{ route('work_reviews.create', ['work_id' => $work->work_id]) }}">新規投稿作成</a>
+    <!-- 検索機能 -->
+    <div class=serch>
+        <form action="{{ route('work_reviews.index', ['work_id' => $work->work->id]) }}" method="GET">
+            <input type="text" name="search" value="{{ request('search') }}" placeholder="キーワードを検索" aria-label="検索...">
+            <input type="submit" value="キーワード検索">
+        </form>
+        <div class="cancel">
+            <a href="{{ route('work_reviews.index', ['work_id' => $work->work->id]) }}">キャンセル</a>
+        </div>
+    </div>
     <div class='work_reviews'>
+        @if($work_reviews->isEmpty())
+        <h2 class='no_result'>結果がありません。</h2>
+        @else
         <div class='work_review'>
             @foreach ($work_reviews as $work_review)
             <div class='work_review'>
@@ -52,9 +65,10 @@
             </div>
             @endforeach
         </div>
+        @endif
     </div>
     <div class="footer">
-        <a href="/works/{{ $work_review->work_id }}">作品詳細画面へ</a>
+        <a href="/works/{{ $work->work->id }}">作品詳細画面へ</a>
     </div>
     <div class='paginate'>
         {{ $work_reviews->links() }}

--- a/resources/views/works/index.blade.php
+++ b/resources/views/works/index.blade.php
@@ -13,22 +13,25 @@
     <!-- 検索機能 -->
     <div class=serch>
         <form action="{{ route('works.index') }}" method="GET">
-            <input type="text" name="search" value="{{ request('serch') }}" placeholder="キーワードを検索" aria-label="検索...">
+            <input type="text" name="search" value="{{ request('search') }}" placeholder="キーワードを検索" aria-label="検索...">
             <input type="submit" value="検索">
         </form>
+        <div class="cancel">
+            <a href="{{ route('works.index') }}">キャンセル</a>
+        </div>
     </div>
     <div class='works'>
         @if($works->isEmpty())
         <h2 class='no_result'>結果がありません。</h2>
         @else
-            @foreach ($works as $work)
-            <div class='work'>
-                <h2 class='name'>
-                    <a href="/works/{{ $work->id }}">{{ $work->name }}</a>
-                </h2>
-                <p class='term'>{{ $work->term }}</p>
-            </div>
-            @endforeach
+        @foreach ($works as $work)
+        <div class='work'>
+            <h2 class='name'>
+                <a href="/works/{{ $work->id }}">{{ $work->name }}</a>
+            </h2>
+            <p class='term'>{{ $work->term }}</p>
+        </div>
+        @endforeach
         @endif
     </div>
     <div class='paginate'>

--- a/resources/views/works/index.blade.php
+++ b/resources/views/works/index.blade.php
@@ -35,7 +35,7 @@
         @endif
     </div>
     <div class='paginate'>
-        {{ $works->links() }}
+        {{ $works->appends(request()->query())->links() }}
     </div>
 </body>
 

--- a/resources/views/works/index.blade.php
+++ b/resources/views/works/index.blade.php
@@ -10,15 +10,26 @@
 
 <body>
     <h1>作品一覧</h1>
+    <!-- 検索機能 -->
+    <div class=serch>
+        <form action="{{ route('works.index') }}" method="GET">
+            <input type="text" name="search" value="{{ request('serch') }}" placeholder="キーワードを検索" aria-label="検索...">
+            <input type="submit" value="検索">
+        </form>
+    </div>
     <div class='works'>
-        @foreach ($works as $work)
-        <div class='work'>
-            <h2 class='name'>
-                <a href="/works/{{ $work->id }}">{{ $work->name }}</a>
-            </h2>
-            <p class='term'>{{ $work->term }}</p>
-        </div>
-        @endforeach
+        @if($works->isEmpty())
+        <h2 class='no_result'>結果がありません。</h2>
+        @else
+            @foreach ($works as $work)
+            <div class='work'>
+                <h2 class='name'>
+                    <a href="/works/{{ $work->id }}">{{ $work->name }}</a>
+                </h2>
+                <p class='term'>{{ $work->term }}</p>
+            </div>
+            @endforeach
+        @endif
     </div>
     <div class='paginate'>
         {{ $works->links() }}


### PR DESCRIPTION
### 作品一覧と作品感想投稿一覧に検索機能の追加

- #29 

・作品一覧と作品感想投稿一覧に検索機能の追加
・作品一覧にはタイトルでの検索が可能
・作品感想投稿一覧にはタイトルと本文での検索が可能
・キャンセルボタン押下で検索をリセットして全表示を行う
・ペジネーション後に検索結果を保持する

・また、作品一覧に関しては制作会社やキャラ名などリレーション追加後に検索可能にする予定

・作品一覧の検索画面
![スクリーンショット 2024-11-03 011952](https://github.com/user-attachments/assets/cf5a688d-4961-4204-bc9e-adc63047c57a)

・作品一覧の検索結果画面
![スクリーンショット 2024-11-03 012005](https://github.com/user-attachments/assets/ecf50603-9201-4b3f-817e-96835b019478)

・作品感想投稿一覧の検索画面
![スクリーンショット 2024-11-03 012026](https://github.com/user-attachments/assets/6d5d70ca-29cb-473e-be54-b79d96be72dd)

・作品感想投稿一覧の検索結果画面
![スクリーンショット 2024-11-03 012042](https://github.com/user-attachments/assets/9971842a-2fb6-491e-904f-7b44a51e2d8c)
