### PR TITLE
feat：複数検索を可能にする

### DIFF
--- a/app/Http/Controllers/WorkController.php
+++ b/app/Http/Controllers/WorkController.php
@@ -12,8 +12,16 @@ class WorkController extends Controller
     {
         $works = Work::orderBy('id', 'ASC')->where(function($query) {
             // キーワード検索がなされた場合
-            if($search = request('search')) {
-                $query->where('name', 'LIKE', "%{$search}%");
+            if ($search = request('search')) {
+                // 検索語のスペースを半角に統一
+                $search_split = mb_convert_kana($search, 's');
+                // 半角スペースで単語ごとに分割して配列にする
+                $search_array = preg_split('/[\s]+/', $search_split);
+                foreach ($search_array as $search_word) {
+                    $query->where(function ($query) use ($search_word) {
+                        $query->where('name', 'LIKE', "%{$search_word}%");
+                    });
+                }
             }
         })->paginate(5);
         return view('works.index')->with(['works' => $works]);


### PR DESCRIPTION
### 複数検索を可能にする

・作品一覧と作品感想投稿一覧の検索で、複数検索を可能にした。
（例）「さやか　最高」
タイトルあるいは説明文の中に、「さやか」と「最高」の文字を両方含む投稿を検索
（タイトル検索（さやかAND最高））OR （説明文検索（さやかAND最高））

・作品感想投稿一覧で「さやか」と検索した場合
![スクリーンショット 2024-11-03 105722](https://github.com/user-attachments/assets/87014f89-a423-4c27-9877-20d31c8b8348)

・作品感想投稿一覧で「さやか　最高」と検索した場合
![スクリーンショット 2024-11-03 105706](https://github.com/user-attachments/assets/5ad0d41a-255a-4845-8206-d878d37a9652)
