### PR TITLE
feat：制作会社詳細画面の作成

### DIFF
--- a/app/Http/Controllers/CreatorController.php
+++ b/app/Http/Controllers/CreatorController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Creator;
+use Illuminate\Http\Request;
+
+class CreatorController extends Controller
+{
+    // 詳細な作品情報を表示する
+    public function show($creator_id)
+    {
+        $creator = Creator::find($creator_id);
+        return view('creators.show')->with(['creator' => $creator]);
+    }
+}

--- a/app/Models/Creator.php
+++ b/app/Models/Creator.php
@@ -15,6 +15,6 @@ class Creator extends Model
     // Workに対するリレーション 1対多の関係
     public function works()
     {
-        return $this->hasMany(Work::class, 'id');
+        return $this->hasMany(Work::class, 'creator_id', 'id');
     }
 }

--- a/app/Models/Work.php
+++ b/app/Models/Work.php
@@ -33,7 +33,7 @@ class Work extends Model
     // Creatorに対するリレーション 1対多の関係
     public function creator()
     {
-        return $this->belongsTo(Creator::class, 'creator_id');
+        return $this->belongsTo(Creator::class, 'creator_id', 'id');
     }
 
     // Musicに対するリレーション 1対多の関係

--- a/resources/views/creators/show.blade.php
+++ b/resources/views/creators/show.blade.php
@@ -1,0 +1,38 @@
+<!DOCTYPE HTML>
+<html lang="ja">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>制作会社詳細画面</title>
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+</head>
+
+<body>
+    <h1 class="title">
+        {{ $creator->name }}
+    </h1>
+    <div class="content">
+        <div class="content__creator">
+            <h3>会社名</h3>
+            <p>{{ $creator->name }}</p>
+            <h3>Wikipediaへのリンク</h3>
+            <p>{{ $creator->wiki_link }}</p>
+            <div class='works'>
+                <h3>作品一覧</h3>
+                @if($creator->works->isEmpty())
+                <h3 class='no_work'>結果がありません。</h3>
+                @else
+                @foreach ($creator->works as $work)
+                <div class='work_name'>
+                    <h3>{{ $work->name }}</h3>
+                </div>
+                @endforeach
+                @endif
+            </div>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/resources/views/works/show.blade.php
+++ b/resources/views/works/show.blade.php
@@ -21,7 +21,7 @@
             <p>{{ $work->term }}</p>
             <div class='creator'>
                 <h3>制作会社</h3>
-                <h3>{{ $work->creator->name }}</h3>
+                <a href="{{ route('creator.show', ['creator_id' => $work->creator->id]) }}">{{ $work->creator->name }}</a>
             </div>
             <div class='music'>
                 <h3>楽曲</h3>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\WorkController;
 use App\Http\Controllers\WorkReviewController;
 use App\Http\Controllers\WorkReviewLikeController;
+use App\Http\Controllers\CreatorController;
 
 /*
 |--------------------------------------------------------------------------
@@ -63,6 +64,12 @@ Route::controller(WorkReviewController::class)->middleware(['auth'])->group(func
 Route::controller(WorkReviewLikeController::class)->middleware(['auth'])->group(function () {
     // 作品一覧の表示
     Route::get('/work_reviews/{work_id}/reviews/{work_review_id}/like/index', 'index')->name('work_review_like.index');
+});
+
+// CreatorControllerに関するルーティング
+Route::controller(CreatorController::class)->middleware(['auth'])->group(function () {
+    // 制作会社の詳細表示
+    Route::get('/creator/{creator_id}', 'show')->name('creator.show');
 });
 
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
### 制作会社の詳細画面を表示

- #32 

・作品詳細の制作会社にリンクを追加し、制作会社詳細画面を表示可能にする。
・制作会社詳細画面には、その制作会社の作品一覧も確認可能。

・作品詳細画面（リンクの追加）
![スクリーンショット 2024-11-04 135005](https://github.com/user-attachments/assets/d39521cc-6a26-46e8-b111-7ad877c12a9a)

・制作会社詳細画面
![スクリーンショット 2024-11-04 135037](https://github.com/user-attachments/assets/aee4228b-9a61-4b1e-9ba5-e46f35e74a10)
