### PR TITLE
Feat：登場人物に関する感想投稿のCRUD機能追加

### DIFF
--- a/app/Http/Controllers/CharacterPostController.php
+++ b/app/Http/Controllers/CharacterPostController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\CharacterPost;
+use App\Models\CharacterPostCategory;
+
+class CharacterPostController extends Controller
+{
+    // 登場人物感想投稿一覧の表示
+    public function index(CharacterPostCategory $category, $character_id)
+    {
+        // 指定したidの登場人物の投稿のみを表示
+        $character_posts = CharacterPost::where('character_id', $character_id)->orderBy('id', 'ASC')->where(function ($query) {
+            // キーワード検索がなされた場合
+            if ($search = request('search')) {
+                // 検索語のスペースを半角に統一
+                $search_split = mb_convert_kana($search, 's');
+                // 半角スペースで単語ごとに分割して配列にする
+                $search_array = preg_split('/[\s]+/', $search_split);
+                foreach ($search_array as $search_word) {
+                    $query->where(function ($query) use ($search_word) {
+                        $query->where('post_title', 'LIKE', "%{$search_word}%")
+                            ->orWhere('body', 'LIKE', "%{$search_word}%");
+                    });
+                }
+            }
+        })->paginate(5);
+        $character_first = CharacterPost::where('character_id', $character_id)->first();
+        return view('character_posts.index')->with(['character_posts' => $character_posts, 'character_first' => $character_first, 'categories' => $category->get()]);
+    }
+}

--- a/app/Http/Controllers/CharacterPostController.php
+++ b/app/Http/Controllers/CharacterPostController.php
@@ -30,4 +30,10 @@ class CharacterPostController extends Controller
         $character_first = CharacterPost::where('character_id', $character_id)->first();
         return view('character_posts.index')->with(['character_posts' => $character_posts, 'character_first' => $character_first, 'categories' => $category->get()]);
     }
+
+    // 登場人物感想投稿詳細の表示
+    public function show(CharacterPost $characterPost, CharacterPostCategory $category, $character_id, $character_post_id)
+    {
+        return view('character_posts.show')->with(['character_post' => $characterPost->getDetailPost($character_id, $character_post_id), 'categories' => $category->get()]);
+    }
 }

--- a/app/Http/Controllers/CharacterPostController.php
+++ b/app/Http/Controllers/CharacterPostController.php
@@ -14,7 +14,7 @@ class CharacterPostController extends Controller
     public function index(CharacterPostCategory $category, $character_id)
     {
         // 指定したidの登場人物の投稿のみを表示
-        $character_posts = CharacterPost::where('character_id', $character_id)->orderBy('id', 'ASC')->where(function ($query) {
+        $character_posts = CharacterPost::where('character_id', $character_id)->orderBy('id', 'DESC')->where(function ($query) {
             // キーワード検索がなされた場合
             if ($search = request('search')) {
                 // 検索語のスペースを半角に統一
@@ -96,5 +96,14 @@ class CharacterPostController extends Controller
         // 中間テーブルへの紐づけと解除を行うsyncメソッドを使用
         $targetCharacterPost->categories()->sync($input_categories);
         return redirect()->route('character_posts.show', ['character_id' => $targetCharacterPost->character_id, 'character_post_id' => $targetCharacterPost->id]);
+    }
+
+    // 感想投稿を削除する
+    public function delete(CharacterPost $characterPost, $character_id, $character_post_id)
+    {
+        // 編集の対象となるデータを取得
+        $targetCharacterPost = $characterPost->getDetailPost($character_id, $character_post_id);
+        $targetCharacterPost->delete();
+        return redirect()->route('character_posts.index', ['character_id' => $character_id]);
     }
 }

--- a/app/Http/Controllers/CharacterPostLikeController.php
+++ b/app/Http/Controllers/CharacterPostLikeController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\CharacterPost;
+
+class CharacterPostLikeController extends Controller
+{
+    // いいねしたユーザーの表示
+    public function index($character_id, $character_post_id)
+    {
+        // 登場人物感想テーブルから、今回開いている登場人物感想にいいねしたユーザーidを取得
+        $users = CharacterPost::whereId($character_post_id)->first()->users()->get();
+        return view('character_post_likes.index')->with(['users' => $users]);
+    }
+}

--- a/app/Http/Requests/CharacterPostRequest.php
+++ b/app/Http/Requests/CharacterPostRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CharacterPostRequest extends FormRequest
+{
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'character_post.post_title' => 'required|string|max:100',
+            'character_post.body' => 'required|string|max:4000',
+            'character_post.categories_array' => 'required|array|max:3',
+            'character_post.star_num' => 'required',
+            'images' => 'array|max:4'
+        ];
+    }
+}

--- a/app/Models/Character.php
+++ b/app/Models/Character.php
@@ -23,4 +23,10 @@ class Character extends Model
     {
         return $this->belongsTo(VoiceArtist::class, 'voice_artist_id', 'id');
     }
+
+    // CharacterPostに対するリレーション 1対1の関係
+    public function characterPost()
+    {
+        return $this->belongsTo(CharacterPost::class, 'id', 'character_id');
+    }
 }

--- a/app/Models/Character.php
+++ b/app/Models/Character.php
@@ -27,6 +27,6 @@ class Character extends Model
     // CharacterPostに対するリレーション 1対1の関係
     public function characterPost()
     {
-        return $this->belongsTo(CharacterPost::class, 'id', 'character_id');
+        return $this->hasOne(CharacterPost::class, 'id', 'character_id');
     }
 }

--- a/app/Models/CharacterPost.php
+++ b/app/Models/CharacterPost.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CharacterPost extends Model
+{
+    use HasFactory;
+
+    // 参照させたいcharacter_postsを指定
+    protected $table = 'character_posts';
+
+    // Characterに対するリレーション 1対1の関係
+    public function character()
+    {
+        return $this->belongsTo(Character::class, 'character_id', 'id');
+    }
+
+    // 投稿者に対するリレーション 1対1の関係
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    // カテゴリーに対するリレーション 多対多の関係
+    public function categories()
+    {
+        return $this->belongsToMany(CharacterPostCategory::class, 'character_post_category', 'character_post_id', 'character_post_category_id');
+    }
+}

--- a/app/Models/CharacterPost.php
+++ b/app/Models/CharacterPost.php
@@ -9,6 +9,20 @@ class CharacterPost extends Model
 {
     use HasFactory;
 
+    // fillを実行するための記述
+    protected $fillable = [
+        'work_id',
+        'character_id',
+        'user_id',
+        'post_title',
+        'star_num',
+        'body',
+        'image1',
+        'image2',
+        'image3',
+        'image4',
+    ];
+
     // 参照させたいcharacter_postsを指定
     protected $table = 'character_posts';
 
@@ -37,5 +51,11 @@ class CharacterPost extends Model
             ['character_id', $character_id],
             ['id', $character_post_id],
         ])->first();
+    }
+
+    // 条件とその値を指定してデータを1件取得する
+    public function getRestrictedPost($condition, $column_name)
+    {
+        return $this->where($condition, $column_name)->first();
     }
 }

--- a/app/Models/CharacterPost.php
+++ b/app/Models/CharacterPost.php
@@ -29,4 +29,13 @@ class CharacterPost extends Model
     {
         return $this->belongsToMany(CharacterPostCategory::class, 'character_post_category', 'character_post_id', 'character_post_category_id');
     }
+
+    // 登場人物idと投稿idを指定して、投稿の詳細表示を行う
+    public function getDetailPost($character_id, $character_post_id)
+    {
+        return $this->where([
+            ['character_id', $character_id],
+            ['id', $character_post_id],
+        ])->first();
+    }
 }

--- a/app/Models/CharacterPost.php
+++ b/app/Models/CharacterPost.php
@@ -44,6 +44,12 @@ class CharacterPost extends Model
         return $this->belongsToMany(CharacterPostCategory::class, 'character_post_category', 'character_post_id', 'character_post_category_id');
     }
 
+    // いいねをしたUserに対するリレーション　多対多の関係
+    public function users()
+    {
+        return $this->belongsToMany(User::class, 'character_posts_users', 'character_post_id', 'user_id');
+    }
+
     // 登場人物idと投稿idを指定して、投稿の詳細表示を行う
     public function getDetailPost($character_id, $character_post_id)
     {

--- a/app/Models/CharacterPostCategory.php
+++ b/app/Models/CharacterPostCategory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CharacterPostCategory extends Model
+{
+    use HasFactory;
+
+    // 参照させたいcharacter_post_categoriesを指定
+    protected $table = 'character_post_categories';
+
+    // CharacterPostに対するリレーション 多対多の関係
+    public function characterPosts()
+    {
+        return $this->belongsToMany(CharacterPost::class, 'character_post_category', 'character_post_category_id', 'character_post_id');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -57,4 +57,10 @@ class User extends Authenticatable
     {
         return $this->belongsToMany(WorkReview::class);
     }
+
+    // いいねをしたCharacterPostに対するリレーション 多対多の関係
+    public function characterPosts()
+    {
+        return $this->belongsToMany(CharacterPost::class, 'character_posts_users', 'user_id', 'character_post_id');
+    }
 }

--- a/lang/ja/validation.php
+++ b/lang/ja/validation.php
@@ -188,12 +188,18 @@ return [
 
     'attributes' => [
         // バリデーションエラーを日本語化する処理
+        // 作品感想投稿のバリデーション
         'work_review.work_id' => '作品名',
         'work_review.user_id' => '投稿者名',
         'work_review.post_title' => 'タイトル',
         'work_review.body' => '内容',
         'work_review.categories_array' => 'カテゴリー',
         'images' => '画像',
+        // 登場人物の感想投稿のバリデーション
+        'character_post.post_title' => 'タイトル',
+        'character_post.body' => '内容',
+        'character_post.categories_array' => 'カテゴリー',
+        'character_post.star_num' => '評価数',
     ],
 
 ];

--- a/resources/views/character_post_likes/index.blade.php
+++ b/resources/views/character_post_likes/index.blade.php
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+<head>
+    <meta charset="utf-8">
+    <title>Blog</title>
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+</head>
+
+<body>
+    <h1>いいねしたユーザー</h1>
+    <div class='users'>
+        @if($users->count() == 0)
+            <h2>いいねしたユーザーはいません。</h2>
+        @else
+            @foreach ($users as $user)
+            <div class='user'>
+                <h2 class='name'>
+                    <!-- あとでユーザー名タップでプロフィール画面に遷移するリンクを作成予定 -->
+                    {{ $user->name }}
+                </h2>
+            </div>
+            @endforeach
+        @endif
+    </div>
+</body>
+
+</html>

--- a/resources/views/character_posts/create.blade.php
+++ b/resources/views/character_posts/create.blade.php
@@ -66,39 +66,39 @@
     </div>
 </body>
 <script>
-    // let key = 0;
+    let key = 0;
 
-    // function loadImage(obj) {
-    //     // 以前に選択したファイルは保持されないため削除
-    //     document.querySelectorAll('figure').forEach(function(figure) {
-    //         figure.remove();
-    //         key = 0;
-    //     });
-    //     // 選択されたファイルの枚数分だけ画像を追加
-    //     for (i = 0; i < obj.files.length; i++) {
-    //         var fileReader = new FileReader();
-    //         fileReader.onload = (function(e) {
-    //             var field = document.getElementById("preview");
-    //             var figure = document.createElement("figure");
-    //             var rmBtn = document.createElement("input");
-    //             var img = new Image();
-    //             img.src = e.target.result;
-    //             rmBtn.type = "button";
-    //             rmBtn.name = key;
-    //             rmBtn.value = "削除";
-    //             // 削除ボタン押下で画像プレビューの削除
-    //             rmBtn.onclick = (function() {
-    //                 var element = document.getElementById("img-" + String(rmBtn.name)).remove();
-    //             });
-    //             figure.setAttribute("id", "img-" + key);
-    //             figure.appendChild(img);
-    //             figure.appendChild(rmBtn)
-    //             field.appendChild(figure);
-    //             key++;
-    //         });
-    //         fileReader.readAsDataURL(obj.files[i]);
-    //     }
-    // }
+    function loadImage(obj) {
+        // 以前に選択したファイルは保持されないため削除
+        document.querySelectorAll('figure').forEach(function(figure) {
+            figure.remove();
+            key = 0;
+        });
+        // 選択されたファイルの枚数分だけ画像を追加
+        for (i = 0; i < obj.files.length; i++) {
+            var fileReader = new FileReader();
+            fileReader.onload = (function(e) {
+                var field = document.getElementById("preview");
+                var figure = document.createElement("figure");
+                var rmBtn = document.createElement("input");
+                var img = new Image();
+                img.src = e.target.result;
+                rmBtn.type = "button";
+                rmBtn.name = key;
+                rmBtn.value = "削除";
+                // 削除ボタン押下で画像プレビューの削除
+                rmBtn.onclick = (function() {
+                    var element = document.getElementById("img-" + String(rmBtn.name)).remove();
+                });
+                figure.setAttribute("id", "img-" + key);
+                figure.appendChild(img);
+                figure.appendChild(rmBtn)
+                field.appendChild(figure);
+                key++;
+            });
+            fileReader.readAsDataURL(obj.files[i]);
+        }
+    }
 </script>
 
 </html>

--- a/resources/views/character_posts/create.blade.php
+++ b/resources/views/character_posts/create.blade.php
@@ -1,0 +1,104 @@
+<!DOCTYPE HTML>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+<head>
+    <meta charset="utf-8">
+    <title>登場人物の感想投稿</title>
+</head>
+
+<body>
+    <h1>「{{$character_post->character->name}}」への新規感想投稿</h1>
+    <form action="{{ route('character_posts.store', ['character_id' => $character_post->character_id]) }}" method="POST" enctype="multipart/form-data">
+        @csrf
+        <div class="work_id">
+            <input type="hidden" name="character_post[work_id]" value="{{ $character_post->work_id }}">
+        </div>
+        <div class="character_id">
+            <input type="hidden" name="character_post[character_id]" value="{{ $character_post->character_id }}">
+        </div>
+        <div class="title">
+            <h2>タイトル</h2>
+            <input type="text" name="character_post[post_title]" placeholder="タイトル" value="{{ old('character_post.post_title') }}" />
+            <p class="title__error" style="color:red">{{ $errors->first('character_post.post_title') }}</p>
+        </div>
+        <div class="star_num">
+            <h2>星の数</h2>
+            <select name="character_post[star_num]">
+                @php
+                $numbers = array(1 => '★', 2 => '★★', 3 => '★★★', 4 => '★★★★', 5 => '★★★★★');
+                @endphp
+                @foreach($numbers as $num => $star)
+                <option value="{{ $num }}" @if(old('character_post.star_num') == $num) selected @endif>
+                    {{$star}}
+                </option>
+                @endforeach
+            </select>
+        </div>
+        <div class="category">
+            <h2>カテゴリー（3個まで）</h2>
+            <select name="character_post[categories_array][]" multiple>
+                @foreach($categories as $category)
+                <option value="{{ $category->id }}" @if(in_array($category->id, old('character_post.categories_array', []))) selected @endif>
+                    {{$category->name}}
+                </option>
+                @endforeach
+            </select>
+            @if ($errors->has('character_post.categories_array'))
+            <p class="category__error" style="color:red">{{ $errors->first('character_post.categories_array') }}</p>
+            @endif
+        </div>
+        <div class="body">
+            <h2>内容</h2>
+            <textarea name="character_post[body]" placeholder="内容を記入してください。">{{ old('character_post.body') }}</textarea>
+            <p class="body__error" style="color:red">{{ $errors->first('character_post.body') }}</p>
+        </div>
+        <div class="image">
+            <h2>画像（4枚まで）</h2>
+            <input id="inputElm" type="file" name="images[]" multiple onchange="loadImage(this);">
+            <p class="image__error" style="color:red">{{ $errors->first('images') }}</p>
+        </div>
+        <!-- プレビュー画像の表示 -->
+        <div id="preview" style="width: 300px;"></div>
+        <button type="submit">投稿する</button>
+    </form>
+    <div class="footer">
+        <a href="{{ route('character_posts.index', ['character_id' => $character_post->character_id]) }}">戻る</a>
+    </div>
+</body>
+<script>
+    // let key = 0;
+
+    // function loadImage(obj) {
+    //     // 以前に選択したファイルは保持されないため削除
+    //     document.querySelectorAll('figure').forEach(function(figure) {
+    //         figure.remove();
+    //         key = 0;
+    //     });
+    //     // 選択されたファイルの枚数分だけ画像を追加
+    //     for (i = 0; i < obj.files.length; i++) {
+    //         var fileReader = new FileReader();
+    //         fileReader.onload = (function(e) {
+    //             var field = document.getElementById("preview");
+    //             var figure = document.createElement("figure");
+    //             var rmBtn = document.createElement("input");
+    //             var img = new Image();
+    //             img.src = e.target.result;
+    //             rmBtn.type = "button";
+    //             rmBtn.name = key;
+    //             rmBtn.value = "削除";
+    //             // 削除ボタン押下で画像プレビューの削除
+    //             rmBtn.onclick = (function() {
+    //                 var element = document.getElementById("img-" + String(rmBtn.name)).remove();
+    //             });
+    //             figure.setAttribute("id", "img-" + key);
+    //             figure.appendChild(img);
+    //             figure.appendChild(rmBtn)
+    //             field.appendChild(figure);
+    //             key++;
+    //         });
+    //         fileReader.readAsDataURL(obj.files[i]);
+    //     }
+    // }
+</script>
+
+</html>

--- a/resources/views/character_posts/edit.blade.php
+++ b/resources/views/character_posts/edit.blade.php
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+<head>
+    <meta charset="utf-8">
+    <title>Blog</title>
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+</head>
+
+<body>
+    <h1 class="title">{{ $character_post->character->name }}への投稿編集画面</h1>
+    <div class="content">
+        <form action="{{ route('character_posts.update', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}" method="POST" enctype="multipart/form-data">
+            @csrf
+            @method('PUT')
+            <div class="work_id">
+                <input type="hidden" name="character_post[work_id]" value="{{ $character_post->work_id }}">
+            </div>
+            <div class="character_id">
+                <input type="hidden" name="character_post[character_id]" value="{{ $character_post->character_id }}">
+            </div>
+            <div class="user_id">
+                <input type="hidden" name="character_post[user_id]" value="{{ $character_post->user_id }}">
+            </div>
+            <div class="title">
+                <h2>タイトル</h2>
+                <input type="text" name="character_post[post_title]" placeholder="タイトル" value="{{ $character_post->post_title }}" />
+                <p class="title__error" style="color:red">{{ $errors->first('character_post.post_title') }}</p>
+            </div>
+            <div class="star_num">
+                <h2>星の数</h2>
+                <select name="character_post[star_num]">
+                    @php
+                    $numbers = array(1 => '★', 2 => '★★', 3 => '★★★', 4 => '★★★★', 5 => '★★★★★');
+                    @endphp
+                    @foreach($numbers as $num => $star)
+                    <option value="{{ $num }}" @if($character_post->star_num == $num) selected @endif>
+                        {{$star}}
+                    </option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="category">
+                <h2>カテゴリー（3個まで）</h2>
+                @php
+                // old() が存在すればそれを使用し、なければ過去の保存値を使用
+                $existingCategories = $character_post->categories->pluck('id')->toArray();
+                $selectedCategories = old('character_post.categories_array', $existingCategories);
+                @endphp
+                <select name="character_post[categories_array][]" multiple>
+                    @foreach($categories as $category)
+                    <option value="{{ $category->id }}"
+                        {{ in_array($category->id, $selectedCategories) ? 'selected' : '' }}>
+                        {{ $category->name }}
+                    </option>
+                    @endforeach
+                </select>
+
+                @if ($errors->has('character_post.categories_array'))
+                <p class="category__error" style="color:red">{{ $errors->first('character_post.categories_array') }}</p>
+                @endif
+            </div>
+            <div class="body">
+                <h2>内容</h2>
+                <textarea name="character_post[body]" placeholder="内容を記入してください。">{{ $character_post->body }}</textarea>
+                <p class="body__error" style="color:red">{{ $errors->first('character_post.body') }}</p>
+            </div>
+            <div class="image">
+                <h2>画像（4枚まで）</h2>
+                <input id="inputElm" type="file" name="images[]" multiple onchange="loadImage(this);">
+                <p class="image__error" style="color:red">{{ $errors->first('images') }}</p>
+            </div>
+            <!-- プレビュー画像の表示 -->
+            <div id="preview" style="width: 300px;"></div>
+            <button type="submit">変更を保存する</button>
+        </form>
+    </div>
+    <div class="footer">
+        <a href="{{ route('character_posts.show', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}">保存しないで戻る</a>
+    </div>
+</body>
+<script>
+    let key = 0;
+
+    function loadImage(obj) {
+        // 以前に選択したファイルは保持されないため削除
+        document.querySelectorAll('figure').forEach(function(figure) {
+            figure.remove();
+            key = 0;
+        });
+        // 選択されたファイルの枚数分だけ画像を追加
+        for (i = 0; i < obj.files.length; i++) {
+            var fileReader = new FileReader();
+            fileReader.onload = (function(e) {
+                var field = document.getElementById("preview");
+                var figure = document.createElement("figure");
+                var rmBtn = document.createElement("input");
+                var img = new Image();
+                img.src = e.target.result;
+                rmBtn.type = "button";
+                rmBtn.name = key;
+                rmBtn.value = "削除";
+                rmBtn.onclick = (function() {
+                    var element = document.getElementById("img-" + String(rmBtn.name)).remove();
+                });
+                figure.setAttribute("id", "img-" + key);
+                figure.appendChild(img);
+                figure.appendChild(rmBtn)
+                field.appendChild(figure);
+                key++;
+            });
+            fileReader.readAsDataURL(obj.files[i]);
+        }
+    }
+</script>
+
+</html>

--- a/resources/views/character_posts/index.blade.php
+++ b/resources/views/character_posts/index.blade.php
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+<head>
+    <meta charset="utf-8">
+    <title>Blog</title>
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+</head>
+
+<body>
+    <h1>「{{ $character_first->character->name }}」の感想投稿一覧</h1>
+    <a href="{{ route('work_reviews.create', ['work_id' => $character_first->character->work_id]) }}">新規投稿作成</a>
+    <!-- 検索機能 -->
+    <div class=serch>
+        <form action="{{ route('character_posts.index', ['character_id' => $character_first->character_id]) }}" method="GET">
+            <input type="text" name="search" value="{{ request('search') }}" placeholder="キーワードを検索" aria-label="検索...">
+            <input type="submit" value="キーワード検索">
+        </form>
+        <div class="cancel">
+            <a href="{{ route('character_posts.index', ['character_id' => $character_first->character_id]) }}">キャンセル</a>
+        </div>
+    </div>
+    <div class='character_posts'>
+        @if($character_posts->isEmpty())
+        <h2 class='no_result'>結果がありません。</h2>
+        @else
+        <div class='character_post'>
+            @foreach ($character_posts as $character_post)
+            <div class='character_post'>
+                <h2 class='title'>
+                    <a href="{{ route('work_reviews.show', ['work_id' => $character_post->work_id, 'work_review_id' => $character_post->id]) }}">{{ $character_post->post_title }}</a>
+                </h2>
+                <div class="like">
+
+                </div>
+
+                <h5 class='category'>
+                    @foreach($character_post->categories as $category)
+                    {{ $category->name }}
+                    @endforeach
+                </h5>
+                <p class='body'>{{ $character_post->body }}</p>
+                @if($character_post->image1)
+                <div>
+                    <img src="{{ $character_post->image1 }}" alt="画像が読み込めません。">
+                </div>
+                @endif
+                <form action="{{ route('work_reviews.delete', ['work_id' => $character_post->work_id, 'work_review_id' => $character_post->id]) }}" id="form_{{ $character_post->id }}" method="post">
+                    @csrf
+                    @method('DELETE')
+                    <button type="button" data-post-id="{{ $character_post->id }}" class="delete-button">投稿を削除する</button>
+                </form>
+            </div>
+            @endforeach
+        </div>
+        @endif
+    </div>
+    <div class="footer">
+        <a href="{{ route('characters.show', ['character_id' => $character_first->character_id]) }}">登場人物詳細画面へ</a>
+    </div>
+    <div class='paginate'>
+        {{ $character_posts->appends(request()->query())->links() }}
+    </div>
+
+    <script>
+        // // DOMツリー読み取り完了後にイベント発火
+        // document.addEventListener('DOMContentLoaded', function() {
+        //     // delete-buttonに一致するすべてのHTML要素を取得
+        //     document.querySelectorAll('.delete-button').forEach(function(button) {
+        //         button.addEventListener('click', function() {
+        //             const postId = button.getAttribute('data-post-id');
+        //             deletePost(postId);
+        //         });
+        //     });
+        // });
+
+        // // 削除処理を行う
+        // function deletePost(postId) {
+        //     'use strict'
+
+        //     if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
+        //         document.getElementById(`form_${postId}`).submit();
+        //     }
+        // }
+
+        // // いいね処理を非同期で行う
+        // document.addEventListener('DOMContentLoaded', function() {
+        //     const likeClasses = document.querySelectorAll('.like');
+        //     likeClasses.forEach(element => {
+        //         // いいねボタンのクラスの取得
+        //         let button = element.querySelector('#like_button');
+        //         // いいねしたユーザー数のクラス取得とpタグの取得
+        //         let likeClass = element.querySelector('.like_user');
+        //         let users = likeClass.querySelector('#like_count');
+
+        //         //いいねボタンクリックによる非同期処理
+        //         button.addEventListener('click', async function() {
+        //             const workId = button.getAttribute('data-work-id');
+        //             const reviewId = button.getAttribute('data-review-id');
+        //             try {
+        //                 const response = await fetch(`/work_reviews/${workId}/reviews/${reviewId}/like`, {
+        //                     method: 'POST',
+        //                     headers: {
+        //                         'Content-Type': 'application/json',
+        //                         'X-CSRF-TOKEN': '{{ csrf_token() }}'
+        //                     },
+        //                 });
+        //                 const data = await response.json();
+        //                 if (data.status === 'liked') {
+        //                     button.innerText = 'いいね取り消し';
+        //                     users.innerText = data.like_user;
+        //                 } else if (data.status === 'unliked') {
+        //                     button.innerText = 'いいね';
+        //                     users.innerText = data.like_user;
+        //                 }
+        //             } catch (error) {
+        //                 console.error('Error:', error);
+        //             }
+        //         });
+        //     });
+        // });
+    </script>
+</body>
+
+</html>

--- a/resources/views/character_posts/index.blade.php
+++ b/resources/views/character_posts/index.blade.php
@@ -10,7 +10,7 @@
 
 <body>
     <h1>「{{ $character_first->character->name }}」の感想投稿一覧</h1>
-    <a href="{{ route('work_reviews.create', ['work_id' => $character_first->character->work_id]) }}">新規投稿作成</a>
+    <a href="{{ route('character_posts.create', ['character_id' => $character_first->character_id]) }}">新規投稿作成</a>
     <!-- 検索機能 -->
     <div class=serch>
         <form action="{{ route('character_posts.index', ['character_id' => $character_first->character_id]) }}" method="GET">

--- a/resources/views/character_posts/index.blade.php
+++ b/resources/views/character_posts/index.blade.php
@@ -40,7 +40,7 @@
                         {{ $character_post->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
                     </button>
                     <div class="like_user">
-                        <a href="{{ route('character_posts.like', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}">
+                        <a href="{{ route('character_post_like.index', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}">
                             <p id="like_count">{{ $character_post->users->count() }}</p>
                         </a>
                     </div>

--- a/resources/views/character_posts/index.blade.php
+++ b/resources/views/character_posts/index.blade.php
@@ -46,7 +46,7 @@
                     <img src="{{ $character_post->image1 }}" alt="画像が読み込めません。">
                 </div>
                 @endif
-                <form action="{{ route('work_reviews.delete', ['work_id' => $character_post->work_id, 'work_review_id' => $character_post->id]) }}" id="form_{{ $character_post->id }}" method="post">
+                <form action="{{ route('character_posts.delete', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}" id="form_{{ $character_post->id }}" method="post">
                     @csrf
                     @method('DELETE')
                     <button type="button" data-post-id="{{ $character_post->id }}" class="delete-button">投稿を削除する</button>
@@ -64,25 +64,25 @@
     </div>
 
     <script>
-        // // DOMツリー読み取り完了後にイベント発火
-        // document.addEventListener('DOMContentLoaded', function() {
-        //     // delete-buttonに一致するすべてのHTML要素を取得
-        //     document.querySelectorAll('.delete-button').forEach(function(button) {
-        //         button.addEventListener('click', function() {
-        //             const postId = button.getAttribute('data-post-id');
-        //             deletePost(postId);
-        //         });
-        //     });
-        // });
+        // DOMツリー読み取り完了後にイベント発火
+        document.addEventListener('DOMContentLoaded', function() {
+            // delete-buttonに一致するすべてのHTML要素を取得
+            document.querySelectorAll('.delete-button').forEach(function(button) {
+                button.addEventListener('click', function() {
+                    const postId = button.getAttribute('data-post-id');
+                    deletePost(postId);
+                });
+            });
+        });
 
-        // // 削除処理を行う
-        // function deletePost(postId) {
-        //     'use strict'
+        // 削除処理を行う
+        function deletePost(postId) {
+            'use strict'
 
-        //     if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
-        //         document.getElementById(`form_${postId}`).submit();
-        //     }
-        // }
+            if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
+                document.getElementById(`form_${postId}`).submit();
+            }
+        }
 
         // // いいね処理を非同期で行う
         // document.addEventListener('DOMContentLoaded', function() {

--- a/resources/views/character_posts/index.blade.php
+++ b/resources/views/character_posts/index.blade.php
@@ -32,7 +32,18 @@
                     <a href="{{ route('character_posts.show', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}">{{ $character_post->post_title }}</a>
                 </h2>
                 <div class="like">
-
+                    <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
+                    <button id="like_button"
+                        data-character-id="{{ $character_post->character_id }}"
+                        data-post-id="{{ $character_post->id }}"
+                        type="submit">
+                        {{ $character_post->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
+                    </button>
+                    <div class="like_user">
+                        <a href="{{ route('character_posts.like', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}">
+                            <p id="like_count">{{ $character_post->users->count() }}</p>
+                        </a>
+                    </div>
                 </div>
 
                 <h5 class='category'>
@@ -84,42 +95,42 @@
             }
         }
 
-        // // いいね処理を非同期で行う
-        // document.addEventListener('DOMContentLoaded', function() {
-        //     const likeClasses = document.querySelectorAll('.like');
-        //     likeClasses.forEach(element => {
-        //         // いいねボタンのクラスの取得
-        //         let button = element.querySelector('#like_button');
-        //         // いいねしたユーザー数のクラス取得とpタグの取得
-        //         let likeClass = element.querySelector('.like_user');
-        //         let users = likeClass.querySelector('#like_count');
+        // いいね処理を非同期で行う
+        document.addEventListener('DOMContentLoaded', function() {
+            const likeClasses = document.querySelectorAll('.like');
+            likeClasses.forEach(element => {
+                // いいねボタンのクラスの取得
+                let button = element.querySelector('#like_button');
+                // いいねしたユーザー数のクラス取得とpタグの取得
+                let likeClass = element.querySelector('.like_user');
+                let users = likeClass.querySelector('#like_count');
 
-        //         //いいねボタンクリックによる非同期処理
-        //         button.addEventListener('click', async function() {
-        //             const workId = button.getAttribute('data-work-id');
-        //             const reviewId = button.getAttribute('data-review-id');
-        //             try {
-        //                 const response = await fetch(`/work_reviews/${workId}/reviews/${reviewId}/like`, {
-        //                     method: 'POST',
-        //                     headers: {
-        //                         'Content-Type': 'application/json',
-        //                         'X-CSRF-TOKEN': '{{ csrf_token() }}'
-        //                     },
-        //                 });
-        //                 const data = await response.json();
-        //                 if (data.status === 'liked') {
-        //                     button.innerText = 'いいね取り消し';
-        //                     users.innerText = data.like_user;
-        //                 } else if (data.status === 'unliked') {
-        //                     button.innerText = 'いいね';
-        //                     users.innerText = data.like_user;
-        //                 }
-        //             } catch (error) {
-        //                 console.error('Error:', error);
-        //             }
-        //         });
-        //     });
-        // });
+                //いいねボタンクリックによる非同期処理
+                button.addEventListener('click', async function() {
+                    const characterId = button.getAttribute('data-character-id');
+                    const postId = button.getAttribute('data-post-id');
+                    try {
+                        const response = await fetch(`/character_posts/${characterId}/posts/${postId}/like`, {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                            },
+                        });
+                        const data = await response.json();
+                        if (data.status === 'liked') {
+                            button.innerText = 'いいね取り消し';
+                            users.innerText = data.like_user;
+                        } else if (data.status === 'unliked') {
+                            button.innerText = 'いいね';
+                            users.innerText = data.like_user;
+                        }
+                    } catch (error) {
+                        console.error('Error:', error);
+                    }
+                });
+            });
+        });
     </script>
 </body>
 

--- a/resources/views/character_posts/show.blade.php
+++ b/resources/views/character_posts/show.blade.php
@@ -58,7 +58,7 @@
         </div>
     </div>
     <div class="edit">
-        <a href="{{ route('work_reviews.edit', ['work_id' => $character_post->work_id, 'work_review_id' => $character_post->id]) }}">編集する</a>
+        <a href="{{ route('character_posts.edit', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}">編集する</a>
     </div>
     <form action="{{ route('work_reviews.delete', ['work_id' => $character_post->work_id, 'work_review_id' => $character_post->id]) }}" id="form_{{ $character_post->id }}" method="post">
         @csrf

--- a/resources/views/character_posts/show.blade.php
+++ b/resources/views/character_posts/show.blade.php
@@ -17,7 +17,18 @@
         {{ $character_post->post_title }}
     </h1>
     <div class="like">
-
+        <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
+        <button id="like_button"
+            data-character-id="{{ $character_post->character_id }}"
+            data-post-id="{{ $character_post->id }}"
+            type="submit">
+            {{ $character_post->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
+        </button>
+        <div class="like_user">
+            <a href="{{ route('character_posts.like', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}">
+                <p id="like_count">{{ $character_post->users->count() }}</p>
+            </a>
+        </div>
     </div>
     <div class="content">
         <div class="content__character_post">
@@ -90,42 +101,42 @@
             }
         }
 
-        // // いいね処理を非同期で行う
-        // document.addEventListener('DOMContentLoaded', function() {
-        //     const likeClasses = document.querySelectorAll('.like');
-        //     likeClasses.forEach(element => {
-        //         // いいねボタンのクラスの取得
-        //         let button = element.querySelector('#like_button');
-        //         // いいねしたユーザー数のクラス取得とpタグの取得
-        //         let likeClass = element.querySelector('.like_user');
-        //         let users = likeClass.querySelector('#like_count');
+        // いいね処理を非同期で行う
+        document.addEventListener('DOMContentLoaded', function() {
+            const likeClasses = document.querySelectorAll('.like');
+            likeClasses.forEach(element => {
+                // いいねボタンのクラスの取得
+                let button = element.querySelector('#like_button');
+                // いいねしたユーザー数のクラス取得とpタグの取得
+                let likeClass = element.querySelector('.like_user');
+                let users = likeClass.querySelector('#like_count');
 
-        //         //いいねボタンクリックによる非同期処理
-        //         button.addEventListener('click', async function() {
-        //             const workId = button.getAttribute('data-work-id');
-        //             const reviewId = button.getAttribute('data-review-id');
-        //             try {
-        //                 const response = await fetch(`/work_reviews/${workId}/reviews/${reviewId}/like`, {
-        //                     method: 'POST',
-        //                     headers: {
-        //                         'Content-Type': 'application/json',
-        //                         'X-CSRF-TOKEN': '{{ csrf_token() }}'
-        //                     },
-        //                 });
-        //                 const data = await response.json();
-        //                 if (data.status === 'liked') {
-        //                     button.innerText = 'いいね取り消し';
-        //                     users.innerText = data.like_user;
-        //                 } else if (data.status === 'unliked') {
-        //                     button.innerText = 'いいね';
-        //                     users.innerText = data.like_user;
-        //                 }
-        //             } catch (error) {
-        //                 console.error('Error:', error);
-        //             }
-        //         });
-        //     });
-        // });
+                //いいねボタンクリックによる非同期処理
+                button.addEventListener('click', async function() {
+                    const characterId = button.getAttribute('data-character-id');
+                    const postId = button.getAttribute('data-post-id');
+                    try {
+                        const response = await fetch(`/character_posts/${characterId}/posts/${postId}/like`, {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json',
+                                'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                            },
+                        });
+                        const data = await response.json();
+                        if (data.status === 'liked') {
+                            button.innerText = 'いいね取り消し';
+                            users.innerText = data.like_user;
+                        } else if (data.status === 'unliked') {
+                            button.innerText = 'いいね';
+                            users.innerText = data.like_user;
+                        }
+                    } catch (error) {
+                        console.error('Error:', error);
+                    }
+                });
+            });
+        });
     </script>
 </body>
 

--- a/resources/views/character_posts/show.blade.php
+++ b/resources/views/character_posts/show.blade.php
@@ -60,7 +60,7 @@
     <div class="edit">
         <a href="{{ route('character_posts.edit', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}">編集する</a>
     </div>
-    <form action="{{ route('work_reviews.delete', ['work_id' => $character_post->work_id, 'work_review_id' => $character_post->id]) }}" id="form_{{ $character_post->id }}" method="post">
+    <form action="{{ route('character_posts.delete', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}" id="form_{{ $character_post->id }}" method="post">
         @csrf
         @method('DELETE')
         <button type="button" data-post-id="{{ $character_post->id }}" class="delete-button">投稿を削除する</button>
@@ -70,25 +70,25 @@
     </div>
 
     <script>
-        // // DOMツリー読み取り完了後にイベント発火
-        // document.addEventListener('DOMContentLoaded', function() {
-        //     // delete-buttonに一致するすべてのHTML要素を取得
-        //     document.querySelectorAll('.delete-button').forEach(function(button) {
-        //         button.addEventListener('click', function() {
-        //             const postId = button.getAttribute('data-post-id');
-        //             deletePost(postId);
-        //         });
-        //     });
-        // });
+        // DOMツリー読み取り完了後にイベント発火
+        document.addEventListener('DOMContentLoaded', function() {
+            // delete-buttonに一致するすべてのHTML要素を取得
+            document.querySelectorAll('.delete-button').forEach(function(button) {
+                button.addEventListener('click', function() {
+                    const postId = button.getAttribute('data-post-id');
+                    deletePost(postId);
+                });
+            });
+        });
 
-        // // 削除処理を行う
-        // function deletePost(postId) {
-        //     'use strict'
+        // 削除処理を行う
+        function deletePost(postId) {
+            'use strict'
 
-        //     if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
-        //         document.getElementById(`form_${postId}`).submit();
-        //     }
-        // }
+            if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
+                document.getElementById(`form_${postId}`).submit();
+            }
+        }
 
         // // いいね処理を非同期で行う
         // document.addEventListener('DOMContentLoaded', function() {

--- a/resources/views/character_posts/show.blade.php
+++ b/resources/views/character_posts/show.blade.php
@@ -25,7 +25,7 @@
             {{ $character_post->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
         </button>
         <div class="like_user">
-            <a href="{{ route('character_posts.like', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}">
+            <a href="{{ route('character_post_like.index', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}">
                 <p id="like_count">{{ $character_post->users->count() }}</p>
             </a>
         </div>

--- a/resources/views/character_posts/show.blade.php
+++ b/resources/views/character_posts/show.blade.php
@@ -11,13 +11,13 @@
 
 <body>
     <h1 class="title">
-        @php 
+        @php
         //dd($character_post);
         @endphp
         {{ $character_post->post_title }}
     </h1>
     <div class="like">
-        
+
     </div>
     <div class="content">
         <div class="content__character_post">
@@ -34,7 +34,10 @@
                 @endforeach
             </h5>
             <h3>評価</h3>
-            <p>{{ $character_post->star_num }}</p>
+            @php
+            $numbers = array(1 => '★', 2 => '★★', 3 => '★★★', 4 => '★★★★', 5 => '★★★★★');
+            @endphp
+            <p>{{ $numbers[$character_post->star_num] }}</p>
             <h3>本文</h3>
             <p>{{ $character_post->body }}</p>
             <h3>作成日</h3>

--- a/resources/views/character_posts/show.blade.php
+++ b/resources/views/character_posts/show.blade.php
@@ -1,66 +1,69 @@
-<!DOCTYPE html>
+<!DOCTYPE HTML>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 
 <head>
     <meta charset="utf-8">
-    <title>Blog</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>登場人物の感想</title>
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
 </head>
 
 <body>
-    <h1>「{{ $character_first->character->name }}」の感想投稿一覧</h1>
-    <a href="{{ route('work_reviews.create', ['work_id' => $character_first->character->work_id]) }}">新規投稿作成</a>
-    <!-- 検索機能 -->
-    <div class=serch>
-        <form action="{{ route('character_posts.index', ['character_id' => $character_first->character_id]) }}" method="GET">
-            <input type="text" name="search" value="{{ request('search') }}" placeholder="キーワードを検索" aria-label="検索...">
-            <input type="submit" value="キーワード検索">
-        </form>
-        <div class="cancel">
-            <a href="{{ route('character_posts.index', ['character_id' => $character_first->character_id]) }}">キャンセル</a>
-        </div>
+    <h1 class="title">
+        @php 
+        //dd($character_post);
+        @endphp
+        {{ $character_post->post_title }}
+    </h1>
+    <div class="like">
+        
     </div>
-    <div class='character_posts'>
-        @if($character_posts->isEmpty())
-        <h2 class='no_result'>結果がありません。</h2>
-        @else
-        <div class='character_post'>
-            @foreach ($character_posts as $character_post)
-            <div class='character_post'>
-                <h2 class='title'>
-                    <a href="{{ route('character_posts.show', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}">{{ $character_post->post_title }}</a>
-                </h2>
-                <div class="like">
-
-                </div>
-
-                <h5 class='category'>
-                    @foreach($character_post->categories as $category)
-                    {{ $category->name }}
-                    @endforeach
-                </h5>
-                <p class='body'>{{ $character_post->body }}</p>
-                @if($character_post->image1)
-                <div>
-                    <img src="{{ $character_post->image1 }}" alt="画像が読み込めません。">
-                </div>
-                @endif
-                <form action="{{ route('work_reviews.delete', ['work_id' => $character_post->work_id, 'work_review_id' => $character_post->id]) }}" id="form_{{ $character_post->id }}" method="post">
-                    @csrf
-                    @method('DELETE')
-                    <button type="button" data-post-id="{{ $character_post->id }}" class="delete-button">投稿を削除する</button>
-                </form>
+    <div class="content">
+        <div class="content__character_post">
+            <h3>登場人物名</h3>
+            <p>{{ $character_post->character->name }}</p>
+            <h3>投稿者</h3>
+            <p>{{ $character_post->user->name }}</p>
+            <h3>タイトル</h3>
+            <p>{{ $character_post->post_title }}</p>
+            <h3>カテゴリー</h3>
+            <h5 class='category'>
+                @foreach($character_post->categories as $category)
+                {{ $category->name }}
+                @endforeach
+            </h5>
+            <h3>評価</h3>
+            <p>{{ $character_post->star_num }}</p>
+            <h3>本文</h3>
+            <p>{{ $character_post->body }}</p>
+            <h3>作成日</h3>
+            <p>{{ $character_post->created_at }}</p>
+            @php
+            $numbers = array(1, 2, 3, 4);
+            @endphp
+            @foreach($numbers as $number)
+            @php
+            $image = "image".$number;
+            @endphp
+            @if($character_post->$image)
+            <div>
+                <img src="{{ $character_post->$image }}" alt="画像が読み込めません。">
             </div>
+            @endif
             @endforeach
         </div>
-        @endif
     </div>
+    <div class="edit">
+        <a href="{{ route('work_reviews.edit', ['work_id' => $character_post->work_id, 'work_review_id' => $character_post->id]) }}">編集する</a>
+    </div>
+    <form action="{{ route('work_reviews.delete', ['work_id' => $character_post->work_id, 'work_review_id' => $character_post->id]) }}" id="form_{{ $character_post->id }}" method="post">
+        @csrf
+        @method('DELETE')
+        <button type="button" data-post-id="{{ $character_post->id }}" class="delete-button">投稿を削除する</button>
+    </form>
     <div class="footer">
-        <a href="{{ route('characters.show', ['character_id' => $character_first->character_id]) }}">登場人物詳細画面へ</a>
-    </div>
-    <div class='paginate'>
-        {{ $character_posts->appends(request()->query())->links() }}
+        <a href="{{ route('character_posts.index', ['character_id' => $character_post->character_id]) }}">戻る</a>
     </div>
 
     <script>

--- a/resources/views/characters/show.blade.php
+++ b/resources/views/characters/show.blade.php
@@ -30,6 +30,10 @@
             <h3>pixivへのリンク</h3>
             <p>{{ $character->wiki_link }}</p>
         </div>
+    </div class="post_link">
+        <a href="{{ route('character_posts.index', ['character_id' => $character->id]) }}">登場人物感想一覧</a>
+    <div>
+
     </div>
     <div class="footer">
         <a href="/works">作品一覧へ</a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -99,7 +99,7 @@ Route::controller(CharacterPostController::class)->middleware(['auth'])->group(f
     // 感想投稿の編集を実行するupdateメソッドを実行
     Route::put('/character_posts/{character_id}/update/{character_post_id}', 'update')->name('character_posts.update');
     // 感想投稿の削除を行うdeleteメソッドを実行
-    Route::delete('/work_reviews/{work_id}/reviews/{work_review_id}/delete', 'delete')->name('work_reviews.delete');
+    Route::delete('/character_posts/{character_id}/posts/{character_post_id}/delete', 'delete')->name('character_posts.delete');
     // 感想投稿のいいねボタン押下で、いいねを追加するlikeメソッドを実行
     Route::post('/work_reviews/{work_id}/reviews/{work_review_id}/like', 'like')->name('work_reviews.like');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -89,9 +89,9 @@ Route::controller(CharacterPostController::class)->middleware(['auth'])->group(f
     // 登場人物ごとの感想投稿一覧の表示
     Route::get('/character_posts/{character_id}', 'index')->name('character_posts.index');
     // 新規投稿作成ボタン押下で、createメソッドを実行
-    Route::get('/work_reviews/{work_id}/create', 'create')->name('work_reviews.create');
+    Route::get('/character_posts/{character_id}/create', 'create')->name('character_posts.create');
     // 作成するボタン押下で、storeメソッドを実行
-    Route::post('/work_reviews/{work_id}/store', 'store')->name('work_reviews.store');
+    Route::post('/character_posts/{character_id}/store', 'store')->name('character_posts.store');
     // 各登場人物の感想投稿一覧ボタン押下で、showメソッドを実行
     Route::get('/character_posts/{character_id}/posts/{character_post_id}', 'show')->name('character_posts.show');
     // 感想投稿編集画面を表示するeditメソッドを実行

--- a/routes/web.php
+++ b/routes/web.php
@@ -93,7 +93,7 @@ Route::controller(CharacterPostController::class)->middleware(['auth'])->group(f
     // 作成するボタン押下で、storeメソッドを実行
     Route::post('/work_reviews/{work_id}/store', 'store')->name('work_reviews.store');
     // 各登場人物の感想投稿一覧ボタン押下で、showメソッドを実行
-    Route::get('/work_reviews/{work_id}/reviews/{work_review_id}', 'show')->name('work_reviews.show');
+    Route::get('/character_posts/{character_id}/posts/{character_post_id}', 'show')->name('character_posts.show');
     // 感想投稿編集画面を表示するeditメソッドを実行
     Route::get('/work_reviews/{work_id}/reviews/{work_review_id}/edit', 'edit')->name('work_reviews.edit');
     // 感想投稿の編集を実行するupdateメソッドを実行

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,7 +7,9 @@ use App\Http\Controllers\WorkReviewController;
 use App\Http\Controllers\WorkReviewLikeController;
 use App\Http\Controllers\CreatorController;
 use App\Http\Controllers\CharacterController;
+use App\Http\Controllers\CharacterPostController;
 use App\Http\Controllers\VoiceArtistController;
+
 
 /*
 |--------------------------------------------------------------------------
@@ -80,6 +82,26 @@ Route::controller(CharacterController::class)->middleware(['auth'])->group(funct
     Route::get('/characters', 'index')->name('characters.index');
     // 登場人物の詳細表示
     Route::get('/characters/{character_id}', 'show')->name('characters.show');
+});
+
+// CharacterPostControllerに関するルーティング
+Route::controller(CharacterPostController::class)->middleware(['auth'])->group(function () {
+    // 登場人物ごとの感想投稿一覧の表示
+    Route::get('/character_posts/{character_id}', 'index')->name('character_posts.index');
+    // 新規投稿作成ボタン押下で、createメソッドを実行
+    Route::get('/work_reviews/{work_id}/create', 'create')->name('work_reviews.create');
+    // 作成するボタン押下で、storeメソッドを実行
+    Route::post('/work_reviews/{work_id}/store', 'store')->name('work_reviews.store');
+    // 各登場人物の感想投稿一覧ボタン押下で、showメソッドを実行
+    Route::get('/work_reviews/{work_id}/reviews/{work_review_id}', 'show')->name('work_reviews.show');
+    // 感想投稿編集画面を表示するeditメソッドを実行
+    Route::get('/work_reviews/{work_id}/reviews/{work_review_id}/edit', 'edit')->name('work_reviews.edit');
+    // 感想投稿の編集を実行するupdateメソッドを実行
+    Route::put('/work_reviews/{work_id}/update/{work_review_id}', 'update')->name('work_reviews.update');
+    // 感想投稿の削除を行うdeleteメソッドを実行
+    Route::delete('/work_reviews/{work_id}/reviews/{work_review_id}/delete', 'delete')->name('work_reviews.delete');
+    // 感想投稿のいいねボタン押下で、いいねを追加するlikeメソッドを実行
+    Route::post('/work_reviews/{work_id}/reviews/{work_review_id}/like', 'like')->name('work_reviews.like');
 });
 
 // VoiceArtistControllerに関するルーティング

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\WorkReviewLikeController;
 use App\Http\Controllers\CreatorController;
 use App\Http\Controllers\CharacterController;
 use App\Http\Controllers\CharacterPostController;
+use App\Http\Controllers\CharacterPostLikeController;
 use App\Http\Controllers\VoiceArtistController;
 
 
@@ -102,6 +103,12 @@ Route::controller(CharacterPostController::class)->middleware(['auth'])->group(f
     Route::delete('/character_posts/{character_id}/posts/{character_post_id}/delete', 'delete')->name('character_posts.delete');
     // 感想投稿のいいねボタン押下で、いいねを追加するlikeメソッドを実行
     Route::post('/character_posts/{character_id}/posts/{character_post_id}/like', 'like')->name('character_posts.like');
+});
+
+// CharacterPostLikeControllerに関するルーティング
+Route::controller(CharacterPostLikeController::class)->middleware(['auth'])->group(function () {
+    // 作品一覧の表示
+    Route::get('/character_posts/{character_id}/posts/{character_post_id}/like/index', 'index')->name('character_post_like.index');
 });
 
 // VoiceArtistControllerに関するルーティング

--- a/routes/web.php
+++ b/routes/web.php
@@ -101,7 +101,7 @@ Route::controller(CharacterPostController::class)->middleware(['auth'])->group(f
     // 感想投稿の削除を行うdeleteメソッドを実行
     Route::delete('/character_posts/{character_id}/posts/{character_post_id}/delete', 'delete')->name('character_posts.delete');
     // 感想投稿のいいねボタン押下で、いいねを追加するlikeメソッドを実行
-    Route::post('/work_reviews/{work_id}/reviews/{work_review_id}/like', 'like')->name('work_reviews.like');
+    Route::post('/character_posts/{character_id}/posts/{character_post_id}/like', 'like')->name('character_posts.like');
 });
 
 // VoiceArtistControllerに関するルーティング

--- a/routes/web.php
+++ b/routes/web.php
@@ -95,9 +95,9 @@ Route::controller(CharacterPostController::class)->middleware(['auth'])->group(f
     // 各登場人物の感想投稿一覧ボタン押下で、showメソッドを実行
     Route::get('/character_posts/{character_id}/posts/{character_post_id}', 'show')->name('character_posts.show');
     // 感想投稿編集画面を表示するeditメソッドを実行
-    Route::get('/work_reviews/{work_id}/reviews/{work_review_id}/edit', 'edit')->name('work_reviews.edit');
+    Route::get('/character_posts/{character_id}/posts/{character_post_id}/edit', 'edit')->name('character_posts.edit');
     // 感想投稿の編集を実行するupdateメソッドを実行
-    Route::put('/work_reviews/{work_id}/update/{work_review_id}', 'update')->name('work_reviews.update');
+    Route::put('/character_posts/{character_id}/update/{character_post_id}', 'update')->name('character_posts.update');
     // 感想投稿の削除を行うdeleteメソッドを実行
     Route::delete('/work_reviews/{work_id}/reviews/{work_review_id}/delete', 'delete')->name('work_reviews.delete');
     // 感想投稿のいいねボタン押下で、いいねを追加するlikeメソッドを実行


### PR DESCRIPTION
### 登場人物に関する感想投稿のCRUD機能追加

- #33 
- #34 

**登場人物感想投稿一覧**
・一覧の表示とタイトル・本文のキーワード検索が可能
・いいねやいいね数の表示
・新規投稿画面へのリンク
・削除機能

**登場人物感想投稿詳細**
・詳細の表示といいねやいいね数の表示
・投稿編集画面へのリンク
・削除機能

**新規投稿画面**
・新規投稿を可能にする
・カテゴリーの追加や画像のアップロード、プレビュー画面

**投稿編集画面**
・投稿の編集を可能にする
・カテゴリーの再追加や画像の再アップロード、プレビュー画面

・登場人物感想投稿一覧
![スクリーンショット 2024-11-05 105607](https://github.com/user-attachments/assets/bd83501a-4b5c-4d38-8aec-96351569499b)

・登場人物感想投稿詳細
![スクリーンショット 2024-11-05 105724](https://github.com/user-attachments/assets/3e3f14d4-0377-4fba-9204-b6c78af48f51)

・新規投稿画面
![スクリーンショット 2024-11-05 105743](https://github.com/user-attachments/assets/c6927413-7a77-4cbb-906c-1581a9b5a419)

・投稿編集画面
![スクリーンショット 2024-11-05 105800](https://github.com/user-attachments/assets/20854ee7-65b4-4f2e-8f96-0e20aacbd9c3)
