### PR TITLE
Feat：音楽一覧と音楽詳細の作成

### DIFF
--- a/app/Http/Controllers/MusicController.php
+++ b/app/Http/Controllers/MusicController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Music;
+
+class MusicController extends Controller
+{
+    // 音楽画面の表示
+    public function index()
+    {
+        $music = Music::orderBy('id', 'ASC')->where(function($query) {
+            // キーワード検索がなされた場合
+            if ($search = request('search')) {
+                // 検索語のスペースを半角に統一
+                $search_split = mb_convert_kana($search, 's');
+                // 半角スペースで単語ごとに分割して配列にする
+                $search_array = preg_split('/[\s]+/', $search_split);
+                foreach ($search_array as $search_word) {
+                    $query->where(function ($query) use ($search_word) {
+                        $query->where('name', 'LIKE', "%{$search_word}%");
+                    });
+                }
+            }
+        })->paginate(5);
+        return view('music.index')->with(['music' => $music]);
+    }
+
+    // 詳細な音楽情報を表示する
+    public function show($music_id)
+    {
+        $music = Music::find($music_id);
+        return view('music.show')->with(['music' => $music]);
+    }
+}

--- a/resources/views/characters/show.blade.php
+++ b/resources/views/characters/show.blade.php
@@ -30,10 +30,9 @@
             <h3>pixivへのリンク</h3>
             <p>{{ $character->wiki_link }}</p>
         </div>
-    </div class="post_link">
+    </div>
+    <div class="post_link">
         <a href="{{ route('character_posts.index', ['character_id' => $character->id]) }}">登場人物感想一覧</a>
-    <div>
-
     </div>
     <div class="footer">
         <a href="/works">作品一覧へ</a>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -21,6 +21,9 @@
                     <x-nav-link :href="route('characters.index')" :active="request()->routeIs('works.index')">
                         {{ __('登場人物一覧') }}
                     </x-nav-link>
+                    <x-nav-link :href="route('music.index')" :active="request()->routeIs('music.index')">
+                        {{ __('音楽一覧') }}
+                    </x-nav-link>
                 </div>
             </div>
 

--- a/resources/views/music/index.blade.php
+++ b/resources/views/music/index.blade.php
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+<head>
+    <meta charset="utf-8">
+    <title>音楽一覧</title>
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+</head>
+
+<body>
+    <h1>音楽一覧</h1>
+    <!-- 検索機能 -->
+    <div class=serch>
+        <form action="{{ route('music.index') }}" method="GET">
+            <input type="text" name="search" value="{{ request('search') }}" placeholder="キーワードを検索" aria-label="検索...">
+            <input type="submit" value="検索">
+        </form>
+        <div class="cancel">
+            <a href="{{ route('music.index') }}">キャンセル</a>
+        </div>
+    </div>
+    <div class='music_collection'>
+        @if($music->isEmpty())
+        <h2 class='no_result'>結果がありません。</h2>
+        @else
+        @foreach ($music as $music_model)
+        <div class='music'>
+            <h2 class='name'>
+                <a href="{{ route('music.show', ['music_id' => $music_model->id]) }}">
+                    {{ $music_model->name }}
+                </a>
+            </h2>
+            <p class='work'>
+                <a href="{{ route('works.show', ['work' => $music_model->work_id]) }}">
+                    {{ $music_model->work->name }}
+                </a>
+            </p>
+            <p class='singer'>
+                歌手:{{ $music_model->singer_id }}
+            </p>
+        </div>
+        @endforeach
+        @endif
+    </div>
+    <div class='paginate'>
+        {{ $music->appends(request()->query())->links() }}
+    </div>
+</body>
+
+</html>

--- a/resources/views/music/show.blade.php
+++ b/resources/views/music/show.blade.php
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML>
+<html lang="ja">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>音楽詳細画面</title>
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+</head>
+
+<body>
+    <h1 class="title">
+        {{ $music->name }}
+    </h1>
+    <div class="content">
+        <div class="content__music">
+            <h3>名前</h3>
+            <p>{{ $music->name }}</p>
+            <h3>歌手</h3>
+            CV:{{ $music->singer_id }}
+            <h3>登場作品</h3>
+            <div class='work'>
+                <a href="{{ route('works.show', ['work' => $music->work_id]) }}">
+                    {{ $music->work->name }}
+                </a>
+            </div>
+            <h3>作詞者</h3>
+            CV:{{ $music->lyric_writer_id }}
+            <h3>作曲者</h3>
+            CV:{{ $music->composer_id }}
+            <h3>Wikipediaへのリンク</h3>
+            <p>{{ $music->wiki_link }}</p>
+            <h3>YouTubeのリンク</h3>
+            <p>{{ $music->youtube_link }}</p>
+        </div>
+    </div>
+    <div class="post_link">
+        <a href="{{ route('character_posts.index', ['character_id' => $music->id]) }}">音楽感想一覧</a>
+    </div>
+</body>
+
+</html>

--- a/resources/views/works/show.blade.php
+++ b/resources/views/works/show.blade.php
@@ -30,7 +30,9 @@
                 @else
                 @foreach ($work->music as $music)
                 <div class='music_name'>
-                    <h3>{{ $music->name }}</h3>
+                <a href="{{ route('music.show', ['music_id' => $music->id]) }}">
+                    {{ $music->name }}
+                </a>
                 </div>
                 @endforeach
                 @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\CharacterController;
 use App\Http\Controllers\CharacterPostController;
 use App\Http\Controllers\CharacterPostLikeController;
 use App\Http\Controllers\VoiceArtistController;
+use App\Http\Controllers\MusicController;
 
 
 /*
@@ -115,6 +116,14 @@ Route::controller(CharacterPostLikeController::class)->middleware(['auth'])->gro
 Route::controller(VoiceArtistController::class)->middleware(['auth'])->group(function () {
     // 声優の詳細表示
     Route::get('/voice_artist/{voice_artist_id}', 'show')->name('voice_artist.show');
+});
+
+// MusicControllerに関するルーティング
+Route::controller(MusicController::class)->middleware(['auth'])->group(function () {
+    // 登場人物一覧の表示
+    Route::get('/music', 'index')->name('music.index');
+    // 登場人物の詳細表示
+    Route::get('/music/{music_id}', 'show')->name('music.show');
 });
 
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
### 音楽一覧と音楽詳細の作成

- #35

**音楽一覧**
・音楽一覧の表示（名前で検索が可能）

**音楽詳細**
・詳細の表示
・歌手・作詞者・作曲者詳細画面へのリンクは後に作成する予定
・音楽感想投稿一覧へのリンクは後に作成する予定

・作品詳細から音楽詳細へのリンクも追加

・音楽一覧
![スクリーンショット 2024-11-05 120635](https://github.com/user-attachments/assets/418b6d0b-36dc-4aa3-9dbd-678182c9d7e6)

・音楽詳細
![スクリーンショット 2024-11-05 120647](https://github.com/user-attachments/assets/c5c7baa7-a5db-44ad-8b1f-485b928a5e0e)
