### PR TITLE
feat：musicテーブルに関する歌手、作詞者、作曲者のリレーション追加

### DIFF
--- a/app/Http/Controllers/ComposerController.php
+++ b/app/Http/Controllers/ComposerController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Composer;
+
+class ComposerController extends Controller
+{
+    // 詳細な作曲者情報を表示する
+    public function show($composer_id)
+    {
+        $composer = Composer::find($composer_id);
+        return view('composers.show')->with(['composer' => $composer]);
+    }
+}

--- a/app/Http/Controllers/LyricWriterController.php
+++ b/app/Http/Controllers/LyricWriterController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\LyricWriter;
+
+class LyricWriterController extends Controller
+{
+    // 詳細な作詞者情報を表示する
+    public function show($lyric_writer_id)
+    {
+        $lyric_writer = LyricWriter::find($lyric_writer_id);
+        return view('lyric_writers.show')->with(['lyric_writer' => $lyric_writer]);
+    }
+}

--- a/app/Http/Controllers/SingerController.php
+++ b/app/Http/Controllers/SingerController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Singer;
+
+class SingerController extends Controller
+{
+    // 詳細な作詞者情報を表示する
+    public function show($singer_id)
+    {
+        $singer = Singer::find($singer_id);
+        return view('singers.show')->with(['singer' => $singer]);
+    }
+}

--- a/app/Models/Composer.php
+++ b/app/Models/Composer.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Composer extends Model
+{
+    use HasFactory;
+
+    // 参照させたいcomposersを指定
+    protected $table = 'composers';
+
+    // Musicに対するリレーション 1対多の関係
+    public function music()
+    {
+        return $this->hasMany(Music::class, 'composer_id', 'id');
+    }
+}

--- a/app/Models/LyricWriter.php
+++ b/app/Models/LyricWriter.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LyricWriter extends Model
+{
+    use HasFactory;
+
+    // 参照させたいlyric_writersを指定
+    protected $table = 'lyric_writers';
+
+    // Musicに対するリレーション 1対多の関係
+    public function music()
+    {
+        return $this->hasMany(Music::class, 'lyric_writer_id', 'id');
+    }
+}

--- a/app/Models/Music.php
+++ b/app/Models/Music.php
@@ -17,4 +17,22 @@ class Music extends Model
     {
         return $this->belongsTo(Work::class, 'work_id', 'id');
     }
+
+    // Composerに対するリレーション 1対多の関係
+    public function composer()
+    {
+        return $this->belongsTo(Composer::class, 'composer_id', 'id');
+    }
+
+    // LyricWriterに対するリレーション 1対多の関係
+    public function lyricWriter()
+    {
+        return $this->belongsTo(LyricWriter::class, 'lyric_writer_id', 'id');
+    }
+
+    // Singerに対するリレーション 1対多の関係
+    public function singer()
+    {
+        return $this->belongsTo(Singer::class, 'singer_id', 'id');
+    }
 }

--- a/app/Models/Singer.php
+++ b/app/Models/Singer.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Singer extends Model
+{
+    use HasFactory;
+
+    // 参照させたいsingersを指定
+    protected $table = 'singers';
+
+    // Musicに対するリレーション 1対多の関係
+    public function music()
+    {
+        return $this->hasMany(Music::class, 'singer_id', 'id');
+    }
+}

--- a/resources/views/composers/show.blade.php
+++ b/resources/views/composers/show.blade.php
@@ -4,31 +4,31 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>制作会社詳細画面</title>
+    <title>作曲者詳細画面</title>
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
 </head>
 
 <body>
     <h1 class="title">
-        {{ $creator->name }}
+        {{ $composer->name }}
     </h1>
     <div class="content">
         <div class="content__creator">
-            <h3>会社名</h3>
-            <p>{{ $creator->name }}</p>
+            <h3>名前</h3>
+            <p>{{ $composer->name }}</p>
             <h3>Wikipediaへのリンク</h3>
-            <p>{{ $creator->wiki_link }}</p>
-            <div class='works'>
-                <h3>作品一覧</h3>
-                @if($creator->works->isEmpty())
+            <p>{{ $composer->wiki_link }}</p>
+            <div class='music'>
+                <h3>音楽一覧</h3>
+                @if($composer->music->isEmpty())
                 <h3 class='no_work'>結果がありません。</h3>
                 @else
-                @foreach ($creator->works as $work)
-                <div class='work_name'>
-                <a href="{{ route('works.show', ['work' => $work->id]) }}">
-                    {{ $work->name }}
-                </a>
+                @foreach ($composer->music as $music)
+                <div class='music_name'>
+                    <a href="{{ route('music.show', ['music_id' => $music->id]) }}">
+                        {{ $music->name }}
+                    </a>
                 </div>
                 @endforeach
                 @endif

--- a/resources/views/lyric_writers/show.blade.php
+++ b/resources/views/lyric_writers/show.blade.php
@@ -4,31 +4,31 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>制作会社詳細画面</title>
+    <title>作詞者詳細画面</title>
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
 </head>
 
 <body>
     <h1 class="title">
-        {{ $creator->name }}
+        {{ $lyric_writer->name }}
     </h1>
     <div class="content">
         <div class="content__creator">
-            <h3>会社名</h3>
-            <p>{{ $creator->name }}</p>
+            <h3>名前</h3>
+            <p>{{ $lyric_writer->name }}</p>
             <h3>Wikipediaへのリンク</h3>
-            <p>{{ $creator->wiki_link }}</p>
-            <div class='works'>
-                <h3>作品一覧</h3>
-                @if($creator->works->isEmpty())
+            <p>{{ $lyric_writer->wiki_link }}</p>
+            <div class='music'>
+                <h3>音楽一覧</h3>
+                @if($lyric_writer->music->isEmpty())
                 <h3 class='no_work'>結果がありません。</h3>
                 @else
-                @foreach ($creator->works as $work)
-                <div class='work_name'>
-                <a href="{{ route('works.show', ['work' => $work->id]) }}">
-                    {{ $work->name }}
-                </a>
+                @foreach ($lyric_writer->music as $music)
+                <div class='music_name'>
+                    <a href="{{ route('music.show', ['music_id' => $music->id]) }}">
+                        {{ $music->name }}
+                    </a>
                 </div>
                 @endforeach
                 @endif

--- a/resources/views/music/index.blade.php
+++ b/resources/views/music/index.blade.php
@@ -37,7 +37,10 @@
                 </a>
             </p>
             <p class='singer'>
-                歌手:{{ $music_model->singer_id }}
+            歌手:
+            <a href="{{ route('singer.show', ['singer_id' => $music_model->singer_id]) }}">
+                {{ $music_model->singer->name }}
+            </a>
             </p>
         </div>
         @endforeach

--- a/resources/views/music/show.blade.php
+++ b/resources/views/music/show.blade.php
@@ -17,18 +17,30 @@
         <div class="content__music">
             <h3>名前</h3>
             <p>{{ $music->name }}</p>
-            <h3>歌手</h3>
-            CV:{{ $music->singer_id }}
-            <h3>登場作品</h3>
+            <div class='singer'>
+                <h3>歌手</h3>
+                <a href="{{ route('singer.show', ['singer_id' => $music->singer_id]) }}">
+                    {{ $music->singer->name }}
+                </a>
+            </div>
             <div class='work'>
+                <h3>登場作品</h3>
                 <a href="{{ route('works.show', ['work' => $music->work_id]) }}">
                     {{ $music->work->name }}
                 </a>
             </div>
-            <h3>作詞者</h3>
-            CV:{{ $music->lyric_writer_id }}
+            <div class='lyric_writer'>
+                <h3>作詞者</h3>
+                <a href="{{ route('lyric_writer.show', ['lyric_writer_id' => $music->lyric_writer_id]) }}">
+                    {{ $music->lyricWriter->name }}
+                </a>
+            </div>
+            <div class='composer'>
             <h3>作曲者</h3>
-            CV:{{ $music->composer_id }}
+            <a href="{{ route('composer.show', ['composer_id' => $music->composer_id]) }}">
+                    {{ $music->composer->name }}
+                </a>
+            </div>
             <h3>Wikipediaへのリンク</h3>
             <p>{{ $music->wiki_link }}</p>
             <h3>YouTubeのリンク</h3>

--- a/resources/views/singers/show.blade.php
+++ b/resources/views/singers/show.blade.php
@@ -4,31 +4,31 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>制作会社詳細画面</title>
+    <title>歌手詳細画面</title>
     <!-- Fonts -->
     <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
 </head>
 
 <body>
     <h1 class="title">
-        {{ $creator->name }}
+        {{ $singer->name }}
     </h1>
     <div class="content">
         <div class="content__creator">
-            <h3>会社名</h3>
-            <p>{{ $creator->name }}</p>
+            <h3>名前</h3>
+            <p>{{ $singer->name }}</p>
             <h3>Wikipediaへのリンク</h3>
-            <p>{{ $creator->wiki_link }}</p>
-            <div class='works'>
-                <h3>作品一覧</h3>
-                @if($creator->works->isEmpty())
+            <p>{{ $singer->wiki_link }}</p>
+            <div class='music'>
+                <h3>音楽一覧</h3>
+                @if($singer->music->isEmpty())
                 <h3 class='no_work'>結果がありません。</h3>
                 @else
-                @foreach ($creator->works as $work)
-                <div class='work_name'>
-                <a href="{{ route('works.show', ['work' => $work->id]) }}">
-                    {{ $work->name }}
-                </a>
+                @foreach ($singer->music as $music)
+                <div class='music_name'>
+                    <a href="{{ route('music.show', ['music_id' => $music->id]) }}">
+                        {{ $music->name }}
+                    </a>
                 </div>
                 @endforeach
                 @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,9 @@ use App\Http\Controllers\CharacterPostController;
 use App\Http\Controllers\CharacterPostLikeController;
 use App\Http\Controllers\VoiceArtistController;
 use App\Http\Controllers\MusicController;
+use App\Http\Controllers\SingerController;
+use App\Http\Controllers\LyricWriterController;
+use App\Http\Controllers\ComposerController;
 
 
 /*
@@ -124,6 +127,24 @@ Route::controller(MusicController::class)->middleware(['auth'])->group(function 
     Route::get('/music', 'index')->name('music.index');
     // 登場人物の詳細表示
     Route::get('/music/{music_id}', 'show')->name('music.show');
+});
+
+// SingerControllerに関するルーティング
+Route::controller(SingerController::class)->middleware(['auth'])->group(function () {
+    // 歌手の詳細表示
+    Route::get('/singer/{singer_id}', 'show')->name('singer.show');
+});
+
+// LyricWriterControllerに関するルーティング
+Route::controller(LyricWriterController::class)->middleware(['auth'])->group(function () {
+    // 作詞者の詳細表示
+    Route::get('/lyric_writer/{lyric_writer_id}', 'show')->name('lyric_writer.show');
+});
+
+// ComposerControllerに関するルーティング
+Route::controller(ComposerController::class)->middleware(['auth'])->group(function () {
+    // 作曲者の詳細表示
+    Route::get('/composer/{composer_id}', 'show')->name('composer.show');
 });
 
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
### musicテーブルに関する歌手、作詞者、作曲者のリレーション追加

- #36

・singer、lyric_writer、composerのモデルとコントローラーの追加
・musicテーブルとのリレーション追加
・音楽一覧と音楽詳細にて名前の表示

・歌手詳細、作詞者詳細、作曲者詳細画面と各画面へのリンク追加

・音楽詳細
![スクリーンショット 2024-11-05 235559](https://github.com/user-attachments/assets/7d855c32-aae0-4326-aa5f-e08adb69a2e6)

・歌手詳細
![スクリーンショット 2024-11-05 235618](https://github.com/user-attachments/assets/71139673-f394-4327-a98d-46b411f29618)

・作詞者詳細
![スクリーンショット 2024-11-05 235631](https://github.com/user-attachments/assets/8882d41d-ec5e-4417-9e43-88e790205881)

・作曲者詳細
![スクリーンショット 2024-11-05 235651](https://github.com/user-attachments/assets/e6c44505-5ea4-466a-8b4e-b44a0e7a2568)
