### PR TITLE
Feat：音楽感想投稿一覧と音楽感想投稿詳細の作成

### DIFF
--- a/app/Http/Controllers/MusicPostController.php
+++ b/app/Http/Controllers/MusicPostController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\MusicPost;
+use Illuminate\Support\Facades\Auth;
+use CloudinaryLabs\CloudinaryLaravel\Facades\Cloudinary;
+
+class MusicPostController extends Controller
+{
+    // 音楽感想投稿一覧の表示
+    public function index($music_id)
+    {
+        // 指定したidの音楽の投稿のみを表示
+        $music_posts = MusicPost::where('music_id', $music_id)->orderBy('id', 'DESC')->where(function ($query) {
+            // キーワード検索がなされた場合
+            if ($search = request('search')) {
+                // 検索語のスペースを半角に統一
+                $search_split = mb_convert_kana($search, 's');
+                // 半角スペースで単語ごとに分割して配列にする
+                $search_array = preg_split('/[\s]+/', $search_split);
+                foreach ($search_array as $search_word) {
+                    $query->where(function ($query) use ($search_word) {
+                        $query->where('post_title', 'LIKE', "%{$search_word}%")
+                            ->orWhere('body', 'LIKE', "%{$search_word}%");
+                    });
+                }
+            }
+        })->paginate(5);
+        $music_first = MusicPost::where('music_id', $music_id)->first();
+        return view('music_posts.index')->with(['music_posts' => $music_posts, 'music_first' => $music_first]);
+    }
+
+    // 音楽感想投稿詳細の表示
+    public function show(MusicPost $musicPost, $music_id, $music_post_id)
+    {
+        return view('music_posts.show')->with(['music_post' => $musicPost->getDetailPost($music_id, $music_post_id)]);
+    }
+}

--- a/app/Models/Music.php
+++ b/app/Models/Music.php
@@ -35,4 +35,10 @@ class Music extends Model
     {
         return $this->belongsTo(Singer::class, 'singer_id', 'id');
     }
+
+    // MusicPostに対するリレーション 1対1の関係
+    public function musicPost()
+    {
+        return $this->hasOne(MusicPost::class, 'id', 'music_id');
+    }
 }

--- a/app/Models/MusicPost.php
+++ b/app/Models/MusicPost.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MusicPost extends Model
+{
+    use HasFactory;
+
+    // 参照させたいmusic_postsを指定
+    protected $table = 'music_posts';
+
+    // 音楽idと投稿idを指定して、投稿の詳細表示を行う
+    public function getDetailPost($music_id, $music_post_id)
+    {
+        return $this->where([
+            ['music_id', $music_id],
+            ['id', $music_post_id],
+        ])->first();
+    }
+
+    // 条件とその値を指定してデータを1件取得する
+    public function getRestrictedPost($condition, $column_name)
+    {
+        return $this->where($condition, $column_name)->first();
+    }
+}

--- a/app/Models/MusicPost.php
+++ b/app/Models/MusicPost.php
@@ -12,6 +12,24 @@ class MusicPost extends Model
     // 参照させたいmusic_postsを指定
     protected $table = 'music_posts';
 
+    // Musicに対するリレーション 1対1の関係
+    public function music()
+    {
+        return $this->belongsTo(Music::class, 'music_id', 'id');
+    }
+
+    // 投稿者に対するリレーション 1対1の関係
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id', 'id');
+    }
+
+    // 作品に対するリレーション 1対1の関係
+    public function work()
+    {
+        return $this->belongsTo(Work::class, 'work_id', 'id');
+    }
+
     // 音楽idと投稿idを指定して、投稿の詳細表示を行う
     public function getDetailPost($music_id, $music_post_id)
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -58,9 +58,21 @@ class User extends Authenticatable
         return $this->belongsToMany(WorkReview::class);
     }
 
+    // CharacterPostに対するリレーション 1対1の関係
+    public function characterPost()
+    {
+        return $this->hasOne(CharacterPost::class, 'id', 'character_id');
+    }
+
     // いいねをしたCharacterPostに対するリレーション 多対多の関係
     public function characterPosts()
     {
         return $this->belongsToMany(CharacterPost::class, 'character_posts_users', 'user_id', 'character_post_id');
+    }
+
+    // MusicPostに対するリレーション 1対1の関係
+    public function musicPost()
+    {
+        return $this->hasOne(MusicPost::class, 'id', 'music_id');
     }
 }

--- a/app/Models/VoiceArtist.php
+++ b/app/Models/VoiceArtist.php
@@ -12,7 +12,7 @@ class VoiceArtist extends Model
     // 参照させたいvoice_artistsを指定
     protected $table = 'voice_artists';
 
-    // Workに対するリレーション 1対多の関係
+    // Characterに対するリレーション 1対多の関係
     public function characters()
     {
         return $this->hasMany(Character::class, 'voice_artist_id', 'id');

--- a/resources/views/character_posts/show.blade.php
+++ b/resources/views/character_posts/show.blade.php
@@ -11,9 +11,6 @@
 
 <body>
     <h1 class="title">
-        @php
-        //dd($character_post);
-        @endphp
         {{ $character_post->post_title }}
     </h1>
     <div class="like">

--- a/resources/views/music/show.blade.php
+++ b/resources/views/music/show.blade.php
@@ -48,7 +48,7 @@
         </div>
     </div>
     <div class="post_link">
-        <a href="{{ route('character_posts.index', ['character_id' => $music->id]) }}">音楽感想一覧</a>
+        <a href="{{ route('music_posts.index', ['music_id' => $music->id]) }}">音楽感想一覧</a>
     </div>
 </body>
 

--- a/resources/views/music_posts/index.blade.php
+++ b/resources/views/music_posts/index.blade.php
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+<head>
+    <meta charset="utf-8">
+    <title>Blog</title>
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+</head>
+
+<body>
+    <h1>「{{ $music_first->music_id }}」の感想投稿一覧</h1>
+    <a href="{{ route('music_posts.create', ['music_id' => $music_first->music_id]) }}">新規投稿作成</a>
+    <!-- 検索機能 -->
+    <div class=serch>
+        <form action="{{ route('music_posts.index', ['music_id' => $music_first->music_id]) }}" method="GET">
+            <input type="text" name="search" value="{{ request('search') }}" placeholder="キーワードを検索" aria-label="検索...">
+            <input type="submit" value="キーワード検索">
+        </form>
+        <div class="cancel">
+            <a href="{{ route('music_posts.index', ['music_id' => $music_first->music_id]) }}">キャンセル</a>
+        </div>
+    </div>
+    <div class='music_posts'>
+        @if($music_posts->isEmpty())
+        <h2 class='no_result'>結果がありません。</h2>
+        @else
+        <div class='music_post'>
+            @foreach ($music_posts as $music_post)
+            <div class='music_post'>
+                <h2 class='title'>
+                    <a href="{{ route('music_posts.show', ['music_id' => $music_post->music_id, 'music_post_id' => $music_post->id]) }}">{{ $music_post->post_title }}</a>
+                </h2>
+                <div class="like">
+                    
+                </div>
+                <p class='body'>{{ $music_post->body }}</p>
+                <form action="{{ route('music_posts.delete', ['music_id' => $music_post->music_id, 'music_post_id' => $music_post->id]) }}" id="form_{{ $music_post->id }}" method="post">
+                    @csrf
+                    @method('DELETE')
+                    <button type="button" data-post-id="{{ $music_post->id }}" class="delete-button">投稿を削除する</button>
+                </form>
+            </div>
+            @endforeach
+        </div>
+        @endif
+    </div>
+    <div class="footer">
+        <a href="{{ route('music.show', ['music_id' => $music_first->music_id]) }}">音楽詳細画面へ</a>
+    </div>
+    <div class='paginate'>
+        {{ $music_posts->appends(request()->query())->links() }}
+    </div>
+
+    <script>
+        // // DOMツリー読み取り完了後にイベント発火
+        // document.addEventListener('DOMContentLoaded', function() {
+        //     // delete-buttonに一致するすべてのHTML要素を取得
+        //     document.querySelectorAll('.delete-button').forEach(function(button) {
+        //         button.addEventListener('click', function() {
+        //             const postId = button.getAttribute('data-post-id');
+        //             deletePost(postId);
+        //         });
+        //     });
+        // });
+
+        // // 削除処理を行う
+        // function deletePost(postId) {
+        //     'use strict'
+
+        //     if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
+        //         document.getElementById(`form_${postId}`).submit();
+        //     }
+        // }
+
+        // // いいね処理を非同期で行う
+        // document.addEventListener('DOMContentLoaded', function() {
+        //     const likeClasses = document.querySelectorAll('.like');
+        //     likeClasses.forEach(element => {
+        //         // いいねボタンのクラスの取得
+        //         let button = element.querySelector('#like_button');
+        //         // いいねしたユーザー数のクラス取得とpタグの取得
+        //         let likeClass = element.querySelector('.like_user');
+        //         let users = likeClass.querySelector('#like_count');
+
+        //         //いいねボタンクリックによる非同期処理
+        //         button.addEventListener('click', async function() {
+        //             const characterId = button.getAttribute('data-character-id');
+        //             const postId = button.getAttribute('data-post-id');
+        //             try {
+        //                 const response = await fetch(`/character_posts/${characterId}/posts/${postId}/like`, {
+        //                     method: 'POST',
+        //                     headers: {
+        //                         'Content-Type': 'application/json',
+        //                         'X-CSRF-TOKEN': '{{ csrf_token() }}'
+        //                     },
+        //                 });
+        //                 const data = await response.json();
+        //                 if (data.status === 'liked') {
+        //                     button.innerText = 'いいね取り消し';
+        //                     users.innerText = data.like_user;
+        //                 } else if (data.status === 'unliked') {
+        //                     button.innerText = 'いいね';
+        //                     users.innerText = data.like_user;
+        //                 }
+        //             } catch (error) {
+        //                 console.error('Error:', error);
+        //             }
+        //         });
+        //     });
+        // });
+    </script>
+</body>
+
+</html>

--- a/resources/views/music_posts/index.blade.php
+++ b/resources/views/music_posts/index.blade.php
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-    <h1>「{{ $music_first->music_id }}」の感想投稿一覧</h1>
+    <h1>「{{ $music_first->music->name }}」の感想投稿一覧</h1>
     <a href="{{ route('music_posts.create', ['music_id' => $music_first->music_id]) }}">新規投稿作成</a>
     <!-- 検索機能 -->
     <div class=serch>

--- a/resources/views/music_posts/show.blade.php
+++ b/resources/views/music_posts/show.blade.php
@@ -19,11 +19,11 @@
     <div class="content">
         <div class="content__character_post">
             <h3>音楽名</h3>
-            <p>{{ $music_post->music_id }}</p>
+            <p>{{ $music_post->music->name }}</p>
             <h3>使用作品</h3>
-            <p>{{ $music_post->work_id }}</p>
+            <p>{{ $music_post->work->name }}</p>
             <h3>投稿者</h3>
-            <p>{{ $music_post->user_id }}</p>
+            <p>{{ $music_post->user->name }}</p>
             <h3>タイトル</h3>
             <p>{{ $music_post->post_title }}</p>
             <h3>評価</h3>

--- a/resources/views/music_posts/show.blade.php
+++ b/resources/views/music_posts/show.blade.php
@@ -1,0 +1,112 @@
+<!DOCTYPE HTML>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>音楽の感想</title>
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+</head>
+
+<body>
+    <h1 class="title">
+        {{ $music_post->post_title }}
+    </h1>
+    <div class="like">
+        
+    </div>
+    <div class="content">
+        <div class="content__character_post">
+            <h3>音楽名</h3>
+            <p>{{ $music_post->music_id }}</p>
+            <h3>使用作品</h3>
+            <p>{{ $music_post->work_id }}</p>
+            <h3>投稿者</h3>
+            <p>{{ $music_post->user_id }}</p>
+            <h3>タイトル</h3>
+            <p>{{ $music_post->post_title }}</p>
+            <h3>評価</h3>
+            @php
+            $numbers = array(1 => '★', 2 => '★★', 3 => '★★★', 4 => '★★★★', 5 => '★★★★★');
+            @endphp
+            <p>{{ $numbers[$music_post->star_num] }}</p>
+            <h3>本文</h3>
+            <p>{{ $music_post->body }}</p>
+            <h3>作成日</h3>
+            <p>{{ $music_post->created_at }}</p>
+        </div>
+    </div>
+    <div class="edit">
+        <a href="{{ route('character_posts.edit', ['character_id' => $music_post->music_id, 'character_post_id' => $music_post->id]) }}">編集する</a>
+    </div>
+    <form action="{{ route('character_posts.delete', ['character_id' => $music_post->music_id, 'character_post_id' => $music_post->id]) }}" id="form_{{ $music_post->id }}" method="post">
+        @csrf
+        @method('DELETE')
+        <button type="button" data-post-id="{{ $music_post->id }}" class="delete-button">投稿を削除する</button>
+    </form>
+    <div class="footer">
+        <a href="{{ route('music_posts.index', ['music_id' => $music_post->music_id]) }}">戻る</a>
+    </div>
+
+    <script>
+        // // DOMツリー読み取り完了後にイベント発火
+        // document.addEventListener('DOMContentLoaded', function() {
+        //     // delete-buttonに一致するすべてのHTML要素を取得
+        //     document.querySelectorAll('.delete-button').forEach(function(button) {
+        //         button.addEventListener('click', function() {
+        //             const postId = button.getAttribute('data-post-id');
+        //             deletePost(postId);
+        //         });
+        //     });
+        // });
+
+        // // 削除処理を行う
+        // function deletePost(postId) {
+        //     'use strict'
+
+        //     if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
+        //         document.getElementById(`form_${postId}`).submit();
+        //     }
+        // }
+
+        // // いいね処理を非同期で行う
+        // document.addEventListener('DOMContentLoaded', function() {
+        //     const likeClasses = document.querySelectorAll('.like');
+        //     likeClasses.forEach(element => {
+        //         // いいねボタンのクラスの取得
+        //         let button = element.querySelector('#like_button');
+        //         // いいねしたユーザー数のクラス取得とpタグの取得
+        //         let likeClass = element.querySelector('.like_user');
+        //         let users = likeClass.querySelector('#like_count');
+
+        //         //いいねボタンクリックによる非同期処理
+        //         button.addEventListener('click', async function() {
+        //             const characterId = button.getAttribute('data-character-id');
+        //             const postId = button.getAttribute('data-post-id');
+        //             try {
+        //                 const response = await fetch(`/character_posts/${characterId}/posts/${postId}/like`, {
+        //                     method: 'POST',
+        //                     headers: {
+        //                         'Content-Type': 'application/json',
+        //                         'X-CSRF-TOKEN': '{{ csrf_token() }}'
+        //                     },
+        //                 });
+        //                 const data = await response.json();
+        //                 if (data.status === 'liked') {
+        //                     button.innerText = 'いいね取り消し';
+        //                     users.innerText = data.like_user;
+        //                 } else if (data.status === 'unliked') {
+        //                     button.innerText = 'いいね';
+        //                     users.innerText = data.like_user;
+        //                 }
+        //             } catch (error) {
+        //                 console.error('Error:', error);
+        //             }
+        //         });
+        //     });
+        // });
+    </script>
+</body>
+
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\CharacterPostController;
 use App\Http\Controllers\CharacterPostLikeController;
 use App\Http\Controllers\VoiceArtistController;
 use App\Http\Controllers\MusicController;
+use App\Http\Controllers\MusicPostController;
 use App\Http\Controllers\SingerController;
 use App\Http\Controllers\LyricWriterController;
 use App\Http\Controllers\ComposerController;
@@ -123,10 +124,30 @@ Route::controller(VoiceArtistController::class)->middleware(['auth'])->group(fun
 
 // MusicControllerに関するルーティング
 Route::controller(MusicController::class)->middleware(['auth'])->group(function () {
-    // 登場人物一覧の表示
+    // 音楽一覧の表示
     Route::get('/music', 'index')->name('music.index');
-    // 登場人物の詳細表示
+    // 音楽の詳細表示
     Route::get('/music/{music_id}', 'show')->name('music.show');
+});
+
+// MusicPostControllerに関するルーティング
+Route::controller(MusicPostController::class)->middleware(['auth'])->group(function () {
+    // 音楽人物ごとの感想投稿一覧の表示
+    Route::get('/music_posts/{music_id}', 'index')->name('music_posts.index');
+    // 新規投稿作成ボタン押下で、createメソッドを実行
+    Route::get('/music_posts/{music_id}/create', 'create')->name('music_posts.create');
+    // 作成するボタン押下で、storeメソッドを実行
+    Route::post('/character_posts/{character_id}/store', 'store')->name('character_posts.store');
+    // 各登場人物の感想投稿一覧ボタン押下で、showメソッドを実行
+    Route::get('/music_posts/{music_id}/posts/{music_post_id}', 'show')->name('music_posts.show');
+    // 感想投稿編集画面を表示するeditメソッドを実行
+    Route::get('/character_posts/{character_id}/posts/{character_post_id}/edit', 'edit')->name('character_posts.edit');
+    // 感想投稿の編集を実行するupdateメソッドを実行
+    Route::put('/character_posts/{character_id}/update/{character_post_id}', 'update')->name('character_posts.update');
+    // 感想投稿の削除を行うdeleteメソッドを実行
+    Route::delete('/music_posts/{music_id}/posts/{music_post_id}/delete', 'delete')->name('music_posts.delete');
+    // 感想投稿のいいねボタン押下で、いいねを追加するlikeメソッドを実行
+    Route::post('/character_posts/{character_id}/posts/{character_post_id}/like', 'like')->name('character_posts.like');
 });
 
 // SingerControllerに関するルーティング


### PR DESCRIPTION
### 音楽感想投稿一覧と音楽感想投稿詳細の作成

- #35 

**音楽感想投稿一覧**
・一覧の表示とタイトル・本文のキーワード検索が可能

**音楽感想投稿詳細**
・詳細の表示

・音楽感想投稿と使用作品、ユーザー、音楽のリレーション追加

・音楽感想投稿一覧
![スクリーンショット 2024-11-06 104543](https://github.com/user-attachments/assets/2f537340-7a62-4e7b-b3b3-06ada7a4e8a8)

・音楽感想投稿詳細
![スクリーンショット 2024-11-06 104558](https://github.com/user-attachments/assets/ddb23a1b-a23f-420a-af63-027ca3f60e22)
