### PR TITLE
Feat：音楽感想投稿にCUD機能の追加

### DIFF
--- a/app/Http/Controllers/MusicPostController.php
+++ b/app/Http/Controllers/MusicPostController.php
@@ -4,10 +4,13 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\MusicPostRequest;
 use App\Models\MusicPost;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Auth;
 
 class MusicPostController extends Controller
 {
+    use SoftDeletes;
+
     // 音楽感想投稿一覧の表示
     public function index($music_id)
     {
@@ -67,6 +70,15 @@ class MusicPostController extends Controller
         $targetMusicPost = $musicPost->getDetailPost($music_id, $music_post_id);
         $targetMusicPost->fill($input_post)->save();
         return redirect()->route('music_posts.show', ['music_id' => $targetMusicPost->music_id, 'music_post_id' => $targetMusicPost->id]);
+    }
+
+    // 感想投稿を削除する
+    public function delete(MusicPost $musicPost, $music_id, $music_post_id)
+    {
+        // 編集の対象となるデータを取得
+        $targetMusicPost = $musicPost->getDetailPost($music_id, $music_post_id);
+        $targetMusicPost->delete();
+        return redirect()->route('music_posts.index', ['music_id' => $music_id]);
     }
 
 }

--- a/app/Http/Controllers/MusicPostController.php
+++ b/app/Http/Controllers/MusicPostController.php
@@ -2,10 +2,9 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
+use App\Http\Requests\MusicPostRequest;
 use App\Models\MusicPost;
 use Illuminate\Support\Facades\Auth;
-use CloudinaryLabs\CloudinaryLaravel\Facades\Cloudinary;
 
 class MusicPostController extends Controller
 {
@@ -37,4 +36,21 @@ class MusicPostController extends Controller
     {
         return view('music_posts.show')->with(['music_post' => $musicPost->getDetailPost($music_id, $music_post_id)]);
     }
+
+    // 新規投稿作成画面を表示する
+    public function create(MusicPost $musicPost, $music_id)
+    {
+        return view('music_posts.create')->with(['music_post' => $musicPost->getRestrictedPost('music_id', $music_id)]);
+    }
+
+    // 新しく記述した内容を保存する
+    public function store(MusicPost $musicPost, MusicPostRequest $request)
+    {
+        $input_post = $request['music_post'];
+        // ログインしているユーザーidの登録
+        $input_post['user_id'] = Auth::id();
+        $musicPost->fill($input_post)->save();
+        return redirect()->route('music_posts.show', ['music_id' => $musicPost->music_id, 'music_post_id' => $musicPost->id]);
+    }
+
 }

--- a/app/Http/Controllers/MusicPostController.php
+++ b/app/Http/Controllers/MusicPostController.php
@@ -53,4 +53,20 @@ class MusicPostController extends Controller
         return redirect()->route('music_posts.show', ['music_id' => $musicPost->music_id, 'music_post_id' => $musicPost->id]);
     }
 
+    // 感想投稿編集画面を表示する
+    public function edit(MusicPost $musicPost, $music_id, $music_post_id)
+    {
+        return view('music_posts.edit')->with(['music_post' => $musicPost->getDetailPost($music_id, $music_post_id)]);
+    }
+
+    // 感想投稿の編集を実行する
+    public function update(MusicPostRequest $request, MusicPost $musicPost, $music_id, $music_post_id)
+    {
+        $input_post = $request['music_post'];
+        // 編集の対象となるデータを取得
+        $targetMusicPost = $musicPost->getDetailPost($music_id, $music_post_id);
+        $targetMusicPost->fill($input_post)->save();
+        return redirect()->route('music_posts.show', ['music_id' => $targetMusicPost->music_id, 'music_post_id' => $targetMusicPost->id]);
+    }
+
 }

--- a/app/Http/Requests/MusicPostRequest.php
+++ b/app/Http/Requests/MusicPostRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class MusicPostRequest extends FormRequest
+{
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'music_post.post_title' => 'required|string|max:100',
+            'music_post.body' => 'required|string|max:4000',
+            'music_post.star_num' => 'required',
+        ];
+    }
+}

--- a/app/Models/MusicPost.php
+++ b/app/Models/MusicPost.php
@@ -9,6 +9,16 @@ class MusicPost extends Model
 {
     use HasFactory;
 
+    // fillを実行するための記述
+    protected $fillable = [
+        'music_id',
+        'user_id',
+        'work_id',
+        'post_title',
+        'star_num',
+        'body',
+    ];
+
     // 参照させたいmusic_postsを指定
     protected $table = 'music_posts';
 

--- a/lang/ja/validation.php
+++ b/lang/ja/validation.php
@@ -203,7 +203,7 @@ return [
         // 音楽の感想投稿のバリデーション
         'music_post.post_title' => 'タイトル',
         'music_post.body' => '内容',
-        'character_post.star_num' => '評価数',
+        'music_post.star_num' => '評価数',
     ],
 
 ];

--- a/lang/ja/validation.php
+++ b/lang/ja/validation.php
@@ -200,6 +200,10 @@ return [
         'character_post.body' => '内容',
         'character_post.categories_array' => 'カテゴリー',
         'character_post.star_num' => '評価数',
+        // 音楽の感想投稿のバリデーション
+        'music_post.post_title' => 'タイトル',
+        'music_post.body' => '内容',
+        'character_post.star_num' => '評価数',
     ],
 
 ];

--- a/resources/views/music_posts/create.blade.php
+++ b/resources/views/music_posts/create.blade.php
@@ -1,0 +1,50 @@
+<!DOCTYPE HTML>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+<head>
+    <meta charset="utf-8">
+    <title>音楽の感想投稿</title>
+</head>
+
+<body>
+    <h1>「{{ $music_post->music->name }}」への新規感想投稿</h1>
+    <form action="{{ route('music_posts.store', ['music_id' => $music_post->music_id]) }}" method="POST">
+        @csrf
+        <div class="work_id">
+            <input type="hidden" name="music_post[work_id]" value="{{ $music_post->work_id }}">
+        </div>
+        <div class="music_id">
+            <input type="hidden" name="music_post[music_id]" value="{{ $music_post->music_id }}">
+        </div>
+        <div class="title">
+            <h2>タイトル</h2>
+            <input type="text" name="music_post[post_title]" placeholder="タイトル" value="{{ old('music_post.post_title') }}" />
+            <p class="title__error" style="color:red">{{ $errors->first('music_post.post_title') }}</p>
+        </div>
+        <div class="star_num">
+            <h2>星の数</h2>
+            <select name="music_post[star_num]">
+                @php
+                $numbers = array(1 => '★', 2 => '★★', 3 => '★★★', 4 => '★★★★', 5 => '★★★★★');
+                @endphp
+                @foreach($numbers as $num => $star)
+                <option value="{{ $num }}" @if(old('music_post.star_num') == $num) selected @endif>
+                    {{$star}}
+                </option>
+                @endforeach
+            </select>
+            <p class="title__star_num" style="color:red">{{ $errors->first('music_post.star_num') }}</p>
+        </div>
+        <div class="body">
+            <h2>内容</h2>
+            <textarea name="music_post[body]" placeholder="内容を記入してください。">{{ old('music_post.body') }}</textarea>
+            <p class="body__error" style="color:red">{{ $errors->first('music_post.body') }}</p>
+        </div>
+        <button type="submit">投稿する</button>
+    </form>
+    <div class="footer">
+        <a href="{{ route('music_posts.index', ['music_id' => $music_post->music_id]) }}">戻る</a>
+    </div>
+</body>
+
+</html>

--- a/resources/views/music_posts/edit.blade.php
+++ b/resources/views/music_posts/edit.blade.php
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+<head>
+    <meta charset="utf-8">
+    <title>Blog</title>
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+</head>
+
+<body>
+    <h1 class="title">{{ $music_post->music->name }}への投稿編集画面</h1>
+    <div class="content">
+        <form action="{{ route('music_posts.update', ['music_id' => $music_post->music_id, 'music_post_id' => $music_post->id]) }}" method="POST">
+            @csrf
+            @method('PUT')
+            <div class="work_id">
+                <input type="hidden" name="music_post[work_id]" value="{{ $music_post->work_id }}">
+            </div>
+            <div class="music_id">
+                <input type="hidden" name="music_post[music_id]" value="{{ $music_post->music_id }}">
+            </div>
+            <div class="user_id">
+                <input type="hidden" name="music_post[user_id]" value="{{ $music_post->user_id }}">
+            </div>
+            <div class="title">
+                <h2>タイトル</h2>
+                <input type="text" name="music_post[post_title]" placeholder="タイトル" value="{{ $music_post->post_title }}" />
+                <p class="title__error" style="color:red">{{ $errors->first('music_post.post_title') }}</p>
+            </div>
+            <div class="star_num">
+                <h2>星の数</h2>
+                <select name="music_post[star_num]">
+                    @php
+                    $numbers = array(1 => '★', 2 => '★★', 3 => '★★★', 4 => '★★★★', 5 => '★★★★★');
+                    @endphp
+                    @foreach($numbers as $num => $star)
+                    <option value="{{ $num }}" @if($music_post->star_num == $num) selected @endif>
+                        {{$star}}
+                    </option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="body">
+                <h2>内容</h2>
+                <textarea name="music_post[body]" placeholder="内容を記入してください。">{{ $music_post->body }}</textarea>
+                <p class="body__error" style="color:red">{{ $errors->first('music_post.body') }}</p>
+            </div>
+            <button type="submit">変更を保存する</button>
+        </form>
+    </div>
+    <div class="footer">
+        <a href="{{ route('music_posts.show', ['music_id' => $music_post->music_id, 'music_post_id' => $music_post->id]) }}">保存しないで戻る</a>
+    </div>
+</body>
+
+</html>

--- a/resources/views/music_posts/index.blade.php
+++ b/resources/views/music_posts/index.blade.php
@@ -53,25 +53,25 @@
     </div>
 
     <script>
-        // // DOMツリー読み取り完了後にイベント発火
-        // document.addEventListener('DOMContentLoaded', function() {
-        //     // delete-buttonに一致するすべてのHTML要素を取得
-        //     document.querySelectorAll('.delete-button').forEach(function(button) {
-        //         button.addEventListener('click', function() {
-        //             const postId = button.getAttribute('data-post-id');
-        //             deletePost(postId);
-        //         });
-        //     });
-        // });
+        // DOMツリー読み取り完了後にイベント発火
+        document.addEventListener('DOMContentLoaded', function() {
+            // delete-buttonに一致するすべてのHTML要素を取得
+            document.querySelectorAll('.delete-button').forEach(function(button) {
+                button.addEventListener('click', function() {
+                    const postId = button.getAttribute('data-post-id');
+                    deletePost(postId);
+                });
+            });
+        });
 
-        // // 削除処理を行う
-        // function deletePost(postId) {
-        //     'use strict'
+        // 削除処理を行う
+        function deletePost(postId) {
+            'use strict'
 
-        //     if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
-        //         document.getElementById(`form_${postId}`).submit();
-        //     }
-        // }
+            if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
+                document.getElementById(`form_${postId}`).submit();
+            }
+        }
 
         // // いいね処理を非同期で行う
         // document.addEventListener('DOMContentLoaded', function() {

--- a/resources/views/music_posts/show.blade.php
+++ b/resources/views/music_posts/show.blade.php
@@ -50,25 +50,25 @@
     </div>
 
     <script>
-        // // DOMツリー読み取り完了後にイベント発火
-        // document.addEventListener('DOMContentLoaded', function() {
-        //     // delete-buttonに一致するすべてのHTML要素を取得
-        //     document.querySelectorAll('.delete-button').forEach(function(button) {
-        //         button.addEventListener('click', function() {
-        //             const postId = button.getAttribute('data-post-id');
-        //             deletePost(postId);
-        //         });
-        //     });
-        // });
+        // DOMツリー読み取り完了後にイベント発火
+        document.addEventListener('DOMContentLoaded', function() {
+            // delete-buttonに一致するすべてのHTML要素を取得
+            document.querySelectorAll('.delete-button').forEach(function(button) {
+                button.addEventListener('click', function() {
+                    const postId = button.getAttribute('data-post-id');
+                    deletePost(postId);
+                });
+            });
+        });
 
-        // // 削除処理を行う
-        // function deletePost(postId) {
-        //     'use strict'
+        // 削除処理を行う
+        function deletePost(postId) {
+            'use strict'
 
-        //     if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
-        //         document.getElementById(`form_${postId}`).submit();
-        //     }
-        // }
+            if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
+                document.getElementById(`form_${postId}`).submit();
+            }
+        }
 
         // // いいね処理を非同期で行う
         // document.addEventListener('DOMContentLoaded', function() {

--- a/resources/views/music_posts/show.blade.php
+++ b/resources/views/music_posts/show.blade.php
@@ -38,9 +38,9 @@
         </div>
     </div>
     <div class="edit">
-        <a href="{{ route('character_posts.edit', ['character_id' => $music_post->music_id, 'character_post_id' => $music_post->id]) }}">編集する</a>
+        <a href="{{ route('music_posts.edit', ['music_id' => $music_post->music_id, 'music_post_id' => $music_post->id]) }}">編集する</a>
     </div>
-    <form action="{{ route('character_posts.delete', ['character_id' => $music_post->music_id, 'character_post_id' => $music_post->id]) }}" id="form_{{ $music_post->id }}" method="post">
+    <form action="{{ route('music_posts.delete', ['music_id' => $music_post->music_id, 'music_post_id' => $music_post->id]) }}" id="form_{{ $music_post->id }}" method="post">
         @csrf
         @method('DELETE')
         <button type="button" data-post-id="{{ $music_post->id }}" class="delete-button">投稿を削除する</button>

--- a/routes/web.php
+++ b/routes/web.php
@@ -137,13 +137,13 @@ Route::controller(MusicPostController::class)->middleware(['auth'])->group(funct
     // 新規投稿作成ボタン押下で、createメソッドを実行
     Route::get('/music_posts/{music_id}/create', 'create')->name('music_posts.create');
     // 作成するボタン押下で、storeメソッドを実行
-    Route::post('/character_posts/{character_id}/store', 'store')->name('character_posts.store');
+    Route::post('/music_posts/{music_id}/store', 'store')->name('music_posts.store');
     // 各登場人物の感想投稿一覧ボタン押下で、showメソッドを実行
     Route::get('/music_posts/{music_id}/posts/{music_post_id}', 'show')->name('music_posts.show');
     // 感想投稿編集画面を表示するeditメソッドを実行
-    Route::get('/character_posts/{character_id}/posts/{character_post_id}/edit', 'edit')->name('character_posts.edit');
+    Route::get('/music_posts/{music_id}/posts/{music_post_id}/edit', 'edit')->name('music_posts.edit');
     // 感想投稿の編集を実行するupdateメソッドを実行
-    Route::put('/character_posts/{character_id}/update/{character_post_id}', 'update')->name('character_posts.update');
+    Route::put('/music_posts/{music_id}/update/{music_post_id}', 'update')->name('music_posts.update');
     // 感想投稿の削除を行うdeleteメソッドを実行
     Route::delete('/music_posts/{music_id}/posts/{music_post_id}/delete', 'delete')->name('music_posts.delete');
     // 感想投稿のいいねボタン押下で、いいねを追加するlikeメソッドを実行


### PR DESCRIPTION
### 音楽感想投稿にCUD機能の追加

- #35 

**音楽感想投稿一覧**
・新規投稿画面へのリンク
・削除機能

**音楽感想投稿詳細**
・投稿編集画面へのリンク
・削除機能

**新規投稿画面**
・新規投稿を可能にする

**投稿編集画面**
・投稿の編集を可能にする

・新規投稿画面
![スクリーンショット 2024-11-06 124243](https://github.com/user-attachments/assets/1563290e-f4ab-4e5d-96b3-248e99b6decc)

・新規投稿画面（バリデーションエラー時）
![スクリーンショット 2024-11-06 124723](https://github.com/user-attachments/assets/ff97b03c-3d60-46da-98f5-7fa1b8c1c522)

・投稿編集画面
![スクリーンショット 2024-11-06 124256](https://github.com/user-attachments/assets/a70777b0-59c3-4dc4-8993-3b70f7d07ee9)

・投稿編集画面（バリデーションエラー時）
![スクリーンショット 2024-11-06 124757](https://github.com/user-attachments/assets/1429d67e-5157-4635-99bb-24a552778592)
