### PR TITLE
Feat：聖地感想投稿一覧と詳細の作成

### DIFF
--- a/app/Http/Controllers/AnimePilgrimagePostController.php
+++ b/app/Http/Controllers/AnimePilgrimagePostController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\AnimePilgrimagePost;
+
+class AnimePilgrimagePostController extends Controller
+{
+    // 聖地感想投稿一覧の表示
+    public function index($pilgrimage_id)
+    {
+        // 指定したidの聖地の投稿のみを表示
+        $pilgrimage_posts = AnimePilgrimagePost::where('anime_pilgrimage_id', $pilgrimage_id)->orderBy('id', 'DESC')->where(function ($query) {
+            // キーワード検索がなされた場合
+            if ($search = request('search')) {
+                // 検索語のスペースを半角に統一
+                $search_split = mb_convert_kana($search, 's');
+                // 半角スペースで単語ごとに分割して配列にする
+                $search_array = preg_split('/[\s]+/', $search_split);
+                foreach ($search_array as $search_word) {
+                    $query->where(function ($query) use ($search_word) {
+                        $query->where('title', 'LIKE', "%{$search_word}%")
+                            ->orwhere('scene', 'LIKE', "%{$search_word}%")
+                            ->orWhere('body', 'LIKE', "%{$search_word}%");
+                    });
+                }
+            }
+        })->paginate(5);
+        $pilgrimage_first = AnimePilgrimagePost::where('anime_pilgrimage_id', $pilgrimage_id)->first();
+        return view('anime_pilgrimage_posts.index')->with(['pilgrimage_posts' => $pilgrimage_posts, 'pilgrimage_first' => $pilgrimage_first]);
+    }
+
+    // 聖地感想投稿詳細の表示
+    public function show(AnimePilgrimagePost $pilgrimagePost, $pilgrimage_id, $pilgrimage_post_id)
+    {
+        return view('anime_pilgrimage_posts.show')->with(['pilgrimage_post' => $pilgrimagePost->getDetailPost($pilgrimage_id, $pilgrimage_post_id)]);
+    }
+}

--- a/app/Models/AnimePilgrimage.php
+++ b/app/Models/AnimePilgrimage.php
@@ -23,4 +23,10 @@ class AnimePilgrimage extends Model
     {
         return $this->belongsTo(Prefecture::class, 'prefecture_id', 'id');
     }
+
+    // AnimePilgrimagePostに対するリレーション 1対1の関係
+    public function animePilgrimagePost()
+    {
+        return $this->hasOne(AnimePilgrimagePost::class, 'id', 'anime_pilgrimage_id');
+    }
 }

--- a/app/Models/AnimePilgrimagePost.php
+++ b/app/Models/AnimePilgrimagePost.php
@@ -20,4 +20,16 @@ class AnimePilgrimagePost extends Model
             ['id', $pilgrimage_post_id],
         ])->first();
     }
+
+    // AnimePilgrimageに対するリレーション 1対1の関係
+    public function animePilgrimage()
+    {
+        return $this->belongsTo(AnimePilgrimage::class, 'anime_pilgrimage_id', 'id');
+    }
+
+    // 投稿者に対するリレーション 1対1の関係
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id', 'id');
+    }
 }

--- a/app/Models/AnimePilgrimagePost.php
+++ b/app/Models/AnimePilgrimagePost.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AnimePilgrimagePost extends Model
+{
+    use HasFactory;
+
+    // 参照させたいanime_pilgrimage_postsを指定
+    protected $table = 'anime_pilgrimage_posts';
+
+    // 聖地idと投稿idを指定して、投稿の詳細表示を行う
+    public function getDetailPost($pilgrimage_id, $pilgrimage_post_id)
+    {
+        return $this->where([
+            ['anime_pilgrimage_id', $pilgrimage_id],
+            ['id', $pilgrimage_post_id],
+        ])->first();
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -81,4 +81,10 @@ class User extends Authenticatable
     {
         return $this->belongsToMany(MusicPost::class, 'music_posts_users', 'user_id', 'music_post_id');
     }
+
+    // AnimePilgrimagePostに対するリレーション 1対1の関係
+    public function animePilgrimagePost()
+    {
+        return $this->hasOne(AnimePilgrimagePost::class, 'id', 'anime_pilgrimage_id');
+    }
 }

--- a/resources/views/anime_pilgrimage_posts/index.blade.php
+++ b/resources/views/anime_pilgrimage_posts/index.blade.php
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+<head>
+    <meta charset="utf-8">
+    <title>Blog</title>
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+</head>
+
+<body>
+    <h1>「{{ $pilgrimage_first->anime_pilgrimage_id }}」の感想投稿一覧</h1>
+    <a href="{{ route('character_posts.create', ['character_id' => $pilgrimage_first->anime_pilgrimage_id]) }}">新規投稿作成</a>
+    <!-- 検索機能 -->
+    <div class=serch>
+        <form action="{{ route('pilgrimage_posts.index', ['pilgrimage_id' => $pilgrimage_first->anime_pilgrimage_id]) }}" method="GET">
+            <input type="text" name="search" value="{{ request('search') }}" placeholder="キーワードを検索" aria-label="検索...">
+            <input type="submit" value="キーワード検索">
+        </form>
+        <div class="cancel">
+            <a href="{{ route('pilgrimage_posts.index', ['pilgrimage_id' => $pilgrimage_first->anime_pilgrimage_id]) }}">キャンセル</a>
+        </div>
+    </div>
+    <div class='pilgrimage_posts'>
+        @if($pilgrimage_posts->isEmpty())
+        <h2 class='no_result'>結果がありません。</h2>
+        @else
+        <div class='character_post'>
+            @foreach ($pilgrimage_posts as $pilgrimage_post)
+            <div class='pilgrimage_post'>
+                <h2 class='title'>
+                    <a href="{{ route('pilgrimage_posts.show', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimage_post->id]) }}">{{ $pilgrimage_post->title }}</a>
+                </h2>
+                <h2 class='user'>
+                    {{ $pilgrimage_post->user_id }}
+                </h2>
+                <h2 class='scene'>
+                    {{ $pilgrimage_post->scene }}
+                </h2>
+                <div class="like">
+                    
+                </div>
+                <p class='body'>{{ $pilgrimage_post->body }}</p>
+                @if($pilgrimage_post->image1)
+                <div>
+                    <img src="{{ $pilgrimage_post->image1 }}" alt="画像が読み込めません。">
+                </div>
+                @endif
+                <form action="{{ route('character_posts.delete', ['character_id' => $pilgrimage_post->anime_pilgrimage_id, 'character_post_id' => $pilgrimage_post->id]) }}" id="form_{{ $pilgrimage_post->id }}" method="post">
+                    @csrf
+                    @method('DELETE')
+                    <button type="button" data-post-id="{{ $pilgrimage_post->id }}" class="delete-button">投稿を削除する</button>
+                </form>
+            </div>
+            @endforeach
+        </div>
+        @endif
+    </div>
+    <div class="footer">
+        <a href="{{ route('pilgrimages.show', ['pilgrimage_id' => $pilgrimage_first->anime_pilgrimage_id]) }}">聖地詳細画面へ</a>
+    </div>
+    <div class='paginate'>
+        {{ $pilgrimage_posts->appends(request()->query())->links() }}
+    </div>
+
+    <script>
+        // // DOMツリー読み取り完了後にイベント発火
+        // document.addEventListener('DOMContentLoaded', function() {
+        //     // delete-buttonに一致するすべてのHTML要素を取得
+        //     document.querySelectorAll('.delete-button').forEach(function(button) {
+        //         button.addEventListener('click', function() {
+        //             const postId = button.getAttribute('data-post-id');
+        //             deletePost(postId);
+        //         });
+        //     });
+        // });
+
+        // // 削除処理を行う
+        // function deletePost(postId) {
+        //     'use strict'
+
+        //     if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
+        //         document.getElementById(`form_${postId}`).submit();
+        //     }
+        // }
+
+        // // いいね処理を非同期で行う
+        // document.addEventListener('DOMContentLoaded', function() {
+        //     const likeClasses = document.querySelectorAll('.like');
+        //     likeClasses.forEach(element => {
+        //         // いいねボタンのクラスの取得
+        //         let button = element.querySelector('#like_button');
+        //         // いいねしたユーザー数のクラス取得とpタグの取得
+        //         let likeClass = element.querySelector('.like_user');
+        //         let users = likeClass.querySelector('#like_count');
+
+        //         //いいねボタンクリックによる非同期処理
+        //         button.addEventListener('click', async function() {
+        //             const characterId = button.getAttribute('data-character-id');
+        //             const postId = button.getAttribute('data-post-id');
+        //             try {
+        //                 const response = await fetch(`/character_posts/${characterId}/posts/${postId}/like`, {
+        //                     method: 'POST',
+        //                     headers: {
+        //                         'Content-Type': 'application/json',
+        //                         'X-CSRF-TOKEN': '{{ csrf_token() }}'
+        //                     },
+        //                 });
+        //                 const data = await response.json();
+        //                 if (data.status === 'liked') {
+        //                     button.innerText = 'いいね取り消し';
+        //                     users.innerText = data.like_user;
+        //                 } else if (data.status === 'unliked') {
+        //                     button.innerText = 'いいね';
+        //                     users.innerText = data.like_user;
+        //                 }
+        //             } catch (error) {
+        //                 console.error('Error:', error);
+        //             }
+        //         });
+        //     });
+        // });
+    </script>
+</body>
+
+</html>

--- a/resources/views/anime_pilgrimage_posts/index.blade.php
+++ b/resources/views/anime_pilgrimage_posts/index.blade.php
@@ -9,7 +9,7 @@
 </head>
 
 <body>
-    <h1>「{{ $pilgrimage_first->anime_pilgrimage_id }}」の感想投稿一覧</h1>
+    <h1>「{{ $pilgrimage_first->animePilgrimage->name }}」の感想投稿一覧</h1>
     <a href="{{ route('character_posts.create', ['character_id' => $pilgrimage_first->anime_pilgrimage_id]) }}">新規投稿作成</a>
     <!-- 検索機能 -->
     <div class=serch>
@@ -31,12 +31,12 @@
                 <h2 class='title'>
                     <a href="{{ route('pilgrimage_posts.show', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimage_post->id]) }}">{{ $pilgrimage_post->title }}</a>
                 </h2>
-                <h2 class='user'>
-                    {{ $pilgrimage_post->user_id }}
-                </h2>
-                <h2 class='scene'>
+                <h3 class='user'>
+                    {{ $pilgrimage_post->user->name }}
+                </h3>
+                <h3 class='scene'>
                     {{ $pilgrimage_post->scene }}
-                </h2>
+                </h3>
                 <div class="like">
                     
                 </div>

--- a/resources/views/anime_pilgrimage_posts/show.blade.php
+++ b/resources/views/anime_pilgrimage_posts/show.blade.php
@@ -19,9 +19,9 @@
     <div class="content">
         <div class="content__character_post">
             <h3>聖地名</h3>
-            <p>{{ $pilgrimage_post->anime_pilgrimage_id }}</p>
+            <p>{{ $pilgrimage_post->animePilgrimage->name }}</p>
             <h3>投稿者</h3>
-            <p>{{ $pilgrimage_post->user_id }}</p>
+            <p>{{ $pilgrimage_post->user->name }}</p>
             <h3>タイトル</h3>
             <p>{{ $pilgrimage_post->title }}</p>
             <h3>シーン</h3>

--- a/resources/views/anime_pilgrimage_posts/show.blade.php
+++ b/resources/views/anime_pilgrimage_posts/show.blade.php
@@ -1,0 +1,120 @@
+<!DOCTYPE HTML>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>聖地の感想</title>
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+</head>
+
+<body>
+    <h1 class="title">
+        {{ $pilgrimage_post->title }}
+    </h1>
+    <div class="like">
+        
+    </div>
+    <div class="content">
+        <div class="content__character_post">
+            <h3>聖地名</h3>
+            <p>{{ $pilgrimage_post->anime_pilgrimage_id }}</p>
+            <h3>投稿者</h3>
+            <p>{{ $pilgrimage_post->user_id }}</p>
+            <h3>タイトル</h3>
+            <p>{{ $pilgrimage_post->title }}</p>
+            <h3>シーン</h3>
+            <p>{{ $pilgrimage_post->scene }}</p>
+            <h3>本文</h3>
+            <p>{{ $pilgrimage_post->body }}</p>
+            <h3>作成日</h3>
+            <p>{{ $pilgrimage_post->created_at }}</p>
+            @php
+            $numbers = array(1, 2, 3, 4);
+            @endphp
+            @foreach($numbers as $number)
+            @php
+            $image = "image".$number;
+            @endphp
+            @if($pilgrimage_post->$image)
+            <div>
+                <img src="{{ $pilgrimage_post->$image }}" alt="画像が読み込めません。">
+            </div>
+            @endif
+            @endforeach
+        </div>
+    </div>
+    <div class="edit">
+        <a href="{{ route('character_posts.edit', ['character_id' => $pilgrimage_post->anime_pilgrimage_id, 'character_post_id' => $pilgrimage_post->id]) }}">編集する</a>
+    </div>
+    <form action="{{ route('character_posts.delete', ['character_id' => $pilgrimage_post->anime_pilgrimage_id, 'character_post_id' => $pilgrimage_post->id]) }}" id="form_{{ $pilgrimage_post->id }}" method="post">
+        @csrf
+        @method('DELETE')
+        <button type="button" data-post-id="{{ $pilgrimage_post->id }}" class="delete-button">投稿を削除する</button>
+    </form>
+    <div class="footer">
+        <a href="{{ route('pilgrimage_posts.index', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id]) }}">戻る</a>
+    </div>
+
+    <script>
+        // // DOMツリー読み取り完了後にイベント発火
+        // document.addEventListener('DOMContentLoaded', function() {
+        //     // delete-buttonに一致するすべてのHTML要素を取得
+        //     document.querySelectorAll('.delete-button').forEach(function(button) {
+        //         button.addEventListener('click', function() {
+        //             const postId = button.getAttribute('data-post-id');
+        //             deletePost(postId);
+        //         });
+        //     });
+        // });
+
+        // // 削除処理を行う
+        // function deletePost(postId) {
+        //     'use strict'
+
+        //     if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
+        //         document.getElementById(`form_${postId}`).submit();
+        //     }
+        // }
+
+        // // いいね処理を非同期で行う
+        // document.addEventListener('DOMContentLoaded', function() {
+        //     const likeClasses = document.querySelectorAll('.like');
+        //     likeClasses.forEach(element => {
+        //         // いいねボタンのクラスの取得
+        //         let button = element.querySelector('#like_button');
+        //         // いいねしたユーザー数のクラス取得とpタグの取得
+        //         let likeClass = element.querySelector('.like_user');
+        //         let users = likeClass.querySelector('#like_count');
+
+        //         //いいねボタンクリックによる非同期処理
+        //         button.addEventListener('click', async function() {
+        //             const characterId = button.getAttribute('data-character-id');
+        //             const postId = button.getAttribute('data-post-id');
+        //             try {
+        //                 const response = await fetch(`/character_posts/${characterId}/posts/${postId}/like`, {
+        //                     method: 'POST',
+        //                     headers: {
+        //                         'Content-Type': 'application/json',
+        //                         'X-CSRF-TOKEN': '{{ csrf_token() }}'
+        //                     },
+        //                 });
+        //                 const data = await response.json();
+        //                 if (data.status === 'liked') {
+        //                     button.innerText = 'いいね取り消し';
+        //                     users.innerText = data.like_user;
+        //                 } else if (data.status === 'unliked') {
+        //                     button.innerText = 'いいね';
+        //                     users.innerText = data.like_user;
+        //                 }
+        //             } catch (error) {
+        //                 console.error('Error:', error);
+        //             }
+        //         });
+        //     });
+        // });
+    </script>
+</body>
+
+</html>

--- a/resources/views/pilgrimages/show.blade.php
+++ b/resources/views/pilgrimages/show.blade.php
@@ -30,7 +30,7 @@
         </div>
     </div>
     <div class="post_link">
-        <a href="{{ route('character_posts.index', ['character_id' => $pilgrimage->id]) }}">聖地投稿一覧</a>
+        <a href="{{ route('pilgrimage_posts.index', ['pilgrimage_id' => $pilgrimage->id]) }}">聖地投稿一覧</a>
     </div>
     <div class="footer">
         <a href="/works">作品一覧へ</a>

--- a/resources/views/works/show.blade.php
+++ b/resources/views/works/show.blade.php
@@ -30,9 +30,9 @@
                 @else
                 @foreach ($work->music as $music)
                 <div class='music_name'>
-                <a href="{{ route('music.show', ['music_id' => $music->id]) }}">
-                    {{ $music->name }}
-                </a>
+                    <a href="{{ route('music.show', ['music_id' => $music->id]) }}">
+                        {{ $music->name }}
+                    </a>
                 </div>
                 @endforeach
                 @endif
@@ -58,7 +58,9 @@
                 @else
                 @foreach ($work->animePilgrimages as $anime_pilgrimage)
                 <div class='anime_pilgrimage_name'>
-                    <h3>{{ $anime_pilgrimage->name }}</h3>
+                    <a href="{{ route('pilgrimages.show', ['pilgrimage_id' => $anime_pilgrimage->id]) }}">
+                        {{ $anime_pilgrimage->name }}
+                    </a>
                 </div>
                 @endforeach
                 @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,7 +17,7 @@ use App\Http\Controllers\SingerController;
 use App\Http\Controllers\LyricWriterController;
 use App\Http\Controllers\ComposerController;
 use App\Http\Controllers\AnimePilgrimageController;
-use App\Models\AnimePilgrimage;
+use App\Http\Controllers\AnimePilgrimagePostController;
 
 /*
 |--------------------------------------------------------------------------
@@ -178,10 +178,30 @@ Route::controller(ComposerController::class)->middleware(['auth'])->group(functi
 
 // AnimePilgrimageControllerに関するルーティング
 Route::controller(AnimePilgrimageController::class)->middleware(['auth'])->group(function () {
-    // 登場人物一覧の表示
+    // 聖地一覧の表示
     Route::get('/pilgrimages', 'index')->name('pilgrimages.index');
-    // 登場人物の詳細表示
+    // 聖地の詳細表示
     Route::get('/pilgrimages/{pilgrimage_id}', 'show')->name('pilgrimages.show');
+});
+
+// AnimePilgrimagePostControllerに関するルーティング
+Route::controller(AnimePilgrimagePostController::class)->middleware(['auth'])->group(function () {
+    // 聖地ごとの感想投稿一覧の表示
+    Route::get('/pilgrimage_posts/{pilgrimage_id}', 'index')->name('pilgrimage_posts.index');
+    // 新規投稿作成ボタン押下で、createメソッドを実行
+    Route::get('/music_posts/{music_id}/create', 'create')->name('music_posts.create');
+    // 作成するボタン押下で、storeメソッドを実行
+    Route::post('/music_posts/{music_id}/store', 'store')->name('music_posts.store');
+    // 各聖地の感想投稿一覧ボタン押下で、showメソッドを実行
+    Route::get('/pilgrimage_posts/{pilgrimage_id}/posts/{pilgrimage_post_id}', 'show')->name('pilgrimage_posts.show');
+    // 感想投稿編集画面を表示するeditメソッドを実行
+    Route::get('/music_posts/{music_id}/posts/{music_post_id}/edit', 'edit')->name('music_posts.edit');
+    // 感想投稿の編集を実行するupdateメソッドを実行
+    Route::put('/music_posts/{music_id}/update/{music_post_id}', 'update')->name('music_posts.update');
+    // 感想投稿の削除を行うdeleteメソッドを実行
+    Route::delete('/music_posts/{music_id}/posts/{music_post_id}/delete', 'delete')->name('music_posts.delete');
+    // 感想投稿のいいねボタン押下で、いいねを追加するlikeメソッドを実行
+    Route::post('/music_posts/{music_id}/posts/{music_post_id}/like', 'like')->name('music_posts.like');
 });
 
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
### 聖地感想投稿一覧と詳細の作成

- #37 

**聖地詳細**
・聖地感想投稿一覧へのリンク

**聖地感想投稿一覧**
・一覧の表示とタイトル・本文のキーワード検索が可能

**聖地感想投稿詳細**
・詳細の表示
・投稿者、聖地モデルとのリレーション追加

・聖地感想投稿一覧
![スクリーンショット 2024-11-07 085509](https://github.com/user-attachments/assets/6e27c9b3-4fdf-4585-8a63-039dc0205e8a)

・聖地感想投稿詳細
![スクリーンショット 2024-11-07 085521](https://github.com/user-attachments/assets/a639121f-ee5a-4308-bda4-bf7515646619)
