### PR TITLE
Feat：聖地感想投稿にCUD機能の追加

### DIFF
--- a/app/Http/Controllers/AnimePilgrimagePostController.php
+++ b/app/Http/Controllers/AnimePilgrimagePostController.php
@@ -65,4 +65,30 @@ class AnimePilgrimagePostController extends Controller
         $pilgrimagePost->fill($input_post)->save();
         return redirect()->route('pilgrimage_posts.show', ['pilgrimage_id' => $pilgrimagePost->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimagePost->id]);
     }
+
+    // 感想投稿編集画面を表示する
+    public function edit(AnimePilgrimagePost $pilgrimagePost, $pilgrimage_id, $pilgrimage_post_id)
+    {
+        return view('anime_pilgrimage_posts.edit')->with(['pilgrimage_post' => $pilgrimagePost->getDetailPost($pilgrimage_id, $pilgrimage_post_id)]);
+    }
+
+    // 感想投稿の編集を実行する
+    public function update(PilgrimagePostRequest $request, AnimePilgrimagePost $pilgrimagePost, $pilgrimage_id, $pilgrimage_post_id)
+    {
+        $input_post = $request['pilgrimage_post'];
+        //cloudinaryへ画像を送信し、画像のURLを$image_urlに代入
+        //画像ファイルが送られた時だけ処理が実行される
+        if ($request->file('images')) {
+            $counter = 1;
+            foreach ($request->file('images') as $image) {
+                $image_url = Cloudinary::upload($image->getRealPath())->getSecurePath();
+                $input_post["image$counter"] = $image_url;
+                $counter++;
+            }
+        }
+        // 編集の対象となるデータを取得
+        $targetPilgrimagePost = $pilgrimagePost->getDetailPost($pilgrimage_id, $pilgrimage_post_id);
+        $targetPilgrimagePost->fill($input_post)->save();
+        return redirect()->route('pilgrimage_posts.show', ['pilgrimage_id' => $targetPilgrimagePost->anime_pilgrimage_id, 'pilgrimage_post_id' => $targetPilgrimagePost->id]);
+    }
 }

--- a/app/Http/Controllers/AnimePilgrimagePostController.php
+++ b/app/Http/Controllers/AnimePilgrimagePostController.php
@@ -2,8 +2,11 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
+use App\Http\Requests\PilgrimagePostRequest;
 use App\Models\AnimePilgrimagePost;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Auth;
+use CloudinaryLabs\CloudinaryLaravel\Facades\Cloudinary;
 
 class AnimePilgrimagePostController extends Controller
 {
@@ -35,5 +38,31 @@ class AnimePilgrimagePostController extends Controller
     public function show(AnimePilgrimagePost $pilgrimagePost, $pilgrimage_id, $pilgrimage_post_id)
     {
         return view('anime_pilgrimage_posts.show')->with(['pilgrimage_post' => $pilgrimagePost->getDetailPost($pilgrimage_id, $pilgrimage_post_id)]);
+    }
+
+    // 新規投稿作成画面を表示する
+    public function create(AnimePilgrimagePost $pilgrimagePost, $pilgrimage_id)
+    {
+        return view('anime_pilgrimage_posts.create')->with(['pilgrimage_post' => $pilgrimagePost->getRestrictedPost('anime_pilgrimage_id', $pilgrimage_id)]);
+    }
+
+    // 新しく記述した内容を保存する
+    public function store(AnimePilgrimagePost $pilgrimagePost, PilgrimagePostRequest $request)
+    {
+        $input_post = $request['pilgrimage_post'];
+        //cloudinaryへ画像を送信し、画像のURLを$image_urlに代入
+        //画像ファイルが送られた時だけ処理が実行される
+        if ($request->file('images')) {
+            $counter = 1;
+            foreach ($request->file('images') as $image) {
+                $image_url = Cloudinary::upload($image->getRealPath())->getSecurePath();
+                $input_post += ["image$counter" => $image_url];
+                $counter++;
+            }
+        }
+        // ログインしているユーザーidの登録
+        $input_post['user_id'] = Auth::id();
+        $pilgrimagePost->fill($input_post)->save();
+        return redirect()->route('pilgrimage_posts.show', ['pilgrimage_id' => $pilgrimagePost->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimagePost->id]);
     }
 }

--- a/app/Http/Controllers/AnimePilgrimagePostController.php
+++ b/app/Http/Controllers/AnimePilgrimagePostController.php
@@ -10,6 +10,8 @@ use CloudinaryLabs\CloudinaryLaravel\Facades\Cloudinary;
 
 class AnimePilgrimagePostController extends Controller
 {
+    use SoftDeletes;
+
     // 聖地感想投稿一覧の表示
     public function index($pilgrimage_id)
     {
@@ -90,5 +92,14 @@ class AnimePilgrimagePostController extends Controller
         $targetPilgrimagePost = $pilgrimagePost->getDetailPost($pilgrimage_id, $pilgrimage_post_id);
         $targetPilgrimagePost->fill($input_post)->save();
         return redirect()->route('pilgrimage_posts.show', ['pilgrimage_id' => $targetPilgrimagePost->anime_pilgrimage_id, 'pilgrimage_post_id' => $targetPilgrimagePost->id]);
+    }
+
+    // 感想投稿を削除する
+    public function delete(AnimePilgrimagePost $pilgrimagePost, $pilgrimage_id, $pilgrimage_post_id)
+    {
+        // 編集の対象となるデータを取得
+        $targetPilgrimagePost = $pilgrimagePost->getDetailPost($pilgrimage_id, $pilgrimage_post_id);
+        $targetPilgrimagePost->delete();
+        return redirect()->route('pilgrimage_posts.index', ['pilgrimage_id' => $pilgrimage_id]);
     }
 }

--- a/app/Http/Requests/PilgrimagePostRequest.php
+++ b/app/Http/Requests/PilgrimagePostRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PilgrimagePostRequest extends FormRequest
+{
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'pilgrimage_post.title' => 'required|string|max:100',
+            'pilgrimage_post.scene' => 'required|string|max:200',
+            'pilgrimage_post.body' => 'required|string|max:4000',
+            'images' => 'array|max:4'
+        ];
+    }
+}

--- a/app/Models/AnimePilgrimagePost.php
+++ b/app/Models/AnimePilgrimagePost.php
@@ -9,6 +9,19 @@ class AnimePilgrimagePost extends Model
 {
     use HasFactory;
 
+    // fillを実行するための記述
+    protected $fillable = [
+        'user_id',
+        'anime_pilgrimage_id',
+        'title',
+        'scene',
+        'body',
+        'image1',
+        'image2',
+        'image3',
+        'image4',
+    ];
+
     // 参照させたいanime_pilgrimage_postsを指定
     protected $table = 'anime_pilgrimage_posts';
 
@@ -19,6 +32,12 @@ class AnimePilgrimagePost extends Model
             ['anime_pilgrimage_id', $pilgrimage_id],
             ['id', $pilgrimage_post_id],
         ])->first();
+    }
+
+    // 条件とその値を指定してデータを1件取得する
+    public function getRestrictedPost($condition, $column_name)
+    {
+        return $this->where($condition, $column_name)->first();
     }
 
     // AnimePilgrimageに対するリレーション 1対1の関係

--- a/lang/ja/validation.php
+++ b/lang/ja/validation.php
@@ -204,6 +204,10 @@ return [
         'music_post.post_title' => 'タイトル',
         'music_post.body' => '内容',
         'music_post.star_num' => '評価数',
+        // 聖地の感想投稿のバリデーション
+        'pilgrimage_post.title' => 'タイトル',
+        'pilgrimage_post.scene' => 'シーン',
+        'pilgrimage_post.body' => '内容',
     ],
 
 ];

--- a/resources/views/anime_pilgrimage_posts/create.blade.php
+++ b/resources/views/anime_pilgrimage_posts/create.blade.php
@@ -1,0 +1,80 @@
+<!DOCTYPE HTML>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+<head>
+    <meta charset="utf-8">
+    <title>聖地の感想投稿</title>
+</head>
+
+<body>
+    <h1>「{{$pilgrimage_post->animePilgrimage->name}}」への新規感想投稿</h1>
+    <form action="{{ route('pilgrimage_posts.store', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id]) }}" method="POST" enctype="multipart/form-data">
+        @csrf
+        <div class="anime_pilgrimage_id">
+            <input type="hidden" name="pilgrimage_post[anime_pilgrimage_id]" value="{{ $pilgrimage_post->anime_pilgrimage_id }}">
+        </div>
+        <div class="title">
+            <h2>タイトル</h2>
+            <input type="text" name="pilgrimage_post[title]" placeholder="タイトル" value="{{ old('pilgrimage_post.title') }}" />
+            <p class="title__error" style="color:red">{{ $errors->first('pilgrimage_post.title') }}</p>
+        </div>
+        <div class="scene">
+            <h2>シーン</h2>
+            <input type="text" name="pilgrimage_post[scene]" placeholder="シーン" value="{{ old('pilgrimage_post.scene') }}" />
+            <p class="title__error" style="color:red">{{ $errors->first('pilgrimage_post.scene') }}</p>
+        </div>
+        <div class="body">
+            <h2>内容</h2>
+            <textarea name="pilgrimage_post[body]" placeholder="内容を記入してください。">{{ old('pilgrimage_post.body') }}</textarea>
+            <p class="body__error" style="color:red">{{ $errors->first('pilgrimage_post.body') }}</p>
+        </div>
+        <div class="image">
+            <h2>画像（4枚まで）</h2>
+            <input id="inputElm" type="file" name="images[]" multiple onchange="loadImage(this);">
+            <p class="image__error" style="color:red">{{ $errors->first('images') }}</p>
+        </div>
+        <!-- プレビュー画像の表示 -->
+        <div id="preview" style="width: 300px;"></div>
+        <button type="submit">投稿する</button>
+    </form>
+    <div class="footer">
+        <a href="{{ route('pilgrimage_posts.index', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id]) }}">戻る</a>
+    </div>
+</body>
+<script>
+    let key = 0;
+
+    function loadImage(obj) {
+        // 以前に選択したファイルは保持されないため削除
+        document.querySelectorAll('figure').forEach(function(figure) {
+            figure.remove();
+            key = 0;
+        });
+        // 選択されたファイルの枚数分だけ画像を追加
+        for (i = 0; i < obj.files.length; i++) {
+            var fileReader = new FileReader();
+            fileReader.onload = (function(e) {
+                var field = document.getElementById("preview");
+                var figure = document.createElement("figure");
+                var rmBtn = document.createElement("input");
+                var img = new Image();
+                img.src = e.target.result;
+                rmBtn.type = "button";
+                rmBtn.name = key;
+                rmBtn.value = "削除";
+                // 削除ボタン押下で画像プレビューの削除
+                rmBtn.onclick = (function() {
+                    var element = document.getElementById("img-" + String(rmBtn.name)).remove();
+                });
+                figure.setAttribute("id", "img-" + key);
+                figure.appendChild(img);
+                figure.appendChild(rmBtn)
+                field.appendChild(figure);
+                key++;
+            });
+            fileReader.readAsDataURL(obj.files[i]);
+        }
+    }
+</script>
+
+</html>

--- a/resources/views/anime_pilgrimage_posts/edit.blade.php
+++ b/resources/views/anime_pilgrimage_posts/edit.blade.php
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+<head>
+    <meta charset="utf-8">
+    <title>Blog</title>
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+</head>
+
+<body>
+    <h1 class="title">{{ $pilgrimage_post->animePilgrimage->name }}への投稿編集画面</h1>
+    <div class="content">
+        <form action="{{ route('pilgrimage_posts.update', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimage_post->id]) }}" method="POST" enctype="multipart/form-data">
+            @csrf
+            @method('PUT')
+            <div class="user_id">
+                <input type="hidden" name="pilgrimage_post[user_id]" value="{{ $pilgrimage_post->user_id }}">
+            </div>
+            <div class="anime_pilgrimage_id">
+                <input type="hidden" name="pilgrimage_post[anime_pilgrimage_id]" value="{{ $pilgrimage_post->anime_pilgrimage_id }}">
+            </div>
+            <div class="title">
+                <h2>タイトル</h2>
+                <input type="text" name="pilgrimage_post[title]" placeholder="タイトル" value="{{ $pilgrimage_post->title }}" />
+                <p class="title__error" style="color:red">{{ $errors->first('pilgrimage_post.title') }}</p>
+            </div>
+            <div class="scene">
+                <h2>シーン</h2>
+                <input type="text" name="pilgrimage_post[scene]" placeholder="シーン" value="{{ $pilgrimage_post->scene }}" />
+                <p class="title__error" style="color:red">{{ $errors->first('character_post.post_title') }}</p>
+            </div>
+            <div class="body">
+                <h2>内容</h2>
+                <textarea name="pilgrimage_post[body]" placeholder="内容を記入してください。">{{ $pilgrimage_post->body }}</textarea>
+                <p class="body__error" style="color:red">{{ $errors->first('pilgrimage_post.body') }}</p>
+            </div>
+            <div class="image">
+                <h2>画像（4枚まで）</h2>
+                <input id="inputElm" type="file" name="images[]" multiple onchange="loadImage(this);">
+                <p class="image__error" style="color:red">{{ $errors->first('images') }}</p>
+            </div>
+            <!-- プレビュー画像の表示 -->
+            <div id="preview" style="width: 300px;"></div>
+            <button type="submit">変更を保存する</button>
+        </form>
+    </div>
+    <div class="footer">
+        <a href="{{ route('pilgrimage_posts.show', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimage_post->id]) }}">保存しないで戻る</a>
+    </div>
+</body>
+<script>
+    let key = 0;
+
+    function loadImage(obj) {
+        // 以前に選択したファイルは保持されないため削除
+        document.querySelectorAll('figure').forEach(function(figure) {
+            figure.remove();
+            key = 0;
+        });
+        // 選択されたファイルの枚数分だけ画像を追加
+        for (i = 0; i < obj.files.length; i++) {
+            var fileReader = new FileReader();
+            fileReader.onload = (function(e) {
+                var field = document.getElementById("preview");
+                var figure = document.createElement("figure");
+                var rmBtn = document.createElement("input");
+                var img = new Image();
+                img.src = e.target.result;
+                rmBtn.type = "button";
+                rmBtn.name = key;
+                rmBtn.value = "削除";
+                rmBtn.onclick = (function() {
+                    var element = document.getElementById("img-" + String(rmBtn.name)).remove();
+                });
+                figure.setAttribute("id", "img-" + key);
+                figure.appendChild(img);
+                figure.appendChild(rmBtn)
+                field.appendChild(figure);
+                key++;
+            });
+            fileReader.readAsDataURL(obj.files[i]);
+        }
+    }
+</script>
+
+</html>

--- a/resources/views/anime_pilgrimage_posts/edit.blade.php
+++ b/resources/views/anime_pilgrimage_posts/edit.blade.php
@@ -28,7 +28,7 @@
             <div class="scene">
                 <h2>シーン</h2>
                 <input type="text" name="pilgrimage_post[scene]" placeholder="シーン" value="{{ $pilgrimage_post->scene }}" />
-                <p class="title__error" style="color:red">{{ $errors->first('character_post.post_title') }}</p>
+                <p class="title__error" style="color:red">{{ $errors->first('pilgrimage_post.scene') }}</p>
             </div>
             <div class="body">
                 <h2>内容</h2>

--- a/resources/views/anime_pilgrimage_posts/index.blade.php
+++ b/resources/views/anime_pilgrimage_posts/index.blade.php
@@ -10,7 +10,7 @@
 
 <body>
     <h1>「{{ $pilgrimage_first->animePilgrimage->name }}」の感想投稿一覧</h1>
-    <a href="{{ route('character_posts.create', ['character_id' => $pilgrimage_first->anime_pilgrimage_id]) }}">新規投稿作成</a>
+    <a href="{{ route('pilgrimage_posts.create', ['pilgrimage_id' => $pilgrimage_first->anime_pilgrimage_id]) }}">新規投稿作成</a>
     <!-- 検索機能 -->
     <div class=serch>
         <form action="{{ route('pilgrimage_posts.index', ['pilgrimage_id' => $pilgrimage_first->anime_pilgrimage_id]) }}" method="GET">

--- a/resources/views/anime_pilgrimage_posts/index.blade.php
+++ b/resources/views/anime_pilgrimage_posts/index.blade.php
@@ -46,7 +46,7 @@
                     <img src="{{ $pilgrimage_post->image1 }}" alt="画像が読み込めません。">
                 </div>
                 @endif
-                <form action="{{ route('character_posts.delete', ['character_id' => $pilgrimage_post->anime_pilgrimage_id, 'character_post_id' => $pilgrimage_post->id]) }}" id="form_{{ $pilgrimage_post->id }}" method="post">
+                <form action="{{ route('pilgrimage_posts.delete', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimage_post->id]) }}" id="form_{{ $pilgrimage_post->id }}" method="post">
                     @csrf
                     @method('DELETE')
                     <button type="button" data-post-id="{{ $pilgrimage_post->id }}" class="delete-button">投稿を削除する</button>
@@ -64,25 +64,25 @@
     </div>
 
     <script>
-        // // DOMツリー読み取り完了後にイベント発火
-        // document.addEventListener('DOMContentLoaded', function() {
-        //     // delete-buttonに一致するすべてのHTML要素を取得
-        //     document.querySelectorAll('.delete-button').forEach(function(button) {
-        //         button.addEventListener('click', function() {
-        //             const postId = button.getAttribute('data-post-id');
-        //             deletePost(postId);
-        //         });
-        //     });
-        // });
+        // DOMツリー読み取り完了後にイベント発火
+        document.addEventListener('DOMContentLoaded', function() {
+            // delete-buttonに一致するすべてのHTML要素を取得
+            document.querySelectorAll('.delete-button').forEach(function(button) {
+                button.addEventListener('click', function() {
+                    const postId = button.getAttribute('data-post-id');
+                    deletePost(postId);
+                });
+            });
+        });
 
-        // // 削除処理を行う
-        // function deletePost(postId) {
-        //     'use strict'
+        // 削除処理を行う
+        function deletePost(postId) {
+            'use strict'
 
-        //     if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
-        //         document.getElementById(`form_${postId}`).submit();
-        //     }
-        // }
+            if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
+                document.getElementById(`form_${postId}`).submit();
+            }
+        }
 
         // // いいね処理を非同期で行う
         // document.addEventListener('DOMContentLoaded', function() {

--- a/resources/views/anime_pilgrimage_posts/show.blade.php
+++ b/resources/views/anime_pilgrimage_posts/show.blade.php
@@ -46,7 +46,7 @@
         </div>
     </div>
     <div class="edit">
-        <a href="{{ route('character_posts.edit', ['character_id' => $pilgrimage_post->anime_pilgrimage_id, 'character_post_id' => $pilgrimage_post->id]) }}">編集する</a>
+        <a href="{{ route('pilgrimage_posts.edit', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimage_post->id]) }}">編集する</a>
     </div>
     <form action="{{ route('character_posts.delete', ['character_id' => $pilgrimage_post->anime_pilgrimage_id, 'character_post_id' => $pilgrimage_post->id]) }}" id="form_{{ $pilgrimage_post->id }}" method="post">
         @csrf

--- a/resources/views/anime_pilgrimage_posts/show.blade.php
+++ b/resources/views/anime_pilgrimage_posts/show.blade.php
@@ -48,7 +48,7 @@
     <div class="edit">
         <a href="{{ route('pilgrimage_posts.edit', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimage_post->id]) }}">編集する</a>
     </div>
-    <form action="{{ route('character_posts.delete', ['character_id' => $pilgrimage_post->anime_pilgrimage_id, 'character_post_id' => $pilgrimage_post->id]) }}" id="form_{{ $pilgrimage_post->id }}" method="post">
+    <form action="{{ route('pilgrimage_posts.delete', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimage_post->id]) }}" id="form_{{ $pilgrimage_post->id }}" method="post">
         @csrf
         @method('DELETE')
         <button type="button" data-post-id="{{ $pilgrimage_post->id }}" class="delete-button">投稿を削除する</button>
@@ -58,25 +58,25 @@
     </div>
 
     <script>
-        // // DOMツリー読み取り完了後にイベント発火
-        // document.addEventListener('DOMContentLoaded', function() {
-        //     // delete-buttonに一致するすべてのHTML要素を取得
-        //     document.querySelectorAll('.delete-button').forEach(function(button) {
-        //         button.addEventListener('click', function() {
-        //             const postId = button.getAttribute('data-post-id');
-        //             deletePost(postId);
-        //         });
-        //     });
-        // });
+        // DOMツリー読み取り完了後にイベント発火
+        document.addEventListener('DOMContentLoaded', function() {
+            // delete-buttonに一致するすべてのHTML要素を取得
+            document.querySelectorAll('.delete-button').forEach(function(button) {
+                button.addEventListener('click', function() {
+                    const postId = button.getAttribute('data-post-id');
+                    deletePost(postId);
+                });
+            });
+        });
 
-        // // 削除処理を行う
-        // function deletePost(postId) {
-        //     'use strict'
+        // 削除処理を行う
+        function deletePost(postId) {
+            'use strict'
 
-        //     if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
-        //         document.getElementById(`form_${postId}`).submit();
-        //     }
-        // }
+            if (confirm('削除すると復元できません。\n本当に削除しますか？')) {
+                document.getElementById(`form_${postId}`).submit();
+            }
+        }
 
         // // いいね処理を非同期で行う
         // document.addEventListener('DOMContentLoaded', function() {

--- a/routes/web.php
+++ b/routes/web.php
@@ -189,17 +189,17 @@ Route::controller(AnimePilgrimagePostController::class)->middleware(['auth'])->g
     // 聖地ごとの感想投稿一覧の表示
     Route::get('/pilgrimage_posts/{pilgrimage_id}', 'index')->name('pilgrimage_posts.index');
     // 新規投稿作成ボタン押下で、createメソッドを実行
-    Route::get('/music_posts/{music_id}/create', 'create')->name('music_posts.create');
+    Route::get('/pilgrimage_posts/{pilgrimage_id}/create', 'create')->name('pilgrimage_posts.create');
     // 作成するボタン押下で、storeメソッドを実行
-    Route::post('/music_posts/{music_id}/store', 'store')->name('music_posts.store');
+    Route::post('/pilgrimage_posts/{pilgrimage_id}/store', 'store')->name('pilgrimage_posts.store');
     // 各聖地の感想投稿一覧ボタン押下で、showメソッドを実行
     Route::get('/pilgrimage_posts/{pilgrimage_id}/posts/{pilgrimage_post_id}', 'show')->name('pilgrimage_posts.show');
     // 感想投稿編集画面を表示するeditメソッドを実行
-    Route::get('/music_posts/{music_id}/posts/{music_post_id}/edit', 'edit')->name('music_posts.edit');
+    Route::get('/pilgrimage_posts/{pilgrimage_id}/posts/{pilgrimage_post_id}/edit', 'edit')->name('pilgrimage_posts.edit');
     // 感想投稿の編集を実行するupdateメソッドを実行
-    Route::put('/music_posts/{music_id}/update/{music_post_id}', 'update')->name('music_posts.update');
+    Route::put('/pilgrimage_posts/{pilgrimage_id}/update/{pilgrimage_post_id}', 'update')->name('pilgrimage_posts.update');
     // 感想投稿の削除を行うdeleteメソッドを実行
-    Route::delete('/music_posts/{music_id}/posts/{music_post_id}/delete', 'delete')->name('music_posts.delete');
+    Route::delete('/pilgrimage_posts/{pilgrimage_id}/posts/{pilgrimage_post_id}/delete', 'delete')->name('pilgrimage_posts.delete');
     // 感想投稿のいいねボタン押下で、いいねを追加するlikeメソッドを実行
     Route::post('/music_posts/{music_id}/posts/{music_post_id}/like', 'like')->name('music_posts.like');
 });


### PR DESCRIPTION
### 聖地感想投稿にCUD機能の追加

- #37

**聖地感想投稿一覧**
・新規投稿画面へのリンク
・削除機能

**聖地感想投稿詳細**
・投稿編集画面へのリンク
・削除機能

**新規投稿画面**
・新規投稿を可能にする
・画像のアップロード、プレビュー画面

**投稿編集画面**
・投稿の編集を可能にする
・画像の再アップロード、プレビュー画面

・新規投稿画面
![スクリーンショット 2024-11-07 102352](https://github.com/user-attachments/assets/1cd3c749-e91f-4b7b-994e-a24c0d96d506)

・投稿編集画面
![スクリーンショット 2024-11-07 102438](https://github.com/user-attachments/assets/7b2fc53c-c456-440b-9f1f-39cd80dd51b7)

・新規投稿画面（バリデーションエラー時）
![スクリーンショット 2024-11-07 102418](https://github.com/user-attachments/assets/dfbb239f-36c6-40a4-bf89-89460e3d5ba2)

・投稿編集画面（バリデーションエラー時）
![スクリーンショット 2024-11-07 102914](https://github.com/user-attachments/assets/c25579f2-5b02-40d6-b008-bd7d6967a324)
