### PR TITLE
Feat：あらすじ一覧と詳細の作成

### DIFF
--- a/app/Http/Controllers/WorkStoryController.php
+++ b/app/Http/Controllers/WorkStoryController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\WorkStory;
+
+class WorkStoryController extends Controller
+{
+    // あらすじ一覧画面の表示
+    public function index($work_id)
+    {
+        $work_stories = WorkStory::where('work_id', '=', $work_id)->orderBy('id', 'ASC')->where(function($query) {
+            
+            // キーワード検索がなされた場合
+            if ($search = request('search')) {
+                // 検索語のスペースを半角に統一
+                $search_split = mb_convert_kana($search, 's');
+                // 半角スペースで単語ごとに分割して配列にする
+                $search_array = preg_split('/[\s]+/', $search_split);
+                foreach ($search_array as $search_word) {
+                    $query->where(function ($query) use ($search_word) {
+                        $query->where('episode', 'LIKE', "%{$search_word}%")
+                        ->orWhere('sub_title', 'LIKE', "%{$search_word}%")
+                        ->orWhere('body', 'LIKE', "%{$search_word}%");
+                    });
+                }
+            }
+        })->paginate(20);
+        // あらすじのモデルを1つ取得
+        $work_story_model = WorkStory::where('work_id', '=', $work_id)->first();
+        return view('work_stories.index')->with(['work_stories' => $work_stories, 'work_story_model' => $work_story_model]);
+    }
+
+    // 詳細なあらすじ情報を表示する
+    public function show($work_id, $work_story_id)
+    {
+        $work_story = WorkStory::find($work_story_id);
+        return view('work_stories.show')->with(['work_story' => $work_story]);
+    }
+}

--- a/app/Models/Work.php
+++ b/app/Models/Work.php
@@ -42,6 +42,12 @@ class Work extends Model
         return $this->hasMany(Music::class, 'work_id', 'id');
     }
 
+    // WorkStoryに対するリレーション 1対多の関係
+    public function workStories()
+    {
+        return $this->hasMany(WorkStory::class, 'work_id', 'id');
+    }
+
     // created_atで降順に並べたあと、limitで件数制限をかける
     public function getPaginateByLimit(int $limit_count = 5)
     {

--- a/app/Models/WorkStory.php
+++ b/app/Models/WorkStory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class WorkStory extends Model
+{
+    use HasFactory;
+
+    // 参照させたいwork_storiesを指定
+    protected $table = 'work_stories';
+
+    // Workに対するリレーション 1対多の関係
+    public function work()
+    {
+        return $this->belongsTo(Work::class, 'work_id', 'id');
+    }
+}

--- a/database/migrations/2024_09_21_174923_create_work_stories_table.php
+++ b/database/migrations/2024_09_21_174923_create_work_stories_table.php
@@ -11,15 +11,13 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('works', function (Blueprint $table) {
+        Schema::create('work_stories', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('creator_id')->constrained('creators')->onDelete('cascade');
-            $table->string('name');
-            $table->string('image');
-            $table->string('term');
-            $table->string('official_site_link');
-            $table->string('wiki_link');
-            $table->string('twitter_link');
+            $table->foreignId('work_id')->constrained('works')->onDelete('cascade');
+            $table->string('episode', 10);
+            $table->string('sub_title', 200);
+            $table->string('body', 500)->nullable();
+            $table->string('official_link')->nullable();
             $table->timestamps();
             $table->softDeletes();
         });
@@ -31,6 +29,5 @@ return new class extends Migration
     public function down(): void
     {
         Schema::dropIfExists('work_stories');
-        Schema::dropIfExists('works');
     }
 };

--- a/database/migrations/2024_09_21_174924_create_work_story_reviews_table.php
+++ b/database/migrations/2024_09_21_174924_create_work_story_reviews_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->id();
             $table->foreignId('work_id')->constrained('works')->onDelete('cascade');
             $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
-            $table->string('sub_title');
+            $table->foreignId('sub_title_id')->constrained('work_stories')->onDelete('cascade');
             $table->string('post_title');
             $table->string('body');
             $table->string('image1')->nullable();

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -31,6 +31,7 @@ class DatabaseSeeder extends Seeder
             USER_Work_Review_Seeder::class,
             Work_Categories_Seeder::class,
             Work_Category_Seeder::class,
+            Work_StorySeeder::class,
             Work_Story_Review_Seeder::class,
             Work_Story_Review_Like_Seeder::class,
             Character_Categories_Seeder::class,

--- a/database/seeders/Work_StorySeeder.php
+++ b/database/seeders/Work_StorySeeder.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use DateTime;
+
+class Work_StorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        DB::table('work_stories')->insert([
+            'work_id' => 1,
+            'episode' => '第1話',
+            'sub_title' => '夢の中で逢った、ような……',
+            'body' => '大好きな家族がいて、親友がいて、時には笑い、時には泣く、
+そんな平和な日々を送る中学二年生、鹿目まどか。
+ある晩、まどかはとても不思議な夢を見る。
+
+その日も訪れるはずだった、変わらぬ日常――。
+しかし、訪れたのは非日常――。
+
+まどかの通うクラスにやってきた、一人の転校生・暁美ほむら。
+まどかが夢で見た少女と瓜二つの容姿をした少女。
+
+偶然の一致に戸惑うまどかに、ほむらは意味深な言葉を投げかけるのだった・・・。',
+            'official_link' => 'https://www.madoka-magica.com/tv/story/01.html',
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('work_stories')->insert([
+            'work_id' => 1,
+            'episode' => '第2話',
+            'sub_title' => 'それはとっても嬉しいなって',
+            'body' => 'ほむらに襲われたキュゥべえを助ける途中、
+迷い込んだのは摩訶不思議な空間。
+絶対絶命のピンチに陥ったまどかとさやかを救ったのは一人の魔法少女。
+巴マミ。
+
+その後二人が誘われたのは、魔法少女の部屋。
+
+語られしは、キュゥべえに選ばれし者に与えられる資格。
+魔法少女という存在、そして魔女という存在。
+
+どんな望みをも叶えるチャンスと、その先に待つ過酷な使命。
+悩む二人に、マミは「自分の魔女退治に付き合わないか」と提案をするのだった。',
+            'official_link' => 'https://www.madoka-magica.com/tv/story/02.html',
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('work_stories')->insert([
+            'work_id' => 1,
+            'episode' => '第3話',
+            'sub_title' => 'もう何も恐くない',
+            'body' => 'マミの魔女退治体験コースにも慣れつつある、まどかとさやか。
+ただし、肝心な願い事は未決のまま。
+
+悩むふたりに明かされた、マミの過去。
+
+「願いの内容が、自分のための事柄でなくてはならいのか？」と問うさやかに、
+マミは、厳しい口調で「他人の願いを叶えるのなら、なおのこと自分の望みをはっきりさせておかないと」と嗜めるのだった。
+
+翌日の放課後、
+恭介の見舞いに行ったとさやかと付き添いのまどかは、
+その帰り道、偶然にも病院の駐輪場で孵化しかけたグリーフシードを発見する。
+放置すれば、大惨事になりかねない事態に、さやかはキュゥべえと共に見張りを、まどかはマミを助けに呼びに走るのだった。',
+            'official_link' => 'https://www.madoka-magica.com/tv/story/03.html',
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('work_stories')->insert([
+            'work_id' => 1,
+            'episode' => '第4話',
+            'sub_title' => '奇跡も、魔法も、あるんだよ',
+            'body' => 'マミと魔女との壮絶な戦いの翌日、訪れたのはいつもと変わらない平和な日常。
+
+魔法少女の敗北の結果を目の当たりにしたまどかとさやかは、魔法の世界に関わったことの重さを実感し、魔法少女になることを諦める。
+
+その日の夕方、誰もいなくなったマミの部屋を訪れたまどかは、帰り道、マンションのエントランスでほむらと出会う。
+
+夕日の中、並んで歩く二人。
+
+魔法少女としての死ぬことの現実を語るほむらに、まどかは切ないほど優しい言葉をかけるのだった。',
+            'official_link' => 'https://www.madoka-magica.com/tv/story/04.html',
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('work_stories')->insert([
+            'work_id' => 1,
+            'episode' => '第5話',
+            'sub_title' => '後悔なんて、あるわけない',
+            'body' => '魔法少女として、魔女の手からまどかと仁美を救ったさやか。
+キュゥべえとの契約により願いを叶えた今、その心は清々しく、魔法少女となったことに後悔はない様子。
+反対にまどかはさやかよりも先に魔法少女になる決意をするも、諦めてしまった自分に悩む。
+
+恭介の両親、主治医、病院スタッフが集まり、病院の屋上で開かれたのは恭介の手の快復祝い。
+そこで、父の手から、かつて自分が愛用していたバイオリンを渡される。
+始めは躊躇するも、意を決してバイオリンを披露する恭介。
+まったく衰えていない天才の才能に、聴き惚れる一同。
+その光景を見たさやかは、至福の喜びをかみ締める。
+
+一方展望台には、そんな病院屋上でのさやかの動向をうかがう杏子の姿があった。',
+            'official_link' => 'https://www.madoka-magica.com/tv/story/05.html',
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('work_stories')->insert([
+            'work_id' => 1,
+            'episode' => '第6話',
+            'sub_title' => 'こんなの絶対おかしいよ',
+            'body' => 'さやかと杏子の戦闘現場に、突如現れたほむら。
+戦闘の仲裁に入った彼女はさやかを一撃で気絶させ、
+それを見た杏子はほむらを警戒し、その場を離脱したことにより、
+戦闘は終息する。
+
+翌日、杏子の乱入により取り逃してしまった使い魔の痕跡を探すさやかとまどか。
+戦闘の痕跡が残るその現場で、杏子との平和的な解決を提案するまどかと、
+命を賭けた魔法少女同士の闘いに覚悟を決めたさやか。
+二人の意見は擦れ違ってしまう
+
+そんな二人のやりとりの一方、
+ゲームセンターでは、とある目的のため、ほむらは杏子と接触するのだった。',
+            'official_link' => 'https://www.madoka-magica.com/tv/story/06.html',
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('work_stories')->insert([
+            'work_id' => 1,
+            'episode' => '第7話',
+            'sub_title' => '本当の気持ちと向き合えますか？',
+            'body' => '魔法少女となった自分の体の真実を知ったさやか。
+戦いの運命を受け入れてまで叶えた願いと、その代償の大きさの間で揺れてしまう。
+
+そんな自宅でふさぎこむさやかの元に現れたのは、敵対していたはずの佐倉杏子。
+彼女はさやかを外へと連れ出し、とある廃墟の教会へと誘う。
+
+そこで杏子の口から語られたのは、自身が魔法少女となった理由。
+果たして彼女の真意とは――',
+            'official_link' => 'https://www.madoka-magica.com/tv/story/07.html',
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('work_stories')->insert([
+            'work_id' => 1,
+            'episode' => '第8話',
+            'sub_title' => 'あたしって、ほんとバカ',
+            'body' => '自らの負傷も意に介さず、ただ目の前の魔女を切り刻むさやか。
+治癒魔法のおかげで最終的には無傷で魔女に勝利するも、もはや憔悴しきった様子。
+
+その帰り道、降り出した雨の雨宿りがてらの休憩中、憔悴しきったさやかの様子を見かねたまどかは、さやかの戦い方について、口を出してしまう。
+きれいごとばかりに感じるまどかのその言葉に、さやかはついに感情を爆発させ、その場を立ち去ってしまう。
+
+涙に暮れながら、それでも追いかけられないまどか――
+雨の中をはしりながら、自己嫌悪に悔し泣きをするさやか――
+
+彼女のソウルジェムは、黒く黒く濁っていくのであった。',
+            'official_link' => 'https://www.madoka-magica.com/tv/story/08.html',
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('work_stories')->insert([
+            'work_id' => 1,
+            'episode' => '第9話',
+            'sub_title' => 'そんなの、あたしが許さない',
+            'body' => '漆黒のグリーフシードと化したさやかのソウルジェム。
+そのグリーフシードは孵化し、新たな魔女が現れる。
+さやかの身体を抱え、迫りくる魔女の攻撃に防戦一方の杏子。
+魔女の結界に割って入ってきたほむらは、杏子を先導し結界から脱出する。
+
+一方まどかは、さやかの捜索途中、重い足取りで歩く杏子とほむらの姿を見つける。変わり果てた姿となったさやかの前で泣き崩れるまどかに、
+ほむらは冷淡な口調でソウルジェムの最後の秘密を語り、その場を立ち去る。
+
+その日の深夜、杏子の元に現れたのはキュゥべえ。
+キュゥべえとさやかの身体を元に戻すことについて話す杏子は、その会話の中で一縷の可能性を見出す。
+翌朝、杏子は仁美と登校途中のまどかをテレパシーで呼び出し、驚きの提案をするのだった。',
+            'official_link' => 'https://www.madoka-magica.com/tv/story/09.html',
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('work_stories')->insert([
+            'work_id' => 1,
+            'episode' => '第10話',
+            'sub_title' => 'もう誰にも頼らない',
+            'body' => 'それはとある少女の転校風景。
+必要以上に緊張し、萎縮する気弱そうな少女は、
+クラスの全生徒の視線を一身に浴びながら、慣れない自己紹介をする。
+
+休み時間、押しかけて興味津々に質問をしてくる女子たちに、
+気圧されておどおどしている彼女を、その場から連れだしてくれたのは、クラスの保健委員を名乗る少女。
+優しい笑顔を向ける彼女は、自分を名前負けだと感じる少女に対し、カッコいい名前だと言う。
+
+長らくの入院生活により、学力も体力も他の生徒に劣る彼女は、
+劣等感に肩を落として帰宅する途中、ふとしたことで魔女の結界に迷いこんでしまう。
+彼女の絶対絶命のピンチに現れたのは、二人の魔法少女だった。',
+            'official_link' => 'https://www.madoka-magica.com/tv/story/10.html',
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('work_stories')->insert([
+            'work_id' => 1,
+            'episode' => '第11話',
+            'sub_title' => '最後に残った道しるべ',
+            'body' => '雨の中、しめやかに行われたさやかの葬儀。
+うつろな目をして家に戻ったまどかは、玄関で出迎えた詢子への挨拶もそこらに自分の部屋に入ってしまう。
+一人悲しみに暮れるまどかの元に現れたのはキュゥべえ。
+さやか達の死について冷たい口調で語るその姿に、さすがのまどかも怒りを感じる。
+そんなまどかの態度が理解できないキュゥべえは、
+自分たちと人類がこれまで共に歩んできた歴史を語るのだった。',
+            'official_link' => 'https://www.madoka-magica.com/tv/story/11.html',
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('work_stories')->insert([
+            'work_id' => 1,
+            'episode' => '第12話',
+            'sub_title' => 'わたしの、最高の友達',
+            'body' => '一人ワルプルギスの夜に挑み、深手を負ったほむら。
+何度挑戦しても勝てないくやしさ、自分の行為がかえってまどかを苦しめることになっていたことへの絶望で、自らのソウルジェムを黒く染め上げていく。そんなほむらの前に現れた少女、鹿目まどか。まどかは、決意のまなざしでワルプルギスの夜を見据え、ほむらに言い放つ。
+
+「叶えたい願い事をみつけたの」
+
+魔法少女となる者の運命を全て知った彼女は、
+果たして何を願い、どんな決断を下すのか？',
+            'official_link' => 'https://www.madoka-magica.com/tv/story/12.html',
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+    }
+}

--- a/database/seeders/Work_Story_Review_Seeder.php
+++ b/database/seeders/Work_Story_Review_Seeder.php
@@ -17,7 +17,7 @@ class Work_Story_Review_Seeder extends Seeder
         DB::table('work_story_reviews')->insert([
             'work_id' => 1,
             'user_id' => 3,
-            'sub_title' => 'もう何も怖くない',
+            'sub_title_id' => 3,
             'post_title' => 'マミさぁぁぁん',
             'body' => 'いやーひどい脚本や。',
             'created_at' => new DateTime(),
@@ -26,7 +26,7 @@ class Work_Story_Review_Seeder extends Seeder
         DB::table('work_story_reviews')->insert([
             'work_id' => 1,
             'user_id' => 5,
-            'sub_title' => 'もう誰にも頼らない',
+            'sub_title_id' => 10,
             'post_title' => 'ついに謎が解けた！',
             'body' => 'すがすがしいほどの伏線回収、おつかれした',
             'created_at' => new DateTime(),
@@ -35,7 +35,7 @@ class Work_Story_Review_Seeder extends Seeder
         DB::table('work_story_reviews')->insert([
             'work_id' => 2,
             'user_id' => 3,
-            'sub_title' => 'ハジマリ',
+            'sub_title_id' => 4,
             'post_title' => '思ってたより平和な世界',
             'body' => 'ひぐらしってぐろいと聞いていたけど、そんなことないね',
             'created_at' => new DateTime(),
@@ -44,8 +44,8 @@ class Work_Story_Review_Seeder extends Seeder
         DB::table('work_story_reviews')->insert([
             'work_id' => 5,
             'user_id' => 6,
-            'sub_title' => 'Fate/Zero',
-            'post_title' => '虚無',
+            'sub_title_id' => 3,
+            'post_title' => '難しいね',
             'body' => '結局聖杯って何だったのでしょうか。',
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
@@ -53,7 +53,7 @@ class Work_Story_Review_Seeder extends Seeder
         DB::table('work_story_reviews')->insert([
             'work_id' => 3,
             'user_id' => 4,
-            'sub_title' => 'まきりんぱな',
+            'sub_title_id' => 6,
             'post_title' => '癒される',
             'body' => 'ついにまきりんぱなが仲間になってうれしい',
             'created_at' => new DateTime(),
@@ -62,7 +62,7 @@ class Work_Story_Review_Seeder extends Seeder
         DB::table('work_story_reviews')->insert([
             'work_id' => 4,
             'user_id' => 4,
-            'sub_title' => 'ラストライブ',
+            'sub_title_id' => 7,
             'post_title' => '結局OPが一番',
             'body' => 'ついに大舞台で僕らは今のなかでを披露か。',
             'created_at' => new DateTime(),

--- a/resources/views/work_stories/index.blade.php
+++ b/resources/views/work_stories/index.blade.php
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
+<head>
+    <meta charset="utf-8">
+    <title>あらすじ一覧</title>
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+</head>
+
+<body>
+    <h1>「{{ $work_story_model->work->name }}」のあらすじ一覧</h1>
+    <!-- 検索機能 -->
+    <div class=serch>
+        <form action="{{ route('work_stories.index', ['work_id' => $work_story_model->work_id]) }}" method="GET">
+            <input type="text" name="search" value="{{ request('search') }}" placeholder="キーワードを検索" aria-label="検索...">
+            <input type="submit" value="検索">
+        </form>
+        <div class="cancel">
+            <a href="{{ route('work_stories.index', ['work_id' => $work_story_model->work_id]) }}">キャンセル</a>
+        </div>
+    </div>
+    <div class='work_stories'>
+        @if($work_stories->isEmpty())
+        <h2 class='no_result'>結果がありません。</h2>
+        @else
+        @foreach ($work_stories as $work_story)
+        <div class='work_story'>
+            <h2 class='episode'>
+                    {{ $work_story->episode }}
+            </h2>
+            <p class='sub_title'>
+                <a href="{{ route('work_stories.show', ['work_id' => $work_story->work_id, 'work_story_id' => $work_story->id]) }}">
+                    {{ $work_story->sub_title }}
+                </a>
+            </p>
+        </div>
+        @endforeach
+        @endif
+    </div>
+    <div class='paginate'>
+        {{ $work_stories->appends(request()->query())->links() }}
+    </div>
+</body>
+
+</html>

--- a/resources/views/work_stories/show.blade.php
+++ b/resources/views/work_stories/show.blade.php
@@ -1,0 +1,37 @@
+<!DOCTYPE HTML>
+<html lang="ja">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>あらすじ詳細画面</title>
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Nunito:200,600" rel="stylesheet">
+</head>
+
+<body>
+    <h1 class="title">
+        {{ $work_story->sub_title }}
+    </h1>
+    <div class="content">
+        <div class="content__work_story">
+            <div class='episode'>
+                <h3>話数</h3>
+                <p>{{ $work_story->episode }}</p>
+            </div>
+            <div class='body'>
+                <h3>あらすじ(公式サイトより)</h3>
+                <a>{{ $work_story->body }}</a>
+            </div>
+            <div class='official_link'>
+                <h3>公式サイトへのリンク</h3>
+                <a>{{ $work_story->official_link }}</a>
+            </div>
+        </div>
+    </div>
+    <div class="post_link">
+        <a href="{{ route('music_posts.index', ['music_id' => $work_story->id]) }}">音楽感想一覧</a>
+    </div>
+</body>
+
+</html>

--- a/resources/views/works/show.blade.php
+++ b/resources/views/works/show.blade.php
@@ -74,6 +74,9 @@
             <a href="{{ route('work_reviews.index', ['work_id' => $work->id]) }}">作品感想一覧</a>
         </div>
     </div>
+    <div class="work_story_link">
+    <a href="{{ route('work_stories.index', ['work_id' => $work->id]) }}">あらすじ一覧</a>
+    </div>
     <div class="footer">
         <a href="/works">作品一覧へ</a>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ use App\Http\Controllers\ComposerController;
 use App\Http\Controllers\AnimePilgrimageController;
 use App\Http\Controllers\AnimePilgrimagePostController;
 use App\Http\Controllers\AnimePilgrimagePostLikeController;
+use App\Http\Controllers\WorkStoryController;
 
 /*
 |--------------------------------------------------------------------------
@@ -209,6 +210,14 @@ Route::controller(AnimePilgrimagePostController::class)->middleware(['auth'])->g
 Route::controller(AnimePilgrimagePostLikeController::class)->middleware(['auth'])->group(function () {
     // 作品一覧の表示
     Route::get('/pilgrimage_posts/{pilgrimage_id}/posts/{pilgrimage_post_id}/like/index', 'index')->name('pilgrimage_post_like.index');
+});
+
+// WorkStoryControllerに関するルーティング
+Route::controller(WorkStoryController::class)->middleware(['auth'])->group(function () {
+    // あらすじ一覧の表示
+    Route::get('/works/{work_id}/stories', 'index')->name('work_stories.index');
+    // あらすじの詳細表示
+    Route::get('/works/{work_id}/stories/{work_story_id}', 'show')->name('work_stories.show');
 });
 
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
### あらすじ一覧と詳細の作成

- #39

**あらすじ一覧**
・あらすじ一覧の表示（タイトル、内容、話数検索が可能）
・ペジネーションにおいて、20件ずつ表示するようにする

**あらすじ詳細**
・詳細の表示

・あらすじ用のwork_storiesテーブルの作成

・あらすじ一覧
![スクリーンショット 2024-11-08 145114](https://github.com/user-attachments/assets/879ae5f3-62f3-4ceb-b191-4cdcaba9ec35)

・あらすじ詳細
![スクリーンショット 2024-11-08 145126](https://github.com/user-attachments/assets/01ed29ad-753f-4fb0-bee0-af5592189f45)
