### PR TITLE
Feat：プレビュー表示と選択されたファイルの紐づけ

### DIFF
--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -81,20 +81,31 @@ class WorkReviewController extends Controller
     // 感想投稿の編集を実行する
     public function update(WorkReviewRequest $request, WorkReview $workreview, $work_id, $work_review_id)
     {
+        $input_review = $request['work_review'];
+        $input_categories = $request->work_review['categories_array'];
+
         // 保存する画像のPathの配列
         $image_paths = [];
         // 削除されていない既存画像がある場合のみ以下の処理を実行
+        if ($request['remainedImages'][0]) {
+            // JSON文字列をデコードしてPHP配列に変換
+            $remained_images = json_decode($request['remainedImages'][0], true);
+            // Pathの配列に削除されていない画像のPathを追加
+            foreach ($remained_images as $remained_image) {
+                array_push($image_paths, $remained_image['url']);
+            }
+        }
+        // 削除された既存画像がある場合のみ以下の処理を実行
         if ($request['removedImages'][0]) {
             // JSON文字列をデコードしてPHP配列に変換
             $removed_images = json_decode($request['removedImages'][0], true);
-            // Pathの配列に削除されていない画像のPathを追加
+            // 削除された画像のPathをCloudinaryから削除
             foreach ($removed_images as $removed_image) {
-                array_push($image_paths, $removed_image['url']);
+                // Cloudinaryに登録した画像のURLからpublic_idを取得する
+                $public_id = $this->extractPublicIdFromUrl($removed_image['url']);
+                Cloudinary::destroy($public_id);
             }
         }
-
-        $input_review = $request['work_review'];
-        $input_categories = $request->work_review['categories_array'];
         //cloudinaryへ画像を送信し、画像のURLを$image_urlに代入
         //画像ファイルが送られた時だけ処理が実行される
         if ($request->file('images')) {
@@ -103,15 +114,14 @@ class WorkReviewController extends Controller
                 array_push($image_paths, $image_path);
             }
         }
-        // 一旦、保存している画像のPathを全削除
         // $imagePathのうち、Pathのないものにはnullを代入
         $vacantElementNum = 4 - count($image_paths);
-        for($counter=0; $counter<$vacantElementNum; $counter++){
+        for ($counter = 0; $counter < $vacantElementNum; $counter++) {
             array_push($image_paths, NULL);
         }
         $counter = 1;
         // 今回保存するPathをDBのImageカラムに代入する
-        foreach($image_paths as $imagePath) {
+        foreach ($image_paths as $imagePath) {
             $input_review["image$counter"] = $imagePath;
             $counter++;
         }
@@ -157,5 +167,19 @@ class WorkReviewController extends Controller
             return response()->json(['status' => 'liked', 'like_user' => $count]);
         }
         return back();
+    }
+
+    // Cloudinaryにある画像のURLからpublic_Idを取得する
+    public function extractPublicIdFromUrl($url)
+    {
+        // URLの中からpublic_idを抽出するための正規表現
+        $pattern = '/upload\/(?:v\d+\/)?([^\.]+)\./';
+
+        if (preg_match($pattern, $url, $matches)) {
+            // 抽出されたpublic_id
+            return $matches[1];
+        }
+        // 該当しない場合はnull
+        return null;
     }
 }

--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -139,6 +139,17 @@ class WorkReviewController extends Controller
     {
         // 編集の対象となるデータを取得
         $targetworkreview = $workreview->getDetailPost($work_id, $work_review_id);
+        // 削除する投稿の画像も削除する処理
+        for ($counter = 1; $counter < 5; $counter++) {
+            $removed_image_path = $targetworkreview->{'image' . $counter};
+            // DBのimageの中身がnullであれば処理をスキップする
+            if(is_null($removed_image_path)) {
+                break;
+            }
+            $public_id = $this->extractPublicIdFromUrl($removed_image_path);
+            Cloudinary::destroy($public_id);
+        }
+        // データの削除
         $targetworkreview->delete();
         return redirect()->route('work_reviews.index', ['work_id' => $work_id]);
     }

--- a/resources/views/work_reviews/create.blade.php
+++ b/resources/views/work_reviews/create.blade.php
@@ -30,7 +30,10 @@
         </div>
         <div class="image">
             <h2>画像（4枚まで）</h2>
-            <input id="inputElm" type="file" name="images[]" multiple onchange="loadImage(this);">
+            <label>
+                <input id="inputElm" type="file" style="display:none" name="images[]" multiple onchange="loadImage(this);">画像の追加
+                <div id="count">現在、0枚の画像を選択しています。</div>
+            </label>
             <p class="image__error" style="color:red">{{ $errors->first('images') }}</p>
         </div>
         <!-- プレビュー画像の表示 -->
@@ -42,15 +45,15 @@
     </div>
     <script>
         // 元々選択されているファイルのリスト
-        let selectedFiles = [];
+        let selectedImages = [];
 
         function loadImage(obj) {
             // 新しく選択されたファイル
-            const newFiles = Array.from(obj.files);
+            const newImages = Array.from(obj.files);
 
             // 合計が4枚を超える場合のチェック
             // 元々選択されていたファイルと新しいファイルの合計を確認
-            if (selectedFiles.length + newFiles.length > 4) {
+            if (selectedImages.length + newImages.length > 4) {
                 alert('画像は4枚までアップロード可能です');
                 // プレビューを更新し、以前選択していたファイルを再表示する
                 // 新しく選択していた方のファイルは破棄
@@ -59,7 +62,7 @@
             }
 
             // 新しいファイルを選択済みリストに追加
-            selectedFiles.push(...newFiles);
+            selectedImages.push(...newImages);
 
             // プレビューの更新
             renderPreviews();
@@ -69,8 +72,10 @@
             // プレビューを取得後、クリア
             const preview = document.getElementById('preview');
             preview.innerHTML = '';
+            // 選択している画像の枚数を表示する
+            countImages(selectedImages);
 
-            selectedFiles.forEach((file, index) => {
+            selectedImages.forEach((image, index) => {
                 const fileReader = new FileReader();
 
                 fileReader.onload = function(e) {
@@ -96,7 +101,7 @@
                     preview.appendChild(figure);
                 };
 
-                fileReader.readAsDataURL(file);
+                fileReader.readAsDataURL(image);
             });
 
             // 選択しているファイルを反映
@@ -105,7 +110,7 @@
 
         function removeImage(index) {
             // 選択済みファイルリストから該当インデックスのファイルを削除
-            selectedFiles.splice(index, 1);
+            selectedImages.splice(index, 1);
 
             // プレビューを再描画
             renderPreviews();
@@ -113,11 +118,21 @@
 
         function updateInputElement() {
             const dataTransfer = new DataTransfer();
-            selectedFiles.forEach(file => dataTransfer.items.add(file));
+            selectedImages.forEach(image => dataTransfer.items.add(image));
 
             // 選択されたファイルを反映
             const inputElm = document.getElementById('inputElm');
             inputElm.files = dataTransfer.files;
+        }
+
+        // 選択している画像の枚数を表示する
+        function countImages() {
+            const count = document.getElementById('count');
+            count.innerHTML = '';
+            const countText = document.createElement('p');
+            const ImageCount = selectedImages.length;
+            countText.textContent = `現在、${ImageCount}枚の画像を選択しています。`;
+            count.appendChild(countText);
         }
     </script>
 

--- a/resources/views/work_reviews/create.blade.php
+++ b/resources/views/work_reviews/create.blade.php
@@ -41,38 +41,83 @@
         <a href="{{ route('work_reviews.index', ['work_id' => $workreview->work_id]) }}">戻る</a>
     </div>
     <script>
-        let key = 0;
+        // 元々選択されているファイルのリスト
+        let selectedFiles = [];
 
         function loadImage(obj) {
-            // 以前に選択したファイルは保持されないため削除
-            document.querySelectorAll('figure').forEach(function(figure) {
-                figure.remove();
-                key = 0;
-            });
-            // 選択されたファイルの枚数分だけ画像を追加
-            for (i = 0; i < obj.files.length; i++) {
-                var fileReader = new FileReader();
-                fileReader.onload = (function(e) {
-                    var field = document.getElementById("preview");
-                    var figure = document.createElement("figure");
-                    var rmBtn = document.createElement("input");
-                    var img = new Image();
-                    img.src = e.target.result;
-                    rmBtn.type = "button";
-                    rmBtn.name = key;
-                    rmBtn.value = "削除";
-                    // 削除ボタン押下で画像プレビューの削除
-                    rmBtn.onclick = (function() {
-                        var element = document.getElementById("img-" + String(rmBtn.name)).remove();
-                    });
-                    figure.setAttribute("id", "img-" + key);
-                    figure.appendChild(img);
-                    figure.appendChild(rmBtn)
-                    field.appendChild(figure);
-                    key++;
-                });
-                fileReader.readAsDataURL(obj.files[i]);
+            // 新しく選択されたファイル
+            const newFiles = Array.from(obj.files);
+
+            // 合計が4枚を超える場合のチェック
+            // 元々選択されていたファイルと新しいファイルの合計を確認
+            if (selectedFiles.length + newFiles.length > 4) {
+                alert('画像は4枚までアップロード可能です');
+                // プレビューを更新し、以前選択していたファイルを再表示する
+                // 新しく選択していた方のファイルは破棄
+                renderPreviews();
+                return;
             }
+
+            // 新しいファイルを選択済みリストに追加
+            selectedFiles.push(...newFiles);
+
+            // プレビューの更新
+            renderPreviews();
+        }
+
+        function renderPreviews() {
+            // プレビューを取得後、クリア
+            const preview = document.getElementById('preview');
+            preview.innerHTML = '';
+
+            selectedFiles.forEach((file, index) => {
+                const fileReader = new FileReader();
+
+                fileReader.onload = function(e) {
+                    const figure = document.createElement('figure');
+                    figure.setAttribute('id', `img-${index}`);
+                    figure.className = 'relative flex flex-col items-center mb-4';
+
+                    const img = document.createElement('img');
+                    img.src = e.target.result;
+                    img.alt = 'preview';
+                    img.className = 'w-36 h-36 object-cover rounded-md border border-gray-300 mb-2';
+
+                    const rmBtn = document.createElement('button');
+                    rmBtn.type = 'button';
+                    rmBtn.textContent = '削除';
+                    rmBtn.className = 'px-2 py-1 bg-red-500 text-white text-sm rounded hover:bg-red-600';
+                    rmBtn.onclick = function() {
+                        removeImage(index);
+                    };
+
+                    figure.appendChild(img);
+                    figure.appendChild(rmBtn);
+                    preview.appendChild(figure);
+                };
+
+                fileReader.readAsDataURL(file);
+            });
+
+            // 選択しているファイルを反映
+            updateInputElement();
+        }
+
+        function removeImage(index) {
+            // 選択済みファイルリストから該当インデックスのファイルを削除
+            selectedFiles.splice(index, 1);
+
+            // プレビューを再描画
+            renderPreviews();
+        }
+
+        function updateInputElement() {
+            const dataTransfer = new DataTransfer();
+            selectedFiles.forEach(file => dataTransfer.items.add(file));
+
+            // 選択されたファイルを反映
+            const inputElm = document.getElementById('inputElm');
+            inputElm.files = dataTransfer.files;
         }
     </script>
 

--- a/resources/views/work_reviews/edit.blade.php
+++ b/resources/views/work_reviews/edit.blade.php
@@ -60,6 +60,8 @@
                 </label>
                 <!-- 削除された既存画像のリスト -->
                 <input type="hidden" name="removedImages[]" id="removedImages" value="">
+                <!-- 削除されず残った既存画像のリスト -->
+                <input type="hidden" name="remainedImages[]" id="remainedImages" value="">
                 <p class="image__error" style="color:red">{{ $errors->first('images') }}</p>
             </div>
             <!-- プレビュー画像の表示 -->
@@ -76,7 +78,9 @@
         // 既存の画像URLを保持
         let existingImages = [];
         // 既存の画像のうち、削除されていない画像のURLを保持
-        let removedImages = []
+        let remainedImages = [];
+        // 既存の画像のうち、削除された画像のURLを保持
+        let removedImages = [];
 
         // 編集画面にて、以前画像が選択されていた場合、それらの画像を反映する
         // DOMツリー読み取り完了後にイベント発火
@@ -93,7 +97,7 @@
                 renderExistingImages();
             })
             // 削除されていない画像のURLをフォームに反映
-            document.getElementById('removedImages').value = JSON.stringify(existingImages);
+            document.getElementById('remainedImages').value = JSON.stringify(existingImages);
         });
 
         // 既存画像をプレビューとして表示
@@ -193,12 +197,14 @@
         // 既存画像リストから該当画像を削除
         function removeExistingImage(id) {
             const index = existingImages.findIndex(img => img.id === id);
+            removedImages.push(existingImages[index]);
             if (index !== -1) {
                 existingImages.splice(index, 1);
             }
             // 削除されていない画像のURLをフォームに反映
-            document.getElementById('removedImages').value = JSON.stringify(existingImages); 
-            console.log(document.getElementById('removedImages').value);
+            document.getElementById('remainedImages').value = JSON.stringify(existingImages); 
+            // 削除された画像のURLをフォームに反映
+            document.getElementById('removedImages').value = JSON.stringify(removedImages); 
             // プレビューを再描画
             renderPreviews();
         }

--- a/resources/views/work_reviews/edit.blade.php
+++ b/resources/views/work_reviews/edit.blade.php
@@ -42,7 +42,24 @@
             </div>
             <div class="image">
                 <h2>画像（4枚まで）</h2>
-                <input id="inputElm" type="file" name="images[]" multiple onchange="loadImage(this);">
+                @php
+                // 既にファイルが選択されている場合はそれらを表示する
+                $existingImages = [];
+                $numbers = array(1, 2, 3, 4);
+                foreach($numbers as $number){
+                $image = "image".$number;
+                if($work_review->$image){
+                array_push($existingImages, $work_review->$image);
+                }
+                }
+                $existingImages = json_encode($existingImages);
+                @endphp
+                <label>
+                    <input id="inputElm" type="file" style="display:none" name="images[]" multiple onchange="loadImage(this);">画像の追加
+                    <div id="count"></div>
+                </label>
+                <!-- 削除された既存画像のリスト -->
+                <input type="hidden" name="removedImages[]" id="removedImages" value="">
                 <p class="image__error" style="color:red">{{ $errors->first('images') }}</p>
             </div>
             <!-- プレビュー画像の表示 -->
@@ -54,37 +71,163 @@
         <a href="{{ route('work_reviews.show', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}">保存しないで戻る</a>
     </div>
     <script>
-        let key = 0;
+        // 元々選択されている画像のリスト
+        let selectedImages = [];
+        // 既存の画像URLを保持
+        let existingImages = [];
+        // 既存の画像のうち、削除されていない画像のURLを保持
+        let removedImages = []
+
+        // 編集画面にて、以前画像が選択されていた場合、それらの画像を反映する
+        // DOMツリー読み取り完了後にイベント発火
+        document.addEventListener('DOMContentLoaded', function() {
+            // 既存の画像を取得
+            const ImagePaths = JSON.parse('<?php echo $existingImages; ?>');
+            ImagePaths.forEach((path, index) => {
+                existingImages.push({
+                    id: index,
+                    url: path
+                });
+
+                // 既存画像をプレビューとして表示
+                renderExistingImages();
+            })
+            // 削除されていない画像のURLをフォームに反映
+            document.getElementById('removedImages').value = JSON.stringify(existingImages);
+        });
+
+        // 既存画像をプレビューとして表示
+        function renderExistingImages() {
+            const preview = document.getElementById('preview');
+            // プレビューを初期化
+            preview.innerHTML = '';
+            // 選択している画像の枚数を表示する
+            countImages(existingImages);
+
+            existingImages.forEach(image => {
+                const figure = document.createElement('figure');
+                figure.setAttribute('id', `existing-img-${image.id}`);
+                figure.className = 'relative flex flex-col items-center mb-4';
+
+                const img = document.createElement('img');
+                // サーバー上の画像URLを使用
+                img.src = image.url;
+                img.alt = 'existing preview';
+                img.className = 'w-36 h-36 object-cover rounded-md border border-gray-300 mb-2';
+
+                const rmBtn = document.createElement('button');
+                rmBtn.type = 'button';
+                rmBtn.textContent = '削除';
+                rmBtn.className = 'px-2 py-1 bg-red-500 text-white text-sm rounded hover:bg-red-600';
+                rmBtn.onclick = function() {
+                    removeExistingImage(image.id);
+                };
+
+                figure.appendChild(img);
+                figure.appendChild(rmBtn);
+                preview.appendChild(figure);
+            });
+        }
 
         function loadImage(obj) {
-            // 以前に選択したファイルは保持されないため削除
-            document.querySelectorAll('figure').forEach(function(figure) {
-                figure.remove();
-                key = 0;
-            });
-            // 選択されたファイルの枚数分だけ画像を追加
-            for (i = 0; i < obj.files.length; i++) {
-                var fileReader = new FileReader();
-                fileReader.onload = (function(e) {
-                    var field = document.getElementById("preview");
-                    var figure = document.createElement("figure");
-                    var rmBtn = document.createElement("input");
-                    var img = new Image();
-                    img.src = e.target.result;
-                    rmBtn.type = "button";
-                    rmBtn.name = key;
-                    rmBtn.value = "削除";
-                    rmBtn.onclick = (function() {
-                        var element = document.getElementById("img-" + String(rmBtn.name)).remove();
-                    });
-                    figure.setAttribute("id", "img-" + key);
-                    figure.appendChild(img);
-                    figure.appendChild(rmBtn)
-                    field.appendChild(figure);
-                    key++;
-                });
-                fileReader.readAsDataURL(obj.files[i]);
+            // 新しく選択された画像
+            const newImages = Array.from(obj.files);
+            // 合計が4枚を超える場合のチェック
+            // 元々選択されていた画像と新しい画像、以前保存していた画像の合計を確認
+            if (selectedImages.length + newImages.length + existingImages.length > 4) {
+                alert('画像は4枚までアップロード可能です');
+                // プレビューを更新し、以前選択していた画像を再表示する
+                // 新しく選択していた方の画像は破棄
+                renderPreviews();
+                return;
             }
+
+            // 新しい画像を選択済みリストに追加
+            selectedImages.push(...newImages);
+
+            // プレビューの更新
+            renderPreviews();
+        }
+
+        function renderPreviews() {
+            // プレビューを取得後、クリア
+            const preview = document.getElementById('preview');
+            preview.innerHTML = '';
+
+            // 既存画像を表示
+            renderExistingImages();
+            // 新規追加された画像を表示
+            selectedImages.forEach((image, index) => {
+                const fileReader = new FileReader();
+
+                fileReader.onload = function(e) {
+                    const figure = document.createElement('figure');
+                    figure.setAttribute('id', `img-${index}`);
+                    figure.className = 'relative flex flex-col items-center mb-4';
+
+                    const img = document.createElement('img');
+                    img.src = e.target.result;
+                    img.alt = 'preview';
+                    img.className = 'w-36 h-36 object-cover rounded-md border border-gray-300 mb-2';
+
+                    const rmBtn = document.createElement('button');
+                    rmBtn.type = 'button';
+                    rmBtn.textContent = '削除';
+                    rmBtn.className = 'px-2 py-1 bg-red-500 text-white text-sm rounded hover:bg-red-600';
+                    rmBtn.onclick = function() {
+                        removeImage(index);
+                    };
+
+                    figure.appendChild(img);
+                    figure.appendChild(rmBtn);
+                    preview.appendChild(figure);
+                };
+
+                fileReader.readAsDataURL(image);
+            });
+
+            // 選択している画像を反映
+            updateInputElement();
+        }
+
+        // 既存画像リストから該当画像を削除
+        function removeExistingImage(id) {
+            const index = existingImages.findIndex(img => img.id === id);
+            if (index !== -1) {
+                existingImages.splice(index, 1);
+            }
+            // 削除されていない画像のURLをフォームに反映
+            document.getElementById('removedImages').value = JSON.stringify(existingImages); 
+            console.log(document.getElementById('removedImages').value);
+            // プレビューを再描画
+            renderPreviews();
+        }
+
+        function removeImage(index) {
+            // 選択済み画像リストから該当インデックスの画像を削除
+            selectedImages.splice(index, 1);
+
+            // プレビューを再描画
+            renderPreviews();
+        }
+
+        function updateInputElement() {
+            const dataTransfer = new DataTransfer();
+            selectedImages.forEach(image => dataTransfer.items.add(image));
+
+            // 選択された画像を反映
+            const inputElm = document.getElementById('inputElm');
+            inputElm.files = dataTransfer.files;
+        }
+
+        // 選択している画像の枚数を表示する
+        function countImages() {
+            const count = document.getElementById('count');
+            count.innerHTML = '';
+            const countText = document.createElement('p');
+            const ImageCount = selectedImages.length + existingImages.length;
+            countText.textContent = `現在、${ImageCount}枚の画像を選択しています。`;
+            count.appendChild(countText);
         }
     </script>
 


### PR DESCRIPTION
### プレビュー表示と選択されたファイルの紐づけ

- #66 

・input側で選択した画像とプレビュー表示の紐づけをする。
・input側のデフォルトで用意されている枚数表示を非表示にし、
新しくプレビューの枚数で選択している枚数を表示するpタグの追加。
・編集画面においても同様の処理を実行。
・投稿削除でもCloudinaryから画像の削除ができるようにする。

**・編集画面での処理の流れ**

1. 編集画面表示後、既存画像のURLをjs側で取得し、URLを用いてプレビューの表示
2. 既存画像のプレビュー下の削除ボタン押下で、削除した既存画像のURL配列に該当画像のURLを格納
3. 新しい画像の追加や削除は新規感想作成画面と同様で、selectedImages配列に格納
4. 「編集する」ボタンで、削除した既存画像のURL配列と削除されなかった既存画像のURLをコントローラーに渡す
5. コントローラーのupdate関数内で、削除した既存画像のURL配列からpublic_idを作成し、Cloudinaryから削除する
6. 同様にupdate関数内で、削除されなかった既存画像のURLと新しく追加された画像のURLを格納するimage_paths配列を作成し、4つの要素のうち、URLが格納されない場合はNULLを代入してDBに保存する


・新規感想作成画面
![image](https://github.com/user-attachments/assets/f121292e-f731-427b-b60a-18a039a082b7)

・編集画面
![スクリーンショット 2024-11-21 113545](https://github.com/user-attachments/assets/38240aeb-c33b-4a64-9ada-96ee536979c7)

