### PR TITLE
Feat：あらすじ感想に新プレビュー機能の追加

### DIFF
--- a/app/Http/Controllers/WorkStoryPostController.php
+++ b/app/Http/Controllers/WorkStoryPostController.php
@@ -77,15 +77,46 @@ class WorkStoryPostController extends Controller
     public function update(WorkStoryPostRequest $request, WorkStoryPost $workStoryPost, $work_id, $work_story_id, $work_story_post_id)
     {
         $input_post = $request['work_story_post'];
+        // 保存する画像のPathの配列
+        $image_paths = [];
+        // 削除されていない既存画像がある場合のみ以下の処理を実行
+        if ($request['remainedImages'][0]) {
+            // JSON文字列をデコードしてPHP配列に変換
+            $remained_images = json_decode($request['remainedImages'][0], true);
+            // Pathの配列に削除されていない画像のPathを追加
+            foreach ($remained_images as $remained_image) {
+                array_push($image_paths, $remained_image['url']);
+            }
+        }
+        // 削除された既存画像がある場合のみ以下の処理を実行
+        if ($request['removedImages'][0]) {
+            // JSON文字列をデコードしてPHP配列に変換
+            $removed_images = json_decode($request['removedImages'][0], true);
+            // 削除された画像のPathをCloudinaryから削除
+            foreach ($removed_images as $removed_image) {
+                // Cloudinaryに登録した画像のURLからpublic_idを取得する
+                $public_id = $this->extractPublicIdFromUrl($removed_image['url']);
+                Cloudinary::destroy($public_id);
+            }
+        }
         //cloudinaryへ画像を送信し、画像のURLを$image_urlに代入
         //画像ファイルが送られた時だけ処理が実行される
         if ($request->file('images')) {
-            $counter = 1;
             foreach ($request->file('images') as $image) {
-                $image_url = Cloudinary::upload($image->getRealPath())->getSecurePath();
-                $input_post["image$counter"] = $image_url;
-                $counter++;
+                $image_path = Cloudinary::upload($image->getRealPath())->getSecurePath();
+                array_push($image_paths, $image_path);
             }
+        }
+        // $imagePathのうち、Pathのないものにはnullを代入
+        $vacantElementNum = 4 - count($image_paths);
+        for ($counter = 0; $counter < $vacantElementNum; $counter++) {
+            array_push($image_paths, NULL);
+        }
+        $counter = 1;
+        // 今回保存するPathをDBのImageカラムに代入する
+        foreach ($image_paths as $imagePath) {
+            $input_post["image$counter"] = $imagePath;
+            $counter++;
         }
         // 編集の対象となるデータを取得
         $targetWorkStoryPost = $workStoryPost->getDetailPost($work_story_id, $work_story_post_id);
@@ -98,6 +129,17 @@ class WorkStoryPostController extends Controller
     {
         // 編集の対象となるデータを取得
         $targetWorkStoryPost = $workStoryPost->getDetailPost($work_story_id, $work_story_post_id);
+        // 削除する投稿の画像も削除する処理
+        for ($counter = 1; $counter < 5; $counter++) {
+            $removed_image_path = $targetWorkStoryPost->{'image' . $counter};
+            // DBのimageの中身がnullであれば処理をスキップする
+            if (is_null($removed_image_path)) {
+                break;
+            }
+            $public_id = $this->extractPublicIdFromUrl($removed_image_path);
+            Cloudinary::destroy($public_id);
+        }
+        // データの削除
         $targetWorkStoryPost->delete();
         return redirect()->route('work_story_posts.index', ['work_id' => $targetWorkStoryPost->work_id, 'work_story_id' => $targetWorkStoryPost->sub_title_id]);
     }
@@ -126,5 +168,19 @@ class WorkStoryPostController extends Controller
             return response()->json(['status' => 'liked', 'like_user' => $count]);
         }
         return back();
+    }
+
+    // Cloudinaryにある画像のURLからpublic_Idを取得する
+    public function extractPublicIdFromUrl($url)
+    {
+        // URLの中からpublic_idを抽出するための正規表現
+        $pattern = '/upload\/(?:v\d+\/)?([^\.]+)\./';
+
+        if (preg_match($pattern, $url, $matches)) {
+            // 抽出されたpublic_id
+            return $matches[1];
+        }
+        // 該当しない場合はnull
+        return null;
     }
 }

--- a/resources/views/work_reviews/edit.blade.php
+++ b/resources/views/work_reviews/edit.blade.php
@@ -1,7 +1,9 @@
 <x-app-layout>
     <h1 class="title">{{ $work_review->work->name }}への投稿編集画面</h1>
     <div class="content">
-        <form action="{{ route('work_reviews.update', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}" method="POST" enctype="multipart/form-data">
+        <form
+            action="{{ route('work_reviews.update', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}"
+            method="POST" enctype="multipart/form-data">
             @csrf
             @method('PUT')
             <div class="work_id">
@@ -12,27 +14,29 @@
             </div>
             <div class="title">
                 <h2>タイトル</h2>
-                <input type="text" name="work_review[post_title]" placeholder="タイトル" value="{{ $work_review->post_title }}" />
+                <input type="text" name="work_review[post_title]" placeholder="タイトル"
+                    value="{{ $work_review->post_title }}" />
                 <p class="title__error" style="color:red">{{ $errors->first('work_review.post_title') }}</p>
             </div>
             <div class="category">
                 <h2>カテゴリー（3個まで）</h2>
                 @php
-                // old() が存在すればそれを使用し、なければ過去の保存値を使用
-                $existingCategories = $work_review->categories->pluck('id')->toArray();
-                $selectedCategories = old('work_review.categories_array', $existingCategories);
+                    // old() が存在すればそれを使用し、なければ過去の保存値を使用
+                    $existingCategories = $work_review->categories->pluck('id')->toArray();
+                    $selectedCategories = old('work_review.categories_array', $existingCategories);
                 @endphp
                 <select name="work_review[categories_array][]" multiple>
-                    @foreach($categories as $category)
-                    <option value="{{ $category->id }}"
-                        {{ in_array($category->id, $selectedCategories) ? 'selected' : '' }}>
-                        {{ $category->name }}
-                    </option>
+                    @foreach ($categories as $category)
+                        <option value="{{ $category->id }}"
+                            {{ in_array($category->id, $selectedCategories) ? 'selected' : '' }}>
+                            {{ $category->name }}
+                        </option>
                     @endforeach
                 </select>
 
                 @if ($errors->has('work_review.categories_array'))
-                <p class="category__error" style="color:red">{{ $errors->first('work_review.categories_array') }}</p>
+                    <p class="category__error" style="color:red">{{ $errors->first('work_review.categories_array') }}
+                    </p>
                 @endif
             </div>
             <div class="body">
@@ -43,20 +47,21 @@
             <div class="image">
                 <h2>画像（4枚まで）</h2>
                 @php
-                // 既にファイルが選択されている場合はそれらを表示する
-                $existingImages = [];
-                $numbers = array(1, 2, 3, 4);
-                foreach($numbers as $number){
-                $image = "image".$number;
-                if($work_review->$image){
-                array_push($existingImages, $work_review->$image);
-                }
-                }
-                $existingImages = json_encode($existingImages);
+                    // 既にファイルが選択されている場合はそれらを表示する
+                    $existingImages = [];
+                    $numbers = [1, 2, 3, 4];
+                    foreach ($numbers as $number) {
+                        $image = 'image' . $number;
+                        if ($work_review->$image) {
+                            array_push($existingImages, $work_review->$image);
+                        }
+                    }
+                    $existingImages = json_encode($existingImages);
                 @endphp
                 <div id="existing_image_paths" data-php-variable="{{ $existingImages }}"></div>
                 <label>
-                    <input id="inputElm" type="file" style="display:none" name="images[]" multiple onchange="loadImage(this);">画像の追加
+                    <input id="inputElm" type="file" style="display:none" name="images[]" multiple
+                        onchange="loadImage(this);">画像の追加
                     <div id="count"></div>
                 </label>
                 <!-- 削除された既存画像のリスト -->
@@ -71,7 +76,8 @@
         </form>
     </div>
     <div class="footer">
-        <a href="{{ route('work_reviews.show', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}">保存しないで戻る</a>
+        <a
+            href="{{ route('work_reviews.show', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}">保存しないで戻る</a>
     </div>
     <script src="{{ asset('/js/edit_preview.js') }}"></script>
 

--- a/resources/views/work_reviews/index.blade.php
+++ b/resources/views/work_reviews/index.blade.php
@@ -12,49 +12,52 @@
         </div>
     </div>
     <div class='work_reviews'>
-        @if($work_reviews->isEmpty())
-        <h2 class='no_result'>結果がありません。</h2>
+        @if ($work_reviews->isEmpty())
+            <h2 class='no_result'>結果がありません。</h2>
         @else
-        <div class='work_review'>
-            @foreach ($work_reviews as $work_review)
             <div class='work_review'>
-                <h2 class='title'>
-                    <a href="{{ route('work_reviews.show', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}">{{ $work_review->post_title }}</a>
-                </h2>
-                <div class="like">
+                @foreach ($work_reviews as $work_review)
+                    <div class='work_review'>
+                        <h2 class='title'>
+                            <a
+                                href="{{ route('work_reviews.show', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}">{{ $work_review->post_title }}</a>
+                        </h2>
+                        <div class="like">
 
-                    <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
-                    <button id="like_button"
-                        data-work-id="{{ $work_review->work_id }}"
-                        data-review-id="{{ $work_review->id }}"
-                        type="submit">
-                        {{ $work_review->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
-                    </button>
-                    <div class="like_user">
-                        <a href="{{ route('work_review_like.index', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}">
-                            <p id="like_count">{{ $work_review->users->count() }}</p>
-                        </a>
+                            <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
+                            <button id="like_button" data-work-id="{{ $work_review->work_id }}"
+                                data-review-id="{{ $work_review->id }}" type="submit">
+                                {{ $work_review->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
+                            </button>
+                            <div class="like_user">
+                                <a
+                                    href="{{ route('work_review_like.index', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}">
+                                    <p id="like_count">{{ $work_review->users->count() }}</p>
+                                </a>
+                            </div>
+                        </div>
+                        <h5 class='category'>
+                            @foreach ($work_review->categories as $category)
+                                {{ $category->name }}
+                            @endforeach
+                        </h5>
+                        <p class='body'>{{ $work_review->body }}</p>
+                        @if ($work_review->image1)
+                            <div>
+                                <img src="{{ $work_review->image1 }}" alt="画像が読み込めません。">
+                            </div>
+                        @endif
+                        <form
+                            action="{{ route('work_reviews.delete', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}"
+                            id="form_{{ $work_review->id }}" method="post">
+                            @csrf
+                            @method('DELETE')
+                            <button type="button" data-post-id="{{ $work_review->id }}"
+                                class="delete-button">投稿を削除する</button>
+                        </form>
                     </div>
-                </div>
-                <h5 class='category'>
-                    @foreach($work_review->categories as $category)
-                    {{ $category->name }}
-                    @endforeach
-                </h5>
-                <p class='body'>{{ $work_review->body }}</p>
-                @if($work_review->image1)
-                <div>
-                    <img src="{{ $work_review->image1 }}" alt="画像が読み込めません。">
-                </div>
-                @endif
-                <form action="{{ route('work_reviews.delete', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}" id="form_{{ $work_review->id }}" method="post">
-                    @csrf
-                    @method('DELETE')
-                    <button type="button" data-post-id="{{ $work_review->id }}" class="delete-button">投稿を削除する</button>
-                </form>
+                @endforeach
             </div>
-            @endforeach
-        </div>
         @endif
     </div>
     <div class="footer">
@@ -100,13 +103,14 @@
                     const workId = button.getAttribute('data-work-id');
                     const reviewId = button.getAttribute('data-review-id');
                     try {
-                        const response = await fetch(`/work_reviews/${workId}/reviews/${reviewId}/like`, {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                                'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                            },
-                        });
+                        const response = await fetch(
+                            `/work_reviews/${workId}/reviews/${reviewId}/like`, {
+                                method: 'POST',
+                                headers: {
+                                    'Content-Type': 'application/json',
+                                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                                },
+                            });
                         const data = await response.json();
                         if (data.status === 'liked') {
                             button.innerText = 'いいね取り消し';

--- a/resources/views/work_reviews/show.blade.php
+++ b/resources/views/work_reviews/show.blade.php
@@ -4,14 +4,13 @@
     </h1>
     <div class="like">
         <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
-        <button id="like_button"
-            data-work-id="{{ $work_review->work_id }}"
-            data-review-id="{{ $work_review->id }}"
+        <button id="like_button" data-work-id="{{ $work_review->work_id }}" data-review-id="{{ $work_review->id }}"
             type="submit">
             {{ $work_review->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
         </button>
         <div class="like_user">
-            <a href="{{ route('work_review_like.index', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}">
+            <a
+                href="{{ route('work_review_like.index', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}">
                 <p id="like_count">{{ $work_review->users->count() }}</p>
             </a>
         </div>
@@ -24,8 +23,8 @@
             <p>{{ $work_review->user->name }}</p>
             <h3>カテゴリー</h3>
             <h5 class='category'>
-                @foreach($work_review->categories as $category)
-                {{ $category->name }}
+                @foreach ($work_review->categories as $category)
+                    {{ $category->name }}
                 @endforeach
             </h5>
             <h3>本文</h3>
@@ -33,24 +32,27 @@
             <h3>作成日</h3>
             <p>{{ $work_review->created_at }}</p>
             @php
-            $numbers = array(1, 2, 3, 4);
+                $numbers = [1, 2, 3, 4];
             @endphp
-            @foreach($numbers as $number)
-            @php
-            $image = "image".$number;
-            @endphp
-            @if($work_review->$image)
-            <div>
-                <img src="{{ $work_review->$image }}" alt="画像が読み込めません。">
-            </div>
-            @endif
+            @foreach ($numbers as $number)
+                @php
+                    $image = 'image' . $number;
+                @endphp
+                @if ($work_review->$image)
+                    <div>
+                        <img src="{{ $work_review->$image }}" alt="画像が読み込めません。">
+                    </div>
+                @endif
             @endforeach
         </div>
     </div>
     <div class="edit">
-        <a href="{{ route('work_reviews.edit', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}">編集する</a>
+        <a
+            href="{{ route('work_reviews.edit', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}">編集する</a>
     </div>
-    <form action="{{ route('work_reviews.delete', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}" id="form_{{ $work_review->id }}" method="post">
+    <form
+        action="{{ route('work_reviews.delete', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}"
+        id="form_{{ $work_review->id }}" method="post">
         @csrf
         @method('DELETE')
         <button type="button" data-post-id="{{ $work_review->id }}" class="delete-button">投稿を削除する</button>
@@ -95,13 +97,14 @@
                     const workId = button.getAttribute('data-work-id');
                     const reviewId = button.getAttribute('data-review-id');
                     try {
-                        const response = await fetch(`/work_reviews/${workId}/reviews/${reviewId}/like`, {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                                'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                            },
-                        });
+                        const response = await fetch(
+                            `/work_reviews/${workId}/reviews/${reviewId}/like`, {
+                                method: 'POST',
+                                headers: {
+                                    'Content-Type': 'application/json',
+                                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                                },
+                            });
                         const data = await response.json();
                         if (data.status === 'liked') {
                             button.innerText = 'いいね取り消し';

--- a/resources/views/work_story_posts/create.blade.php
+++ b/resources/views/work_story_posts/create.blade.php
@@ -1,6 +1,8 @@
 <x-app-layout>
     <h1>「{{ $work_story_post->workStory->sub_title }}」への新規感想投稿</h1>
-    <form action="{{ route('work_story_posts.store', ['work_id' => $work_story_post->work_id, 'work_story_id' => $work_story_post->sub_title_id, 'work_story_post_id' => $work_story_post->id]) }}" method="POST" enctype="multipart/form-data">
+    <form
+        action="{{ route('work_story_posts.store', ['work_id' => $work_story_post->work_id, 'work_story_id' => $work_story_post->sub_title_id, 'work_story_post_id' => $work_story_post->id]) }}"
+        method="POST" enctype="multipart/form-data">
         @csrf
         <div class="work_id">
             <input type="hidden" name="work_story_post[work_id]" value="{{ $work_story_post->work_id }}">
@@ -10,7 +12,8 @@
         </div>
         <div class="title">
             <h2>タイトル</h2>
-            <input type="text" name="work_story_post[post_title]" placeholder="タイトル" value="{{ old('work_story_post.post_title') }}" />
+            <input type="text" name="work_story_post[post_title]" placeholder="タイトル"
+                value="{{ old('work_story_post.post_title') }}" />
             <p class="title__error" style="color:red">{{ $errors->first('work_story_post.post_title') }}</p>
         </div>
         <div class="body">
@@ -20,7 +23,11 @@
         </div>
         <div class="image">
             <h2>画像（4枚まで）</h2>
-            <input id="inputElm" type="file" name="images[]" multiple onchange="loadImage(this);">
+            <label>
+                <input id="inputElm" type="file" style="display:none" name="images[]" multiple
+                    onchange="loadImage(this);">画像の追加
+                <div id="count">現在、0枚の画像を選択しています。</div>
+            </label>
             <p class="image__error" style="color:red">{{ $errors->first('images') }}</p>
         </div>
         <!-- プレビュー画像の表示 -->
@@ -28,42 +35,9 @@
         <button type="submit">投稿する</button>
     </form>
     <div class="footer">
-        <a href="{{ route('work_story_posts.index', ['work_id' => $work_story_post->work_id, 'work_story_id' => $work_story_post->sub_title_id]) }}">戻る</a>
+        <a
+            href="{{ route('work_story_posts.index', ['work_id' => $work_story_post->work_id, 'work_story_id' => $work_story_post->sub_title_id]) }}">戻る</a>
     </div>
-    <script>
-        let key = 0;
-
-        function loadImage(obj) {
-            // 以前に選択したファイルは保持されないため削除
-            document.querySelectorAll('figure').forEach(function(figure) {
-                figure.remove();
-                key = 0;
-            });
-            // 選択されたファイルの枚数分だけ画像を追加
-            for (i = 0; i < obj.files.length; i++) {
-                var fileReader = new FileReader();
-                fileReader.onload = (function(e) {
-                    var field = document.getElementById("preview");
-                    var figure = document.createElement("figure");
-                    var rmBtn = document.createElement("input");
-                    var img = new Image();
-                    img.src = e.target.result;
-                    rmBtn.type = "button";
-                    rmBtn.name = key;
-                    rmBtn.value = "削除";
-                    // 削除ボタン押下で画像プレビューの削除
-                    rmBtn.onclick = (function() {
-                        var element = document.getElementById("img-" + String(rmBtn.name)).remove();
-                    });
-                    figure.setAttribute("id", "img-" + key);
-                    figure.appendChild(img);
-                    figure.appendChild(rmBtn)
-                    field.appendChild(figure);
-                    key++;
-                });
-                fileReader.readAsDataURL(obj.files[i]);
-            }
-        }
-    </script>
+    <script src="{{ asset('/js/create_preview.js') }}"></script>
 
 </x-app-layout>

--- a/resources/views/work_story_posts/edit.blade.php
+++ b/resources/views/work_story_posts/edit.blade.php
@@ -1,7 +1,9 @@
 <x-app-layout>
     <h1 class="title">「{{ $work_story_post->workStory->sub_title }}」への投稿編集画面</h1>
     <div class="content">
-        <form action="{{ route('work_story_posts.update', ['work_id' => $work_story_post->work_id, 'work_story_id' => $work_story_post->sub_title_id, 'work_story_post_id' => $work_story_post->id]) }}" method="POST" enctype="multipart/form-data">
+        <form
+            action="{{ route('work_story_posts.update', ['work_id' => $work_story_post->work_id, 'work_story_id' => $work_story_post->sub_title_id, 'work_story_post_id' => $work_story_post->id]) }}"
+            method="POST" enctype="multipart/form-data">
             @csrf
             @method('PUT')
             <div class="work_id">
@@ -15,7 +17,8 @@
             </div>
             <div class="title">
                 <h2>タイトル</h2>
-                <input type="text" name="work_story_post[post_title]" placeholder="タイトル" value="{{ $work_story_post->post_title }}" />
+                <input type="text" name="work_story_post[post_title]" placeholder="タイトル"
+                    value="{{ $work_story_post->post_title }}" />
                 <p class="title__error" style="color:red">{{ $errors->first('work_story_post.post_title') }}</p>
             </div>
             <div class="body">
@@ -25,7 +28,28 @@
             </div>
             <div class="image">
                 <h2>画像（4枚まで）</h2>
-                <input id="inputElm" type="file" name="images[]" multiple onchange="loadImage(this);">
+                @php
+                    // 既にファイルが選択されている場合はそれらを表示する
+                    $existingImages = [];
+                    $numbers = [1, 2, 3, 4];
+                    foreach ($numbers as $number) {
+                        $image = 'image' . $number;
+                        if ($work_story_post->$image) {
+                            array_push($existingImages, $work_story_post->$image);
+                        }
+                    }
+                    $existingImages = json_encode($existingImages);
+                @endphp
+                <div id="existing_image_paths" data-php-variable="{{ $existingImages }}"></div>
+                <label>
+                    <input id="inputElm" type="file" style="display:none" name="images[]" multiple
+                        onchange="loadImage(this);">画像の追加
+                    <div id="count"></div>
+                </label>
+                <!-- 削除された既存画像のリスト -->
+                <input type="hidden" name="removedImages[]" id="removedImages" value="">
+                <!-- 削除されず残った既存画像のリスト -->
+                <input type="hidden" name="remainedImages[]" id="remainedImages" value="">
                 <p class="image__error" style="color:red">{{ $errors->first('images') }}</p>
             </div>
             <!-- プレビュー画像の表示 -->
@@ -34,40 +58,8 @@
         </form>
     </div>
     <div class="footer">
-        <a href="{{ route('work_story_posts.show', ['work_id' => $work_story_post->work_id, 'work_story_id' => $work_story_post->sub_title_id, 'work_story_post_id' => $work_story_post->id]) }}">保存しないで戻る</a>
+        <a
+            href="{{ route('work_story_posts.show', ['work_id' => $work_story_post->work_id, 'work_story_id' => $work_story_post->sub_title_id, 'work_story_post_id' => $work_story_post->id]) }}">保存しないで戻る</a>
     </div>
-    <script>
-        let key = 0;
-
-        function loadImage(obj) {
-            // 以前に選択したファイルは保持されないため削除
-            document.querySelectorAll('figure').forEach(function(figure) {
-                figure.remove();
-                key = 0;
-            });
-            // 選択されたファイルの枚数分だけ画像を追加
-            for (i = 0; i < obj.files.length; i++) {
-                var fileReader = new FileReader();
-                fileReader.onload = (function(e) {
-                    var field = document.getElementById("preview");
-                    var figure = document.createElement("figure");
-                    var rmBtn = document.createElement("input");
-                    var img = new Image();
-                    img.src = e.target.result;
-                    rmBtn.type = "button";
-                    rmBtn.name = key;
-                    rmBtn.value = "削除";
-                    rmBtn.onclick = (function() {
-                        var element = document.getElementById("img-" + String(rmBtn.name)).remove();
-                    });
-                    figure.setAttribute("id", "img-" + key);
-                    figure.appendChild(img);
-                    figure.appendChild(rmBtn)
-                    field.appendChild(figure);
-                    key++;
-                });
-                fileReader.readAsDataURL(obj.files[i]);
-            }
-        }
-    </script>
+    <script src="{{ asset('/js/edit_preview.js') }}"></script>
 </x-app-layout>


### PR DESCRIPTION
### あらすじ感想に新プレビュー機能の追加

- #66 

・作品感想で実装したプレビュー機能をあらすじ感想の新規作成と編集の2画面に追加。
・投稿を削除した際に、Cloudinaryから削除する機能も反映。

・blade formatterをインストールしてコードの整形も実行

・あらすじ感想の新規作成
![スクリーンショット 2024-11-21 221123](https://github.com/user-attachments/assets/22137234-ca5e-4532-91ef-262079ad308b)

・あらすじ感想の編集画面
![スクリーンショット 2024-11-21 221140](https://github.com/user-attachments/assets/09223ed7-6c58-43b4-81d1-5c4bf9d77c8d)
