### PR TITLE
Feat：プロフィール編集画面の作成

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -40,7 +40,8 @@ class ProfileController extends Controller
 
         $request->user()->save();
 
-        return Redirect::route('profile.edit')->with('status', 'profile-updated');
+        //return Redirect::route('profile.edit')->with('status', 'profile-updated');
+        return Redirect::route('profile.index');
     }
 
     /**

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -11,9 +11,15 @@ use Illuminate\View\View;
 
 class ProfileController extends Controller
 {
-    /**
-     * Display the user's profile form.
-     */
+    public function index()
+    {
+        // 現在認証しているユーザーを取得
+        $user = auth()->user();
+        return view('profile.index', [
+            'user' => $user
+        ]);
+    }
+
     public function edit(Request $request): View
     {
         return view('profile.edit', [

--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -19,7 +19,6 @@ class ProfileUpdateRequest extends FormRequest
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($this->user()->id)],
             'age' => ['required'],
-            'sex' => ['required', 'string'],
             'introduction' => ['required', 'string', 'max:255'],
         ];
     }

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -140,5 +140,6 @@
     "Showing": "表示中：",
     "Age": "年齢",
     "Sex": "性別",
-    "Introduction": "紹介文"
+    "Introduction": "紹介文",
+    "User_Image": "ユーザー画像"
 }

--- a/public/js/edit_profile_preview.js
+++ b/public/js/edit_profile_preview.js
@@ -1,0 +1,113 @@
+const preview = document.getElementById('preview');
+// HTMLのdata属性から既存画像のURLを取得
+const existingImagePath = document.getElementById('existing_image_path');
+const phpVariable = existingImagePath.dataset.phpVariable;
+// 既存の画像を取得
+const existingImage = phpVariable;
+// 画像がない場合の画像パス
+const noImagePath = 'https://res.cloudinary.com/dnumegejl/image/upload/v1732344378/No_User_Image_genl0i.png';
+// 既存の画像を表示
+const currentImage = existingImage != '' ? existingImage : noImagePath;
+
+// 編集画面にて、以前画像が選択されていた場合、それらの画像を反映する
+// DOMツリー読み取り完了後にイベント発火
+document.addEventListener('DOMContentLoaded', function() {
+    renderExistingImages(currentImage)
+    if (currentImage == noImagePath) {
+        // プレビューのうち、削除ボタンを削除する
+        const deleteButton = document.getElementById('delete_button');
+        deleteButton.remove();
+    }
+});
+
+// 既存画像をプレビューとして表示
+function renderExistingImages(currentImage) {
+    // プレビューを初期化
+    preview.innerHTML = '';
+
+    const figure = document.createElement('figure');
+    figure.setAttribute('id', 'preview_image');
+    figure.className = 'relative flex flex-col items-center mb-4';
+
+    const img = document.createElement('img');
+    img.src = currentImage;
+    img.alt = 'existing preview';
+    img.className = 'w-36 h-36 object-cover rounded-md border border-gray-300 mb-2';
+
+    const rmBtn = document.createElement('button');
+    rmBtn.type = 'button';
+    rmBtn.setAttribute('id', 'delete_button');
+    rmBtn.textContent = '削除';
+    rmBtn.className = 'px-2 py-1 bg-red-500 text-white text-sm rounded hover:bg-red-600';
+    rmBtn.onclick = function() {
+        removeExistingImage();
+    };
+
+    figure.appendChild(img);
+    figure.appendChild(rmBtn);
+    preview.appendChild(figure);
+};
+
+// 新しく画像を変えた場合の処理
+document.getElementById('image').addEventListener('change', function(event) {
+
+    const file = event.target.files[0];
+
+    if (file) {
+        preview.innerHTML = '';
+        const reader = new FileReader();
+
+        reader.onload = function(e) {
+            const figure = document.createElement('figure');
+            figure.setAttribute('id', 'preview_image');
+            figure.className = 'relative flex flex-col items-center mb-4';
+            // 画像の更新
+            const img = document.createElement('img');
+            img.src = e.target.result;
+            img.alt = 'preview';
+            img.className = 'w-36 h-36 object-cover rounded-md border border-gray-300 mb-2';
+            // 画像をリセットボタンの作成
+            const rmBtn = document.createElement('button');
+            rmBtn.type = 'button';
+            rmBtn.textContent = '画像変更のリセット';
+            rmBtn.className =
+                'px-2 py-1 bg-red-500 text-white text-sm rounded hover:bg-red-600';
+            rmBtn.onclick = function() {
+                resetImage();
+            };
+
+            figure.appendChild(img);
+            figure.appendChild(rmBtn);
+            preview.appendChild(figure);
+        };
+
+        reader.readAsDataURL(file);
+    }
+});
+
+// 画像の変更をリセットする
+function resetImage(index) {
+    const currentImage = existingImage != '' ? existingImage : noImagePath;
+
+    // プレビューを再描画
+    renderExistingImages(currentImage);
+    if (currentImage == noImagePath) {
+        // プレビューのうち、削除ボタンを削除する
+        const deleteButton = document.getElementById('delete_button');
+        deleteButton.remove();
+    }
+    // 選択した画像をinputから削除する
+    const selectedImage = document.getElementById('image');
+    selectedImage.value = '';
+}
+
+// 画像の削除
+function removeExistingImage() {
+    // 選択なし画像のパスを代入
+    const currentImage = noImagePath;
+    // プレビューを再描画
+    renderExistingImages(currentImage);
+    // プレビューのうち、削除ボタンを削除する
+    const deleteButton = document.getElementById('delete_button');
+    deleteButton.remove();
+}

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -5,14 +5,16 @@
         <!-- Name -->
         <div>
             <x-input-label for="name" :value="__('Name')" />
-            <x-text-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus autocomplete="name" />
+            <x-text-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required
+                autofocus autocomplete="name" />
             <x-input-error :messages="$errors->get('name')" class="mt-2" />
         </div>
 
         <!-- Email Address -->
         <div class="mt-4">
             <x-input-label for="email" :value="__('Email')" />
-            <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autocomplete="username" />
+            <x-text-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')"
+                required autocomplete="username" />
             <x-input-error :messages="$errors->get('email')" class="mt-2" />
         </div>
 
@@ -20,10 +22,8 @@
         <div class="mt-4">
             <x-input-label for="password" :value="__('Password')" />
 
-            <x-text-input id="password" class="block mt-1 w-full"
-                            type="password"
-                            name="password"
-                            required autocomplete="new-password" />
+            <x-text-input id="password" class="block mt-1 w-full" type="password" name="password" required
+                autocomplete="new-password" />
 
             <x-input-error :messages="$errors->get('password')" class="mt-2" />
         </div>
@@ -32,9 +32,8 @@
         <div class="mt-4">
             <x-input-label for="password_confirmation" :value="__('Confirm Password')" />
 
-            <x-text-input id="password_confirmation" class="block mt-1 w-full"
-                            type="password"
-                            name="password_confirmation" required autocomplete="new-password" />
+            <x-text-input id="password_confirmation" class="block mt-1 w-full" type="password"
+                name="password_confirmation" required autocomplete="new-password" />
 
             <x-input-error :messages="$errors->get('password_confirmation')" class="mt-2" />
         </div>
@@ -42,27 +41,30 @@
         <!-- Age -->
         <div class="mt-4">
             <x-input-label for="age" :value="__('Age')" />
-            <x-text-input id="age" class="block mt-1 w-full" type="number" min="0" name="age" :value="old('age')" required autocomplete="age" />
+            <x-text-input id="age" class="block mt-1 w-full" type="number" min="0" name="age"
+                :value="old('age')" required autocomplete="age" />
             <x-input-error :messages="$errors->get('age')" class="mt-2" />
         </div>
 
         <!-- Sex -->
         <div class="mt-4">
             <x-input-label for="sex" :value="__('Sex')" />
-            <x-radio-input id="male" name="sex" value="male" :checked="old('sex') === 'male'" label="男性"/>
-            <x-radio-input id="female" name="sex" value="female" :checked="old('sex') === 'female'" label="女性"/>
+            <x-radio-input id="male" name="sex" value="男性" :checked="old('sex') === 'male'" label="男性" />
+            <x-radio-input id="female" name="sex" value="女性" :checked="old('sex') === 'female'" label="女性" />
             <x-input-error :messages="$errors->get('sex')" class="mt-2" />
         </div>
- 
+
         <!-- Introduction -->
         <div class="mt-4">
             <x-input-label for="introduction" :value="__('Introduction')" />
-            <x-text-input id="introduction" class="block mt-1 w-full" type="text" name="introduction" :value="old('introduction')" required autofocus autocomplete="introduction" />
+            <x-text-input id="introduction" class="block mt-1 w-full" type="text" name="introduction"
+                :value="old('introduction')" required autofocus autocomplete="introduction" />
             <x-input-error :messages="$errors->get('introduction')" class="mt-2" />
         </div>
 
         <div class="flex items-center justify-end mt-4">
-            <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" href="{{ route('login') }}">
+            <a class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                href="{{ route('login') }}">
                 {{ __('Already registered?') }}
             </a>
 

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -34,19 +34,23 @@
             <div class="hidden sm:flex sm:items-center sm:ms-6">
                 <x-dropdown align="right" width="48">
                     <x-slot name="trigger">
-                        <button class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150">
+                        <button
+                            class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150">
                             <div>{{ Auth::user()->name }}</div>
 
                             <div class="ms-1">
-                                <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+                                <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg"
+                                    viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd"
+                                        d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+                                        clip-rule="evenodd" />
                                 </svg>
                             </div>
                         </button>
                     </x-slot>
 
                     <x-slot name="content">
-                        <x-dropdown-link :href="route('profile.edit')">
+                        <x-dropdown-link :href="route('profile.index')">
                             {{ __('Profile') }}
                         </x-dropdown-link>
 
@@ -66,10 +70,14 @@
 
             <!-- Hamburger -->
             <div class="-me-2 flex items-center sm:hidden">
-                <button @click="open = ! open" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
+                <button @click="open = ! open"
+                    class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
                     <svg class="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
-                        <path :class="{'hidden': open, 'inline-flex': ! open }" class="inline-flex" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                        <path :class="{'hidden': ! open, 'inline-flex': open }" class="hidden" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                        <path :class="{ 'hidden': open, 'inline-flex': !open }" class="inline-flex"
+                            stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                            d="M4 6h16M4 12h16M4 18h16" />
+                        <path :class="{ 'hidden': !open, 'inline-flex': open }" class="hidden" stroke-linecap="round"
+                            stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                     </svg>
                 </button>
             </div>
@@ -77,7 +85,7 @@
     </div>
 
     <!-- Responsive Navigation Menu -->
-    <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden">
+    <div :class="{ 'block': open, 'hidden': !open }" class="hidden sm:hidden">
         <div class="pt-2 pb-3 space-y-1">
             <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                 {{ __('Dashboard') }}
@@ -92,7 +100,7 @@
             </div>
 
             <div class="mt-3 space-y-1">
-                <x-responsive-nav-link :href="route('profile.edit')">
+                <x-responsive-nav-link :href="route('profile.index')">
                     {{ __('Profile') }}
                 </x-responsive-nav-link>
 

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -1,27 +1,9 @@
 <x-app-layout>
-    <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Profile') }}
-        </h2>
-    </x-slot>
-
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
             <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
                 <div class="max-w-xl">
                     @include('profile.partials.update-profile-information-form')
-                </div>
-            </div>
-
-            <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
-                <div class="max-w-xl">
-                    @include('profile.partials.update-password-form')
-                </div>
-            </div>
-
-            <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">
-                <div class="max-w-xl">
-                    @include('profile.partials.delete-user-form')
                 </div>
             </div>
         </div>

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -14,12 +14,12 @@
             <p>{{ $user->introduction }}</p>
             @if ($user->image)
                 <div>
-                    <img src="{{ $user->image }}" alt="画像が読み込めません。">
+                    <img src="{{ $user->image }}" alt="画像が読み込めません。" style="width: 300px;">
                 </div>
             @else
                 <div>
                     <img src="https://res.cloudinary.com/dnumegejl/image/upload/v1732344378/No_User_Image_genl0i.png"
-                        alt="画像が読み込めません。">
+                        alt="画像が読み込めません。" style="width: 300px;">
                 </div>
             @endif
         </div>

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -1,0 +1,27 @@
+<x-app-layout>
+    <h1 class="title">
+        プロフィール
+    </h1>
+    <div class="content">
+        <div class="content__user_profile">
+            <h3>ユーザー名</h3>
+            <p>{{ $user->name }}</p>
+            <h3>年齢</h3>
+            <p>{{ $user->age }}歳</p>
+            <h3>性別</h3>
+            <p>{{ $user->sex }}</p>
+            <h3>紹介文</h3>
+            <p>{{ $user->introduction }}</p>
+            @if ($user->image)
+                <div>
+                    <img src="{{ $user->image }}" alt="画像が読み込めません。">
+                </div>
+            @else
+                <div>
+                    <img src="https://res.cloudinary.com/dnumegejl/image/upload/v1732344378/No_User_Image_genl0i.png"
+                        alt="画像が読み込めません。">
+                </div>
+            @endif
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -24,4 +24,9 @@
             @endif
         </div>
     </div>
+    <div>
+        <a href="{{ route('profile.edit') }}">プロフィールの編集</a>
+        <a href="{{ route('profile.password') }}">パスワードの更新</a>
+        <a href="{{ route('profile.delete') }}" class="text-red-500">アカウント削除</a>
+    </div>
 </x-app-layout>

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -19,21 +19,24 @@
 
         <div>
             <x-input-label for="name" :value="__('Name')" />
-            <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" :value="old('name', $user->name)" required autofocus autocomplete="name" />
+            <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" :value="old('name', $user->name)"
+                required autofocus autocomplete="name" />
             <x-input-error class="mt-2" :messages="$errors->get('name')" />
         </div>
 
         <div>
             <x-input-label for="email" :value="__('Email')" />
-            <x-text-input id="email" name="email" type="email" class="mt-1 block w-full" :value="old('email', $user->email)" required autocomplete="username" />
+            <x-text-input id="email" name="email" type="email" class="mt-1 block w-full" :value="old('email', $user->email)"
+                required autocomplete="username" />
             <x-input-error class="mt-2" :messages="$errors->get('email')" />
 
-            @if ($user instanceof \Illuminate\Contracts\Auth\MustVerifyEmail && ! $user->hasVerifiedEmail())
+            @if ($user instanceof \Illuminate\Contracts\Auth\MustVerifyEmail && !$user->hasVerifiedEmail())
                 <div>
                     <p class="text-sm mt-2 text-gray-800">
                         {{ __('Your email address is unverified.') }}
 
-                        <button form="send-verification" class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                        <button form="send-verification"
+                            class="underline text-sm text-gray-600 hover:text-gray-900 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
                             {{ __('Click here to re-send the verification email.') }}
                         </button>
                     </p>
@@ -50,22 +53,22 @@
         <!-- Age -->
         <div class="mt-4">
             <x-input-label for="age" :value="__('Age')" />
-            <x-text-input id="age" class="block mt-1 w-full" type="number" min="0" name="age" :value="old('age')" required autocomplete="age" />
+            <x-text-input id="age" class="block mt-1 w-full" type="number" min="0" name="age"
+                :value="old('age', $user->age)" required autocomplete="age" />
             <x-input-error :messages="$errors->get('age')" class="mt-2" />
         </div>
 
         <!-- Sex -->
         <div class="mt-4">
             <x-input-label for="sex" :value="__('Sex')" />
-            <x-radio-input id="male" name="sex" value="male" :checked="old('sex') === 'male'" label="男性"/>
-            <x-radio-input id="female" name="sex" value="female" :checked="old('sex') === 'female'" label="女性"/>
-            <x-input-error :messages="$errors->get('sex')" class="mt-2" />
+            {{ $user->sex }}
         </div>
- 
+
         <!-- Introduction -->
         <div class="mt-4">
             <x-input-label for="introduction" :value="__('Introduction')" />
-            <x-text-input id="introduction" class="block mt-1 w-full" type="text" name="introduction" :value="old('introduction')" required autofocus autocomplete="introduction" />
+            <x-text-input id="introduction" class="block mt-1 w-full" type="text" name="introduction"
+                :value="old('introduction', $user->introduction)" required autofocus autocomplete="introduction" />
             <x-input-error :messages="$errors->get('introduction')" class="mt-2" />
         </div>
 
@@ -73,13 +76,8 @@
             <x-primary-button>{{ __('Save') }}</x-primary-button>
 
             @if (session('status') === 'profile-updated')
-                <p
-                    x-data="{ show: true }"
-                    x-show="show"
-                    x-transition
-                    x-init="setTimeout(() => show = false, 2000)"
-                    class="text-sm text-gray-600"
-                >{{ __('Saved.') }}</p>
+                <p x-data="{ show: true }" x-show="show" x-transition x-init="setTimeout(() => show = false, 2000)"
+                    class="text-sm text-gray-600">{{ __('Saved.') }}</p>
             @endif
         </div>
     </form>

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -13,7 +13,7 @@
         @csrf
     </form>
 
-    <form method="post" action="{{ route('profile.update') }}" class="mt-6 space-y-6">
+    <form method="post" action="{{ route('profile.update') }}" class="mt-6 space-y-6" enctype="multipart/form-data">
         @csrf
         @method('patch')
 
@@ -72,6 +72,22 @@
             <x-input-error :messages="$errors->get('introduction')" class="mt-2" />
         </div>
 
+        <!-- Image -->
+        @php
+            $existingImagePath = Auth::user()->image;
+        @endphp
+        <div id="existing_image_path" data-php-variable="{{ $existingImagePath }}"></div>
+        <div>
+            <x-input-label for="image" :value="__('User_Image')" />
+            <label>
+                <input id="image" class="block mt-1 w-full" type="file" name="image"
+                    :value="old('image', $user - > image)" style="display:none">画像の選択
+            </label>
+            <x-input-error :messages="$errors->get('image')" class="mt-2" />
+        </div>
+        <!-- プレビュー画像の表示 -->
+        <div id="preview" style="width: 300px;"></div>
+
         <div class="flex items-center gap-4">
             <x-primary-button>{{ __('Save') }}</x-primary-button>
 
@@ -82,3 +98,4 @@
         </div>
     </form>
 </section>
+<script src="{{ asset('/js/edit_profile_preview.js') }}"></script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -43,7 +43,19 @@ Route::get('/dashboard', function () {
 })->middleware(['auth', 'verified'])->name('dashboard');
 
 Route::middleware('auth')->group(function () {
-    Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
+    // ユーザー情報の表示
+    Route::get('/profile', [ProfileController::class, 'index'])->name('profile.index');
+    // ユーザー情報の編集
+    Route::get('/profile/edit', [ProfileController::class, 'edit'])->name('profile.edit');
+    // パスワードの更新画面の表示
+    Route::get('/profile/password', [ProfileController::class, 'editPassword'])->name('profile.password');
+    // パスワードの更新処理
+    Route::put('/profile/password', [ProfileController::class, 'updatePassword'])->name('profile.password.update');
+    // アカウント削除画面の表示
+    Route::get('/profile/delete', [ProfileController::class, 'confirmDelete'])->name('profile.delete');
+    // アカウント削除画面の表示
+    Route::delete('/profile/delete', [ProfileController::class, 'delete'])->name('profile.delete.confirm');
+    // 保険
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });


### PR DESCRIPTION
### プロフィール編集画面の作成

- #38 

・アカウント画面にプロフィール編集・パスワードの編集・アカウント削除のすべてがまとまっていたため、それぞれの画面に遷移できるようにして分離。
・編集画面で、名前、年齢、性別、紹介文、画像を変更可能に。
・画像変更時はプレビューの表示。
・Clip Studio PaintでNo Imageの画像を作成。
・画像の登録をしていない場合はNo Imageの画像を表示。
・画像変更時や削除時はCloudinaryからも削除できるようにコントローラーの修正。

・プロフィール画面
![スクリーンショット 2024-11-24 110707](https://github.com/user-attachments/assets/83a3da28-42ce-4f8e-9e30-06df5a196d0d)

・編集画面
![スクリーンショット 2024-11-24 110721](https://github.com/user-attachments/assets/fdad2815-c7ec-4477-a3b6-53088aaf6e9e)
