### PR TITLE
Feat：ユーザーの投稿をプロフィールに表示

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -87,21 +87,22 @@ class UserController extends Controller
         $posts = [];
 
         // 必要な種類の投稿を取得
+        // 合わせて投稿者情報をリレーションで取得
         switch ($type) {
             case 'work':
-                $posts = WorkReview::where('user_id', $user_id)->get();
+                $posts = WorkReview::where('user_id', $user_id)->with('user')->get();
                 break;
             case 'workStory':
-                $posts = WorkStoryPost::where('user_id', $user_id)->get();
+                $posts = WorkStoryPost::where('user_id', $user_id)->with('user')->get();
                 break;
             case 'character':
-                $posts = CharacterPost::where('user_id', $user_id)->get();
+                $posts = CharacterPost::where('user_id', $user_id)->with('user')->get();
                 break;
             case 'music':
-                $posts = MusicPost::where('user_id', $user_id)->get();
+                $posts = MusicPost::where('user_id', $user_id)->with('user')->get();
                 break;
             case 'animePilgrimage':
-                $posts = AnimePilgrimagePost::where('user_id', $user_id)->get();
+                $posts = AnimePilgrimagePost::where('user_id', $user_id)->with('user')->get();
                 break;
         }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -90,19 +90,19 @@ class UserController extends Controller
         // 合わせて投稿者情報をリレーションで取得
         switch ($type) {
             case 'work':
-                $posts = WorkReview::where('user_id', $user_id)->with('user')->get();
+                $posts = WorkReview::where('user_id', $user_id)->with(['user', 'work'])->get();
                 break;
             case 'workStory':
-                $posts = WorkStoryPost::where('user_id', $user_id)->with('user')->get();
+                $posts = WorkStoryPost::where('user_id', $user_id)->with(['user', 'work', 'workStory'])->get();
                 break;
             case 'character':
-                $posts = CharacterPost::where('user_id', $user_id)->with('user')->get();
+                $posts = CharacterPost::where('user_id', $user_id)->with(['user', 'character'])->get();
                 break;
             case 'music':
-                $posts = MusicPost::where('user_id', $user_id)->with('user')->get();
+                $posts = MusicPost::where('user_id', $user_id)->with(['user', 'music'])->get();
                 break;
             case 'animePilgrimage':
-                $posts = AnimePilgrimagePost::where('user_id', $user_id)->with('user')->get();
+                $posts = AnimePilgrimagePost::where('user_id', $user_id)->with(['user', 'animePilgrimage'])->get();
                 break;
         }
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -5,6 +5,11 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Models\User;
 use Illuminate\Support\Facades\Auth;
+use App\Models\WorkReview;
+use App\Models\WorkStoryPost;
+use App\Models\CharacterPost;
+use App\Models\MusicPost;
+use App\Models\AnimePilgrimagePost;
 
 class UserController extends Controller
 {
@@ -75,5 +80,31 @@ class UserController extends Controller
             'authFollowingCount' => $authFollowingCount,
             'authFollowersCount' => $authFollowersCount
         ]);
+    }
+
+    public function fetchPosts($user_id, $type)
+    {
+        $posts = [];
+
+        // 必要な種類の投稿を取得
+        switch ($type) {
+            case 'work':
+                $posts = WorkReview::where('user_id', $user_id)->get();
+                break;
+            case 'workStory':
+                $posts = WorkStoryPost::where('user_id', $user_id)->get();
+                break;
+            case 'character':
+                $posts = CharacterPost::where('user_id', $user_id)->get();
+                break;
+            case 'music':
+                $posts = MusicPost::where('user_id', $user_id)->get();
+                break;
+            case 'animePilgrimage':
+                $posts = AnimePilgrimagePost::where('user_id', $user_id)->get();
+                break;
+        }
+
+        return response()->json($posts);
     }
 }

--- a/database/migrations/2024_09_21_183305_create_anime_pilgrimage_posts_table.php
+++ b/database/migrations/2024_09_21_183305_create_anime_pilgrimage_posts_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->id();
             $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
             $table->foreignId('anime_pilgrimage_id')->constrained('anime_pilgrimages')->onDelete('cascade');
-            $table->string('title');
+            $table->string('post_title');
             $table->string('scene');
             $table->string('body');
             $table->string('image1')->nullable();

--- a/database/seeders/Anime_Pilgrimage_Post_Seeder.php
+++ b/database/seeders/Anime_Pilgrimage_Post_Seeder.php
@@ -17,7 +17,7 @@ class Anime_Pilgrimage_Post_Seeder extends Seeder
         DB::table('anime_pilgrimage_posts')->insert([
             'user_id' => 2,
             'anime_pilgrimage_id' => 1,
-            'title' => '雛見沢が見渡せる',
+            'post_title' => '雛見沢が見渡せる',
             'scene' => '雛見沢を一望する際の代表的なシーン',
             'body' => '行ってみて感動しました。',
             'created_at' => new DateTime(),
@@ -26,7 +26,7 @@ class Anime_Pilgrimage_Post_Seeder extends Seeder
         DB::table('anime_pilgrimage_posts')->insert([
             'user_id' => 5,
             'anime_pilgrimage_id' => 5,
-            'title' => '京都といえば',
+            'post_title' => '京都といえば',
             'scene' => 'らきすたの修学旅行回',
             'body' => '久々に清水寺に行きましたが...',
             'created_at' => new DateTime(),
@@ -34,8 +34,8 @@ class Anime_Pilgrimage_Post_Seeder extends Seeder
         ]);
         DB::table('anime_pilgrimage_posts')->insert([
             'user_id' => 3,
-            'anime_pilgrimage_id' =>4,
-            'title' => '聖地巡礼！',
+            'anime_pilgrimage_id' => 4,
+            'post_title' => '聖地巡礼！',
             'scene' => 'Aqoursのメンバーが行ってた水族館',
             'body' => '素晴らしいアクアリウムでした',
             'created_at' => new DateTime(),
@@ -44,7 +44,7 @@ class Anime_Pilgrimage_Post_Seeder extends Seeder
         DB::table('anime_pilgrimage_posts')->insert([
             'user_id' => 6,
             'anime_pilgrimage_id' => 2,
-            'title' => 'オヤシロ様を感じた',
+            'post_title' => 'オヤシロ様を感じた',
             'scene' => '古手神社',
             'body' => 'ここが梨花ちゃんの神社なんだなぁ',
             'created_at' => new DateTime(),
@@ -53,7 +53,7 @@ class Anime_Pilgrimage_Post_Seeder extends Seeder
         DB::table('anime_pilgrimage_posts')->insert([
             'user_id' => 1,
             'anime_pilgrimage_id' => 6,
-            'title' => 'めっちゃ映える橋',
+            'post_title' => 'めっちゃ映える橋',
             'scene' => 'コナンの映画',
             'body' => '歌に歌われていましたが実際見るといいですね。',
             'created_at' => new DateTime(),
@@ -62,7 +62,7 @@ class Anime_Pilgrimage_Post_Seeder extends Seeder
         DB::table('anime_pilgrimage_posts')->insert([
             'user_id' => 4,
             'anime_pilgrimage_id' => 3,
-            'title' => 'きっと青春が聞こえる',
+            'post_title' => 'きっと青春が聞こえる',
             'scene' => 'ミューズのメンバーが良く訪れていた神社',
             'body' => '感無量',
             'created_at' => new DateTime(),

--- a/public/js/fetch_post.js
+++ b/public/js/fetch_post.js
@@ -1,0 +1,40 @@
+// HTMLのdata属性から表示しているユーザーのidを取得
+const userIdTag = document.getElementById('user_id');
+const userId = userIdTag.dataset.userId;
+
+document.addEventListener('DOMContentLoaded', function () {
+    const postButtons = document.querySelectorAll('.post-button');
+    const postContainer = document.getElementById('post-container');
+
+    postButtons.forEach(button => {
+        button.addEventListener('click', async function () {
+            // ボタンに設定した data-type 属性の値を取得
+            const type = this.dataset.type;
+
+            try {
+                // データ取得
+                const response = await fetch(`/users/${userId}/posts/${type}`);
+                const posts = await response.json();
+
+                // 表示を更新
+                postContainer.innerHTML = '';
+                if (posts.length > 0) {
+                    posts.forEach(post => {
+                        const postElement = document.createElement('div');
+                        postElement.className = 'post-item p-4 mb-4 bg-gray-100 rounded shadow';
+                        postElement.innerHTML = `
+                            <h3 class="text-lg font-bold">${post.post_title || 'No Title'}</h3>
+                            <p class="text-gray-700">${post.body || 'No Content'}</p>
+                        `;
+                        postContainer.appendChild(postElement);
+                    });
+                } else {
+                    postContainer.innerHTML = '<p class="text-gray-500">投稿がありません。</p>';
+                }
+            } catch (error) {
+                console.error('Error fetching posts:', error);
+                postContainer.innerHTML = '<p class="text-red-500">投稿の取得に失敗しました。</p>';
+            }
+        });
+    });
+});

--- a/public/js/fetch_post.js
+++ b/public/js/fetch_post.js
@@ -14,14 +14,14 @@ document.addEventListener('DOMContentLoaded', async function () {
             // データの取得
             const response = await fetch(`/users/${userId}/posts/${type}`);
             const posts = await response.json();
-
             // 表示を更新
             postContainer.innerHTML = '';
             if (posts.length > 0) {
                 posts.forEach(post => {
-
                     // 投稿の種類に応じたURLを取得
                     const postDetailUrl = createTypeToURL(type, post);
+                    // 投稿の種類に応じた文言を取得
+                    const typeDescription = describeGroup(type, post);
 
                     const postElement = document.createElement('div');
                     postElement.className = 'post-item p-4 mb-4 bg-gray-100 rounded';
@@ -33,6 +33,7 @@ document.addEventListener('DOMContentLoaded', async function () {
                                 <a href="/users/${post.user.id}" class="text-lg font-bold">${post.user.name || '名無し'}</a>
                         </div>
                         <h3 class="text-lg font-bold">
+                            <p>${typeDescription}</p>
                             <a href="${postDetailUrl}" class="hover:underline">
                                 ${post.post_title || 'No Title'}
                             </a>
@@ -89,5 +90,25 @@ document.addEventListener('DOMContentLoaded', async function () {
         // 投稿の種類に応じたURLを取得
         const typeUrl = typeToUrlMap[type];
         return `/${typeUrl}/${post.id}`;
+    }
+
+    function describeGroup(type, post) {
+        // 各投稿の種類に追加する文言
+        const typeToGroup = {
+            // 作品感想の文言
+            work: `「${post.work?.name || '不明な作品'}」への感想投稿`,
+            // あらすじ感想の文言
+            workStory: `「${post.work?.name || '不明な作品'}」${post.work_story?.episode || '不明な話数'}「${post.work_story?.sub_title || '不明なサブタイトル'}」への感想投稿`,
+            // 登場人物感想の文言
+            character: `「${post.character?.name || '不明なキャラクター'}」への感想投稿`,
+            // 音楽感想の文言
+            music: `「${post.music?.name || '不明な音楽'}」への感想投稿`,
+            // 聖地感想の文言
+            animePilgrimage: `「${post.anime_pilgrimage?.name || '不明な聖地'}」への感想投稿`,
+        };
+
+        // 投稿の種類に応じたURLを取得
+        const typeGroup = typeToGroup[type];
+        return typeGroup;
     }
 });

--- a/public/js/fetch_post.js
+++ b/public/js/fetch_post.js
@@ -24,21 +24,31 @@ document.addEventListener('DOMContentLoaded', async function () {
                     const typeDescription = describeGroup(type, post);
 
                     const postElement = document.createElement('div');
-                    postElement.className = 'post-item p-4 mb-4 bg-gray-100 rounded';
+                    postElement.className = 'post-item p-4 mb-4 bg-gray-100 rounded max-w-3xl text-left';
                     postElement.innerHTML = `
                         <div class="post-header flex items-center mb-4">
                             <img src="${post.user.image || 'https://res.cloudinary.com/dnumegejl/image/upload/v1732628038/No_User_Image_wulbjv.png'}" 
-                                alt="${post.user.name}'s avatar" 
+                                alt="${post.user.name}のアバター" 
                                 class="w-10 h-10 rounded-full mr-4">
                                 <a href="/users/${post.user.id}" class="text-lg font-bold">${post.user.name || '名無し'}</a>
                         </div>
-                        <h3 class="text-lg font-bold">
-                            <p>${typeDescription}</p>
-                            <a href="${postDetailUrl}" class="hover:underline">
-                                ${post.post_title || 'No Title'}
-                            </a>
-                        </h3>
-                        <p class="text-gray-700">${post.body || 'No Content'}</p>
+                        <p>${typeDescription}</p>
+                        <div class="post-content flex items-start gap-4 max-w-[800px] mx-auto">
+                            <div class="flex-1">
+                                <h3 class="text-lg font-bold">
+                                    <a href="${postDetailUrl}" class="hover:underline">
+                    ${post.post_title || 'タイトルがありません'}
+                                    </a>
+                                </h3>
+                                <p class="text-gray-700">${post.body || '内容がありません'}</p>
+                            </div>
+                            ${post.image1 ? `
+                            <div class="flex-shrink-0">
+                                <img src="${post.image1}" 
+                 alt="投稿画像"
+                 class="w-24 h-24 object-cover rounded border border-gray-300">
+                            </div>` : ''}
+                        </div>
                     `;
                     postContainer.appendChild(postElement);
                 });

--- a/public/js/fetch_post.js
+++ b/public/js/fetch_post.js
@@ -2,39 +2,92 @@
 const userIdTag = document.getElementById('user_id');
 const userId = userIdTag.dataset.userId;
 
-document.addEventListener('DOMContentLoaded', function () {
+document.addEventListener('DOMContentLoaded', async function () {
     const postButtons = document.querySelectorAll('.post-button');
     const postContainer = document.getElementById('post-container');
+    // デフォルトの投稿の種類
+    const defaultType = 'work';
 
+    // デフォルトの投稿を読み込む
+    async function fetchAndDisplayPosts(type) {
+        try {
+            // データの取得
+            const response = await fetch(`/users/${userId}/posts/${type}`);
+            const posts = await response.json();
+
+            // 表示を更新
+            postContainer.innerHTML = '';
+            if (posts.length > 0) {
+                posts.forEach(post => {
+
+                    // 投稿の種類に応じたURLを取得
+                    const postDetailUrl = createTypeToURL(type, post);
+
+                    const postElement = document.createElement('div');
+                    postElement.className = 'post-item p-4 mb-4 bg-gray-100 rounded';
+                    postElement.innerHTML = `
+                        <div class="post-header flex items-center mb-4">
+                            <img src="${post.user.image || 'https://res.cloudinary.com/dnumegejl/image/upload/v1732628038/No_User_Image_wulbjv.png'}" 
+                                alt="${post.user.name}'s avatar" 
+                                class="w-10 h-10 rounded-full mr-4">
+                                <a href="/users/${post.user.id}" class="text-lg font-bold">${post.user.name || '名無し'}</a>
+                        </div>
+                        <h3 class="text-lg font-bold">
+                            <a href="${postDetailUrl}" class="hover:underline">
+                                ${post.post_title || 'No Title'}
+                            </a>
+                        </h3>
+                        <p class="text-gray-700">${post.body || 'No Content'}</p>
+                    `;
+                    postContainer.appendChild(postElement);
+                });
+            } else {
+                postContainer.innerHTML = '<p class="text-gray-500">投稿がありません。</p>';
+            }
+        } catch (error) {
+            console.error('Error fetching posts:', error);
+            postContainer.innerHTML = '<p class="text-red-500">投稿の取得に失敗しました。</p>';
+        }
+    }
+
+    // 初期の読み込み
+    await fetchAndDisplayPosts(defaultType);
+
+    // ボタンの切り替えイベント
     postButtons.forEach(button => {
         button.addEventListener('click', async function () {
-            // ボタンに設定した data-type 属性の値を取得
+            // 押下したボタンの種類を取得
             const type = this.dataset.type;
 
-            try {
-                // データ取得
-                const response = await fetch(`/users/${userId}/posts/${type}`);
-                const posts = await response.json();
+            // ボタンのスタイルを更新
+            postButtons.forEach(btn => {
+                btn.classList.remove('active', 'bg-blue-500', 'text-white');
+                btn.classList.add('bg-blue-300', 'text-white');
+            });
+            this.classList.add('active', 'bg-blue-500', 'text-white');
 
-                // 表示を更新
-                postContainer.innerHTML = '';
-                if (posts.length > 0) {
-                    posts.forEach(post => {
-                        const postElement = document.createElement('div');
-                        postElement.className = 'post-item p-4 mb-4 bg-gray-100 rounded shadow';
-                        postElement.innerHTML = `
-                            <h3 class="text-lg font-bold">${post.post_title || 'No Title'}</h3>
-                            <p class="text-gray-700">${post.body || 'No Content'}</p>
-                        `;
-                        postContainer.appendChild(postElement);
-                    });
-                } else {
-                    postContainer.innerHTML = '<p class="text-gray-500">投稿がありません。</p>';
-                }
-            } catch (error) {
-                console.error('Error fetching posts:', error);
-                postContainer.innerHTML = '<p class="text-red-500">投稿の取得に失敗しました。</p>';
-            }
+            // 投稿データを更新
+            await fetchAndDisplayPosts(type);
         });
     });
+
+    function createTypeToURL(type, post) {
+        // 各投稿の種類のURL
+        const typeToUrlMap = {
+            // 作品感想の詳細ページ
+            work: `work_reviews/${post.work_id}/reviews`,
+            // あらすじ感想の詳細ページ
+            workStory: `works/${post.work_id}/stories/${post.sub_title_id}/posts`,
+            // 登場人物感想の詳細ページ
+            character: `character_posts/${post.character_id}/posts`,
+            // 音楽感想の詳細ページ
+            music: `music_posts/${post.music_id}/posts`,
+            // 聖地感想の詳細ページ
+            animePilgrimage: `pilgrimage_posts/${post.anime_pilgrimage_id}/posts`,
+        };
+
+        // 投稿の種類に応じたURLを取得
+        const typeUrl = typeToUrlMap[type];
+        return `/${typeUrl}/${post.id}`;
+    }
 });

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -51,16 +51,11 @@
         <a href="{{ route('profile.delete') }}" class="text-red-500">アカウント削除</a>
     </div>
     <div class="post-buttons flex space-x-4">
-        <button class="post-button bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
-            data-type="work">作品感想</button>
-        <button class="post-button bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
-            data-type="workStory">あらすじ感想</button>
-        <button class="post-button bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
-            data-type="character">登場人物感想</button>
-        <button class="post-button bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
-            data-type="music">音楽感想</button>
-        <button class="post-button bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
-            data-type="animePilgrimage">聖地感想</button>
+        <button class="post-button active bg-blue-500 text-white px-4 py-2 rounded" data-type="work">作品感想</button>
+        <button class="post-button bg-blue-300 text-white px-4 py-2 rounded" data-type="workStory">あらすじ感想</button>
+        <button class="post-button bg-blue-300 text-white px-4 py-2 rounded" data-type="character">登場人物感想</button>
+        <button class="post-button bg-blue-300 text-white px-4 py-2 rounded" data-type="music">音楽感想</button>
+        <button class="post-button bg-blue-300 text-white px-4 py-2 rounded" data-type="animePilgrimage">聖地感想</button>
     </div>
     <div id="post-container" class="mt-4">
         <!-- 投稿データの表示 -->

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -50,4 +50,21 @@
         <a href="{{ route('profile.password') }}">パスワードの更新</a>
         <a href="{{ route('profile.delete') }}" class="text-red-500">アカウント削除</a>
     </div>
+    <div class="post-buttons flex space-x-4">
+        <button class="post-button bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+            data-type="work">作品感想</button>
+        <button class="post-button bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+            data-type="workStory">あらすじ感想</button>
+        <button class="post-button bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+            data-type="character">登場人物感想</button>
+        <button class="post-button bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+            data-type="music">音楽感想</button>
+        <button class="post-button bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+            data-type="animePilgrimage">聖地感想</button>
+    </div>
+    <div id="post-container" class="mt-4">
+        <!-- 投稿データの表示 -->
+    </div>
+    <div id="user_id" data-user-id="{{ $user->id }}"></div>
+    <script src="{{ asset('/js/fetch_post.js') }}"></script>
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -271,6 +271,8 @@ Route::controller(UserController::class)->middleware(['auth'])->group(function (
     Route::get('/users/{user_id}', 'show')->name('users.show');
     // ユーザーをフォローするメソッドを実行
     Route::post('/users/{user_id}/follow', 'follow')->name('users.follow');
+    // ユーザーの投稿を表示するメソッドを実行
+    Route::get('/users/{user_id}/posts/{type}', 'fetchPosts')->name('users.fetchPosts');
 });
 
 // UserFollowControllerに関するルーティング


### PR DESCRIPTION
### ユーザーの投稿をプロフィールに表示

・ユーザーの投稿を各投稿の種類ごとにプロフィールに表示する
・リレーションによって、投稿者のアイコンと名前の表示
・リレーションによって、感想の対象の表示（例：「魔法少女まどか☆マギカ」への感想投稿）
・投稿者名と投稿タイトルに、それぞれ詳細画面に遷移するリンクを追加
・各投稿に画像が登録されていれば画像をタイトルの横に表示

・プロフィール画面に表示された投稿
![image](https://github.com/user-attachments/assets/e0e9425c-8ace-4cb3-b71e-067a2082927c)
