### PR TITLE
Feat：ログインしているユーザーの投稿一覧に検索機能の追加

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -82,29 +82,12 @@ class UserController extends Controller
         ]);
     }
 
-    public function fetchPosts($user_id, $type)
+    public function fetchPosts(Request $request, User $user, $user_id, $type)
     {
-        $posts = [];
-
+        // 検索キーワードがあれば取得
+        $keyword = $request->input('keyword', '');
         // 必要な種類の投稿を取得
-        // 合わせて投稿者情報をリレーションで取得
-        switch ($type) {
-            case 'work':
-                $posts = WorkReview::where('user_id', $user_id)->with(['user', 'work'])->get();
-                break;
-            case 'workStory':
-                $posts = WorkStoryPost::where('user_id', $user_id)->with(['user', 'work', 'workStory'])->get();
-                break;
-            case 'character':
-                $posts = CharacterPost::where('user_id', $user_id)->with(['user', 'character'])->get();
-                break;
-            case 'music':
-                $posts = MusicPost::where('user_id', $user_id)->with(['user', 'music'])->get();
-                break;
-            case 'animePilgrimage':
-                $posts = AnimePilgrimagePost::where('user_id', $user_id)->with(['user', 'animePilgrimage'])->get();
-                break;
-        }
+        $posts = $user->fetchPosts($user_id, $type, $keyword);
 
         return response()->json($posts);
     }

--- a/app/Http/Requests/PilgrimagePostRequest.php
+++ b/app/Http/Requests/PilgrimagePostRequest.php
@@ -15,7 +15,7 @@ class PilgrimagePostRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'pilgrimage_post.title' => 'required|string|max:100',
+            'pilgrimage_post.post_title' => 'required|string|max:100',
             'pilgrimage_post.scene' => 'required|string|max:200',
             'pilgrimage_post.body' => 'required|string|max:4000',
             'images' => 'array|max:4'

--- a/app/Models/AnimePilgrimagePost.php
+++ b/app/Models/AnimePilgrimagePost.php
@@ -13,7 +13,7 @@ class AnimePilgrimagePost extends Model
     protected $fillable = [
         'user_id',
         'anime_pilgrimage_id',
-        'title',
+        'post_title',
         'scene',
         'body',
         'image1',

--- a/app/Models/AnimePilgrimagePost.php
+++ b/app/Models/AnimePilgrimagePost.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 class AnimePilgrimagePost extends Model
 {
     use HasFactory;
+    use SerializeDate;
 
     // fillを実行するための記述
     protected $fillable = [

--- a/app/Models/AnimePilgrimagePost.php
+++ b/app/Models/AnimePilgrimagePost.php
@@ -25,6 +25,10 @@ class AnimePilgrimagePost extends Model
     // 参照させたいanime_pilgrimage_postsを指定
     protected $table = 'anime_pilgrimage_posts';
 
+    protected $casts = [
+        'created_at' => 'datetime:Y/m/d H:i',
+    ];
+
     // 聖地idと投稿idを指定して、投稿の詳細表示を行う
     public function getDetailPost($pilgrimage_id, $pilgrimage_post_id)
     {

--- a/app/Models/CharacterPost.php
+++ b/app/Models/CharacterPost.php
@@ -26,6 +26,10 @@ class CharacterPost extends Model
     // 参照させたいcharacter_postsを指定
     protected $table = 'character_posts';
 
+    protected $casts = [
+        'created_at' => 'datetime:Y/m/d H:i',
+    ];
+
     // Characterに対するリレーション 1対1の関係
     public function character()
     {

--- a/app/Models/CharacterPost.php
+++ b/app/Models/CharacterPost.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 class CharacterPost extends Model
 {
     use HasFactory;
+    use SerializeDate;
 
     // fillを実行するための記述
     protected $fillable = [

--- a/app/Models/MusicPost.php
+++ b/app/Models/MusicPost.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 class MusicPost extends Model
 {
     use HasFactory;
+    use SerializeDate;
 
     // fillを実行するための記述
     protected $fillable = [

--- a/app/Models/MusicPost.php
+++ b/app/Models/MusicPost.php
@@ -22,6 +22,10 @@ class MusicPost extends Model
     // 参照させたいmusic_postsを指定
     protected $table = 'music_posts';
 
+    protected $casts = [
+        'created_at' => 'datetime:Y/m/d H:i',
+    ];
+
     // Musicに対するリレーション 1対1の関係
     public function music()
     {

--- a/app/Models/SerializeDate.php
+++ b/app/Models/SerializeDate.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use DateTimeInterface;
+
+trait SerializeDate
+{
+    /**
+     * Prepare a date for array / JSON serialization.
+     *
+     * @param  \DateTimeInterface  $date
+     * @return string
+     */
+    protected function serializeDate(DateTimeInterface $date)
+    {
+        return $date->format('Y-m-d H:i:s');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -50,6 +50,111 @@ class User extends Authenticatable
         'password' => 'hashed',
     ];
 
+    // 投稿の種類とユーザーidで投稿を取得する処理
+    public function fetchPosts($user_id, $type, $search)
+    {
+        // 必要な種類の投稿を取得
+        // 合わせて投稿者情報をリレーションで取得
+        switch ($type) {
+            case 'work':
+                $posts = WorkReview::where('user_id', $user_id)
+                    ->with(['user', 'work'])
+                    ->where(function ($query) use ($search) {
+                        // キーワード検索がなされた場合
+                        if ($search != '') {
+                            // 検索語のスペースを半角に統一
+                            $search_split = mb_convert_kana($search, 's');
+                            // 半角スペースで単語ごとに分割して配列にする
+                            $search_array = preg_split('/[\s]+/', $search_split);
+                            foreach ($search_array as $search_word) {
+                                $query->where(function ($query) use ($search_word) {
+                                    $query->where('post_title', 'LIKE', "%{$search_word}%")
+                                        ->orWhere('body', 'LIKE', "%{$search_word}%");
+                                });
+                            }
+                        }
+                    })->get();
+                break;
+            case 'workStory':
+                $posts = WorkStoryPost::where('user_id', $user_id)
+                    ->with(['user', 'work', 'workStory'])
+                    ->where(function ($query) use ($search) {
+                        // キーワード検索がなされた場合
+                        if ($search != '') {
+                            // 検索語のスペースを半角に統一
+                            $search_split = mb_convert_kana($search, 's');
+                            // 半角スペースで単語ごとに分割して配列にする
+                            $search_array = preg_split('/[\s]+/', $search_split);
+                            foreach ($search_array as $search_word) {
+                                $query->where(function ($query) use ($search_word) {
+                                    $query->where('post_title', 'LIKE', "%{$search_word}%")
+                                        ->orWhere('body', 'LIKE', "%{$search_word}%");
+                                });
+                            }
+                        }
+                    })->get();
+                break;
+            case 'character':
+                $posts = CharacterPost::where('user_id', $user_id)
+                    ->with(['user', 'character'])
+                    ->where(function ($query) use ($search) {
+                        // キーワード検索がなされた場合
+                        if ($search != '') {
+                            // 検索語のスペースを半角に統一
+                            $search_split = mb_convert_kana($search, 's');
+                            // 半角スペースで単語ごとに分割して配列にする
+                            $search_array = preg_split('/[\s]+/', $search_split);
+                            foreach ($search_array as $search_word) {
+                                $query->where(function ($query) use ($search_word) {
+                                    $query->where('post_title', 'LIKE', "%{$search_word}%")
+                                        ->orWhere('body', 'LIKE', "%{$search_word}%");
+                                });
+                            }
+                        }
+                    })->get();
+                break;
+            case 'music':
+                $posts = MusicPost::where('user_id', $user_id)
+                    ->with(['user', 'music'])
+                    ->where(function ($query) use ($search) {
+                        // キーワード検索がなされた場合
+                        if ($search != '') {
+                            // 検索語のスペースを半角に統一
+                            $search_split = mb_convert_kana($search, 's');
+                            // 半角スペースで単語ごとに分割して配列にする
+                            $search_array = preg_split('/[\s]+/', $search_split);
+                            foreach ($search_array as $search_word) {
+                                $query->where(function ($query) use ($search_word) {
+                                    $query->where('post_title', 'LIKE', "%{$search_word}%")
+                                        ->orWhere('body', 'LIKE', "%{$search_word}%");
+                                });
+                            }
+                        }
+                    })->get();
+                break;
+            case 'animePilgrimage':
+                $posts = AnimePilgrimagePost::where('user_id', $user_id)
+                    ->with(['user', 'animePilgrimage'])
+                    ->where(function ($query) use ($search) {
+                        // キーワード検索がなされた場合
+                        if ($search != '') {
+                            // 検索語のスペースを半角に統一
+                            $search_split = mb_convert_kana($search, 's');
+                            // 半角スペースで単語ごとに分割して配列にする
+                            $search_array = preg_split('/[\s]+/', $search_split);
+                            foreach ($search_array as $search_word) {
+                                $query->where(function ($query) use ($search_word) {
+                                    $query->where('post_title', 'LIKE', "%{$search_word}%")
+                                        ->orWhere('body', 'LIKE', "%{$search_word}%");
+                                });
+                            }
+                        }
+                    })->get();
+                break;
+        }
+        return $posts;
+    }
+
     // WorkReviewに対するリレーション 1対1の関係
     public function workreview()
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -74,12 +74,13 @@ class User extends Authenticatable
 
                                     // リレーション先のWorksテーブルのカラムでの検索
                                     $query->orWhereHas('work', function ($workQuery) use ($search_word) {
-                                        $workQuery->where('name', 'like', '%' . $search_word . '%');
+                                        $workQuery->where('name', 'like', '%' . $search_word . '%')
+                                            ->orWhere('term', 'like', '%' . $search_word . '%');
                                     });
                                 });
                             }
                         }
-                    })->get();
+                    })->paginate(10);
                 break;
             case 'workStory':
                 $posts = WorkStoryPost::where('user_id', $user_id)
@@ -99,7 +100,8 @@ class User extends Authenticatable
 
                                     // リレーション先のWorksテーブルのカラムでの検索
                                     $query->orWhereHas('work', function ($workQuery) use ($search_word) {
-                                        $workQuery->where('name', 'like', '%' . $search_word . '%');
+                                        $workQuery->where('name', 'like', '%' . $search_word . '%')
+                                            ->orWhere('term', 'like', '%' . $search_word . '%');
                                     });
 
                                     // リレーション先のWork_storiesテーブルのカラムでの検索
@@ -110,7 +112,7 @@ class User extends Authenticatable
                                 });
                             }
                         }
-                    })->get();
+                    })->paginate(10);
                 break;
             case 'character':
                 $posts = CharacterPost::where('user_id', $user_id)
@@ -134,7 +136,8 @@ class User extends Authenticatable
 
                                         // リレーション先のWorksテーブルのカラムでの検索
                                         $characterQuery->orWhereHas('work', function ($workQuery) use ($search_word) {
-                                            $workQuery->where('name', 'LIKE', "%{$search_word}%");
+                                            $workQuery->where('name', 'LIKE', "%{$search_word}%")
+                                                ->orWhere('term', 'like', '%' . $search_word . '%');
                                         });
 
                                         // リレーション先のvoice_artistsテーブルのカラムでの検索
@@ -145,7 +148,7 @@ class User extends Authenticatable
                                 });
                             }
                         }
-                    })->get();
+                    })->paginate(10);
                 break;
             case 'music':
                 $posts = MusicPost::where('user_id', $user_id)
@@ -169,7 +172,8 @@ class User extends Authenticatable
 
                                         // リレーション先のWorksテーブルのカラムでの検索
                                         $musicQuery->orWhereHas('work', function ($workQuery) use ($search_word) {
-                                            $workQuery->where('name', 'LIKE', "%{$search_word}%");
+                                            $workQuery->where('name', 'LIKE', "%{$search_word}%")
+                                                ->orWhere('term', 'like', '%' . $search_word . '%');
                                         });
 
                                         // リレーション先のsingersテーブルのカラムでの検索
@@ -180,7 +184,7 @@ class User extends Authenticatable
                                 });
                             }
                         }
-                    })->get();
+                    })->paginate(10);
                 break;
             case 'animePilgrimage':
                 $posts = AnimePilgrimagePost::where('user_id', $user_id)
@@ -206,13 +210,14 @@ class User extends Authenticatable
 
                                         // リレーション先のWorksテーブルのカラムでの検索
                                         $animePilgrimageQuery->orWhereHas('work', function ($workQuery) use ($search_word) {
-                                            $workQuery->where('name', 'LIKE', "%{$search_word}%");
+                                            $workQuery->where('name', 'LIKE', "%{$search_word}%")
+                                                ->orWhere('term', 'like', '%' . $search_word . '%');
                                         });;
                                     });
                                 });
                             }
                         }
-                    })->get();
+                    })->paginate(10);
                 break;
         }
         return $posts;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -81,6 +81,7 @@ class User extends Authenticatable
                             }
                         }
                     })->orderBy('created_at', 'DESC')->paginate(10);
+                $this->addPostType($posts, $type);
                 break;
             case 'workStory':
                 $posts = WorkStoryPost::where('user_id', $user_id)
@@ -113,6 +114,7 @@ class User extends Authenticatable
                             }
                         }
                     })->orderBy('created_at', 'DESC')->paginate(10);
+                $this->addPostType($posts, $type);
                 break;
             case 'character':
                 $posts = CharacterPost::where('user_id', $user_id)
@@ -149,6 +151,7 @@ class User extends Authenticatable
                             }
                         }
                     })->orderBy('created_at', 'DESC')->paginate(10);
+                $this->addPostType($posts, $type);
                 break;
             case 'music':
                 $posts = MusicPost::where('user_id', $user_id)
@@ -185,6 +188,7 @@ class User extends Authenticatable
                             }
                         }
                     })->orderBy('created_at', 'DESC')->paginate(10);
+                $this->addPostType($posts, $type);
                 break;
             case 'animePilgrimage':
                 $posts = AnimePilgrimagePost::where('user_id', $user_id)
@@ -218,9 +222,30 @@ class User extends Authenticatable
                             }
                         }
                     })->orderBy('created_at', 'DESC')->paginate(10);
+                $this->addPostType($posts, $type);
                 break;
         }
         return $posts;
+    }
+
+    // 取得した投稿に投稿の種類を付与する処理
+    public function addPostType($posts, $type)
+    {
+        // 投稿の種類
+        $postTypes = [
+            'work' => '作品感想',
+            'workStory' => 'あらすじ感想',
+            'character' => '登場人物感想',
+            'music' => '音楽感想',
+            'animePilgrimage' => '聖地感想',
+        ];
+
+        // 各投稿に postType を追加
+        $posts->getCollection()->transform(function ($post) use ($postTypes, $type) {
+            // 任意の種類を設定
+            $post->postType = $postTypes[$type];
+            return $post;
+        });
     }
 
     // WorkReviewに対するリレーション 1対1の関係

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -68,8 +68,14 @@ class User extends Authenticatable
                             $search_array = preg_split('/[\s]+/', $search_split);
                             foreach ($search_array as $search_word) {
                                 $query->where(function ($query) use ($search_word) {
+                                    // 自身のカラムでの検索
                                     $query->where('post_title', 'LIKE', "%{$search_word}%")
                                         ->orWhere('body', 'LIKE', "%{$search_word}%");
+
+                                    // リレーション先のWorksテーブルのカラムでの検索
+                                    $query->orWhereHas('work', function ($workQuery) use ($search_word) {
+                                        $workQuery->where('name', 'like', '%' . $search_word . '%');
+                                    });
                                 });
                             }
                         }
@@ -87,8 +93,20 @@ class User extends Authenticatable
                             $search_array = preg_split('/[\s]+/', $search_split);
                             foreach ($search_array as $search_word) {
                                 $query->where(function ($query) use ($search_word) {
+                                    // 自身のカラムでの検索
                                     $query->where('post_title', 'LIKE', "%{$search_word}%")
                                         ->orWhere('body', 'LIKE', "%{$search_word}%");
+
+                                    // リレーション先のWorksテーブルのカラムでの検索
+                                    $query->orWhereHas('work', function ($workQuery) use ($search_word) {
+                                        $workQuery->where('name', 'like', '%' . $search_word . '%');
+                                    });
+
+                                    // リレーション先のWork_storiesテーブルのカラムでの検索
+                                    $query->orWhereHas('workStory', function ($workStoryQuery) use ($search_word) {
+                                        $workStoryQuery->where('sub_title', 'like', '%' . $search_word . '%')
+                                            ->orWhere('episode', 'like', '%' . $search_word . '%');
+                                    });
                                 });
                             }
                         }
@@ -96,7 +114,7 @@ class User extends Authenticatable
                 break;
             case 'character':
                 $posts = CharacterPost::where('user_id', $user_id)
-                    ->with(['user', 'character'])
+                    ->with(['user', 'character', 'character.work', 'character.voiceArtist'])
                     ->where(function ($query) use ($search) {
                         // キーワード検索がなされた場合
                         if ($search != '') {
@@ -106,8 +124,24 @@ class User extends Authenticatable
                             $search_array = preg_split('/[\s]+/', $search_split);
                             foreach ($search_array as $search_word) {
                                 $query->where(function ($query) use ($search_word) {
+                                    // 自身のカラムでの検索
                                     $query->where('post_title', 'LIKE', "%{$search_word}%")
                                         ->orWhere('body', 'LIKE', "%{$search_word}%");
+
+                                    // リレーション先のCharactersテーブルのカラムでの検索
+                                    $query->orWhereHas('character', function ($characterQuery) use ($search_word) {
+                                        $characterQuery->where('name', 'like', '%' . $search_word . '%');
+
+                                        // リレーション先のWorksテーブルのカラムでの検索
+                                        $characterQuery->orWhereHas('work', function ($workQuery) use ($search_word) {
+                                            $workQuery->where('name', 'LIKE', "%{$search_word}%");
+                                        });
+
+                                        // リレーション先のvoice_artistsテーブルのカラムでの検索
+                                        $characterQuery->orWhereHas('voiceArtist', function ($voiceArtistQuery) use ($search_word) {
+                                            $voiceArtistQuery->where('name', 'LIKE', "%{$search_word}%");
+                                        });
+                                    });
                                 });
                             }
                         }
@@ -115,7 +149,7 @@ class User extends Authenticatable
                 break;
             case 'music':
                 $posts = MusicPost::where('user_id', $user_id)
-                    ->with(['user', 'music'])
+                    ->with(['user', 'music', 'music.work', 'music.singer'])
                     ->where(function ($query) use ($search) {
                         // キーワード検索がなされた場合
                         if ($search != '') {
@@ -125,8 +159,24 @@ class User extends Authenticatable
                             $search_array = preg_split('/[\s]+/', $search_split);
                             foreach ($search_array as $search_word) {
                                 $query->where(function ($query) use ($search_word) {
+                                    // 自身のカラムでの検索
                                     $query->where('post_title', 'LIKE', "%{$search_word}%")
                                         ->orWhere('body', 'LIKE', "%{$search_word}%");
+
+                                    // リレーション先のMusicsテーブルのカラムでの検索
+                                    $query->orWhereHas('music', function ($musicQuery) use ($search_word) {
+                                        $musicQuery->where('name', 'like', '%' . $search_word . '%');
+
+                                        // リレーション先のWorksテーブルのカラムでの検索
+                                        $musicQuery->orWhereHas('work', function ($workQuery) use ($search_word) {
+                                            $workQuery->where('name', 'LIKE', "%{$search_word}%");
+                                        });
+
+                                        // リレーション先のsingersテーブルのカラムでの検索
+                                        $musicQuery->orWhereHas('singer', function ($singerQuery) use ($search_word) {
+                                            $singerQuery->where('name', 'LIKE', "%{$search_word}%");
+                                        });
+                                    });
                                 });
                             }
                         }
@@ -144,8 +194,21 @@ class User extends Authenticatable
                             $search_array = preg_split('/[\s]+/', $search_split);
                             foreach ($search_array as $search_word) {
                                 $query->where(function ($query) use ($search_word) {
+                                    // 自身のカラムでの検索
                                     $query->where('post_title', 'LIKE', "%{$search_word}%")
-                                        ->orWhere('body', 'LIKE', "%{$search_word}%");
+                                        ->orWhere('body', 'LIKE', "%{$search_word}%")
+                                        ->orWhere('scene', 'LIKE', "%{$search_word}%");
+
+                                    // リレーション先のanime_pilgrimagesテーブルのカラムでの検索
+                                    $query->orWhereHas('animePilgrimage', function ($animePilgrimageQuery) use ($search_word) {
+                                        $animePilgrimageQuery->where('name', 'like', '%' . $search_word . '%')
+                                            ->orWhere('place', 'LIKE', "%{$search_word}%");
+
+                                        // リレーション先のWorksテーブルのカラムでの検索
+                                        $animePilgrimageQuery->orWhereHas('work', function ($workQuery) use ($search_word) {
+                                            $workQuery->where('name', 'LIKE', "%{$search_word}%");
+                                        });;
+                                    });
                                 });
                             }
                         }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -80,7 +80,7 @@ class User extends Authenticatable
                                 });
                             }
                         }
-                    })->paginate(10);
+                    })->orderBy('created_at', 'DESC')->paginate(10);
                 break;
             case 'workStory':
                 $posts = WorkStoryPost::where('user_id', $user_id)
@@ -112,7 +112,7 @@ class User extends Authenticatable
                                 });
                             }
                         }
-                    })->paginate(10);
+                    })->orderBy('created_at', 'DESC')->paginate(10);
                 break;
             case 'character':
                 $posts = CharacterPost::where('user_id', $user_id)
@@ -148,7 +148,7 @@ class User extends Authenticatable
                                 });
                             }
                         }
-                    })->paginate(10);
+                    })->orderBy('created_at', 'DESC')->paginate(10);
                 break;
             case 'music':
                 $posts = MusicPost::where('user_id', $user_id)
@@ -184,7 +184,7 @@ class User extends Authenticatable
                                 });
                             }
                         }
-                    })->paginate(10);
+                    })->orderBy('created_at', 'DESC')->paginate(10);
                 break;
             case 'animePilgrimage':
                 $posts = AnimePilgrimagePost::where('user_id', $user_id)
@@ -217,7 +217,7 @@ class User extends Authenticatable
                                 });
                             }
                         }
-                    })->paginate(10);
+                    })->orderBy('created_at', 'DESC')->paginate(10);
                 break;
         }
         return $posts;

--- a/app/Models/WorkReview.php
+++ b/app/Models/WorkReview.php
@@ -24,6 +24,10 @@ class WorkReview extends Model
     // 参照させたいwork_reviewsを指定
     protected $table = 'work_reviews';
 
+    protected $casts = [
+        'created_at' => 'datetime:Y/m/d H:i',
+    ];
+
     // created_atで降順に並べたあと、limitで件数制限をかける
     public function getPaginateByLimit($work_id, int $limit_count = 5)
     {

--- a/app/Models/WorkReview.php
+++ b/app/Models/WorkReview.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 class WorkReview extends Model
 {
     use HasFactory;
+    use SerializeDate;
 
     // fillを実行するための記述
     protected $fillable = [

--- a/app/Models/WorkStoryPost.php
+++ b/app/Models/WorkStoryPost.php
@@ -25,6 +25,10 @@ class WorkStoryPost extends Model
     // 参照させたいwork_story_postsを指定
     protected $table = 'work_story_posts';
 
+    protected $casts = [
+        'created_at' => 'datetime:Y/m/d H:i',
+    ];
+
     // あらすじidと投稿idを指定して、投稿の詳細表示を行う
     public function getDetailPost($work_story_id, $work_story_post_id)
     {

--- a/app/Models/WorkStoryPost.php
+++ b/app/Models/WorkStoryPost.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 class WorkStoryPost extends Model
 {
     use HasFactory;
+    use SerializeDate;
 
     // fillを実行するための記述
     protected $fillable = [

--- a/public/js/fetch_post.js
+++ b/public/js/fetch_post.js
@@ -58,6 +58,7 @@ document.addEventListener('DOMContentLoaded', async function () {
                                 class="w-10 h-10 rounded-full mr-4">
                                 <a href="/users/${post.user.id}" class="text-lg font-bold">${post.user.name || '名無し'}</a>
                         </div>
+                        <p>${post.created_at}</p>
                         <p>${typeDescription}</p>
                         <div class="post-content flex items-start gap-4 max-w-[800px] mx-auto">
                             <div class="flex-1">

--- a/public/js/fetch_post.js
+++ b/public/js/fetch_post.js
@@ -58,6 +58,7 @@ document.addEventListener('DOMContentLoaded', async function () {
                                 class="w-10 h-10 rounded-full mr-4">
                                 <a href="/users/${post.user.id}" class="text-lg font-bold">${post.user.name || '名無し'}</a>
                         </div>
+                        <p>${post.postType}</p>
                         <p>${post.created_at}</p>
                         <p>${typeDescription}</p>
                         <div class="post-content flex items-start gap-4 max-w-[800px] mx-auto">

--- a/public/js/fetch_post.js
+++ b/public/js/fetch_post.js
@@ -11,11 +11,15 @@ document.addEventListener('DOMContentLoaded', async function () {
     // デフォルトの投稿を読み込む
     async function fetchAndDisplayPosts(type) {
         try {
+            // 検索キーワードを取得
+            const searchInput = document.getElementById('search-input').value.trim();
+
             // データの取得
-            const response = await fetch(`/users/${userId}/posts/${type}`);
+            const response = await fetch(`/users/${userId}/posts/${type}?keyword=${encodeURIComponent(searchInput)}`);
             const posts = await response.json();
             // 表示を更新
             postContainer.innerHTML = '';
+            // 投稿の表示
             if (posts.length > 0) {
                 posts.forEach(post => {
                     // 投稿の種類に応じたURLを取得
@@ -76,7 +80,8 @@ document.addEventListener('DOMContentLoaded', async function () {
                 btn.classList.add('bg-blue-300', 'text-white');
             });
             this.classList.add('active', 'bg-blue-500', 'text-white');
-
+            // 検索状態をリセット
+            document.getElementById('search-input').value = '';
             // 投稿データを更新
             await fetchAndDisplayPosts(type);
         });
@@ -121,4 +126,20 @@ document.addEventListener('DOMContentLoaded', async function () {
         const typeGroup = typeToGroup[type];
         return typeGroup;
     }
+
+    // 検索を行うメソッド
+    document.getElementById('search-button').addEventListener('click', async function () {
+        const activeButton = document.querySelector('.post-button.active');
+        const type = activeButton ? activeButton.dataset.type : 'work';
+        await fetchAndDisplayPosts(type);
+    });
+
+    // キャンセルを行うメソッド
+    document.getElementById('cancel-button').addEventListener('click', async function () {
+        // 検索状態をリセット
+        document.getElementById('search-input').value = '';
+        const activeButton = document.querySelector('.post-button.active');
+        const type = activeButton ? activeButton.dataset.type : 'work';
+        await fetchAndDisplayPosts(type);
+    });
 });

--- a/public/js/fetch_post.js
+++ b/public/js/fetch_post.js
@@ -17,6 +17,7 @@ document.addEventListener('DOMContentLoaded', async function () {
             // データの取得
             const response = await fetch(`/users/${userId}/posts/${type}?keyword=${encodeURIComponent(searchInput)}`);
             const posts = await response.json();
+
             // 表示を更新
             postContainer.innerHTML = '';
             // 投稿の表示

--- a/resources/views/anime_pilgrimage_posts/create.blade.php
+++ b/resources/views/anime_pilgrimage_posts/create.blade.php
@@ -9,9 +9,9 @@
         </div>
         <div class="title">
             <h2>タイトル</h2>
-            <input type="text" name="pilgrimage_post[title]" placeholder="タイトル"
-                value="{{ old('pilgrimage_post.title') }}" />
-            <p class="title__error" style="color:red">{{ $errors->first('pilgrimage_post.title') }}</p>
+            <input type="text" name="pilgrimage_post[post_title]" placeholder="タイトル"
+                value="{{ old('pilgrimage_post.post_title') }}" />
+            <p class="title__error" style="color:red">{{ $errors->first('pilgrimage_post.post_title') }}</p>
         </div>
         <div class="scene">
             <h2>シーン</h2>

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -57,6 +57,10 @@
         <button class="post-button bg-blue-300 text-white px-4 py-2 rounded" data-type="music">音楽感想</button>
         <button class="post-button bg-blue-300 text-white px-4 py-2 rounded" data-type="animePilgrimage">聖地感想</button>
     </div>
+    <!-- 検索バーの設置 -->
+    <input id="search-input" type="text" placeholder="キーワードを入力..." class="border border-gray-300 p-2 rounded mt-1">
+    <button id="search-button" class="bg-blue-500 text-white px-4 py-2 rounded">検索</button>
+    <button id="cancel-button">キャンセル</button>
     <div id="post-container" class="mt-4">
         <!-- 投稿データの表示 -->
     </div>

--- a/resources/views/profile/index.blade.php
+++ b/resources/views/profile/index.blade.php
@@ -64,6 +64,10 @@
     <div id="post-container" class="mt-4">
         <!-- 投稿データの表示 -->
     </div>
+    <!-- ペジネーション -->
+    <div id="pagination-container" class="mt-4 flex justify-center space-x-2">
+        <!-- ページナビゲーションボタンはJavaScriptで動的に生成 -->
+    </div>
     <div id="user_id" data-user-id="{{ $user->id }}"></div>
     <script src="{{ asset('/js/fetch_post.js') }}"></script>
 </x-app-layout>


### PR DESCRIPTION
### ログインしているユーザーの投稿一覧に検索機能の追加

- #75 

・ログインしているユーザーの投稿一覧に検索機能の追加
・リレーション先のデータも検索できるように修正
・10件ずつ表示するようペジネーションの追加
・各投稿に投稿時間を追加し、投稿時間が新しい順に並び替え
・いいねした投稿一覧で、投稿の種類を表示するための準備として、各投稿にpostTypeの追加

・ログインしているユーザーの投稿一覧
![image](https://github.com/user-attachments/assets/77e6b794-fcab-47fe-ab84-7079f414529a)

・検索の実行（作品名の「まどか」と検索した場合）
![image](https://github.com/user-attachments/assets/02202492-6d47-4ac9-85ae-8790408ff99e)

・検索の実行（複数検索で「まどか　さやか」と検索した場合）
![image](https://github.com/user-attachments/assets/091dccf4-2533-48aa-bfac-6b75f951b0eb)

・検索の実行（全く関係のない文字「ラブライブ」を検索した場合）
![image](https://github.com/user-attachments/assets/37989974-f877-42a7-a15d-be86c1befd26)
