### PR TITLE
Feat：いいね機能のリファクタリング

### DIFF
--- a/app/Http/Controllers/AnimePilgrimagePostController.php
+++ b/app/Http/Controllers/AnimePilgrimagePostController.php
@@ -158,17 +158,15 @@ class AnimePilgrimagePostController extends Controller
         if ($isLiked) {
             // 既にいいねしている場合
             $pilgrimage_post->users()->detach(Auth::id());
-            // いいねしたユーザー数の取得
-            $count = count($pilgrimage_post->users()->pluck('anime_pilgrimage_post_id')->toArray());
-            return response()->json(['status' => 'unliked', 'like_user' => $count]);
+            $status = 'unliked';
         } else {
             // 初めてのいいねの場合
             $pilgrimage_post->users()->attach(Auth::id());
-            // いいねしたユーザー数の取得
-            $count = count($pilgrimage_post->users()->pluck('anime_pilgrimage_post_id')->toArray());
-            return response()->json(['status' => 'liked', 'like_user' => $count]);
+            $status = 'liked';
         }
-        return back();
+        // いいねしたユーザー数の取得
+        $count = count($pilgrimage_post->users()->pluck('anime_pilgrimage_post_id')->toArray());
+        return response()->json(['status' => $status, 'like_user' => $count]);
     }
 
     // Cloudinaryにある画像のURLからpublic_Idを取得する

--- a/app/Http/Controllers/AnimePilgrimagePostController.php
+++ b/app/Http/Controllers/AnimePilgrimagePostController.php
@@ -159,14 +159,16 @@ class AnimePilgrimagePostController extends Controller
             // 既にいいねしている場合
             $pilgrimage_post->users()->detach(Auth::id());
             $status = 'unliked';
+            $message = 'いいねを解除しました';
         } else {
             // 初めてのいいねの場合
             $pilgrimage_post->users()->attach(Auth::id());
             $status = 'liked';
+            $message = 'いいねしました';
         }
         // いいねしたユーザー数の取得
         $count = count($pilgrimage_post->users()->pluck('anime_pilgrimage_post_id')->toArray());
-        return response()->json(['status' => $status, 'like_user' => $count]);
+        return response()->json(['status' => $status, 'like_user' => $count, 'message' => $message]);
     }
 
     // Cloudinaryにある画像のURLからpublic_Idを取得する

--- a/app/Http/Controllers/CharacterPostController.php
+++ b/app/Http/Controllers/CharacterPostController.php
@@ -166,14 +166,16 @@ class CharacterPostController extends Controller
             // 既にいいねしている場合
             $character_post->users()->detach(Auth::id());
             $status = 'unliked';
+            $message = 'いいねを解除しました';
         } else {
             // 初めてのいいねの場合
             $character_post->users()->attach(Auth::id());
             $status = 'liked';
+            $message = 'いいねしました';
         }
         // いいねしたユーザー数の取得
         $count = count($character_post->users()->pluck('character_post_id')->toArray());
-        return response()->json(['status' => $status, 'like_user' => $count]);
+        return response()->json(['status' => $status, 'like_user' => $count, 'message' => $message]);
     }
 
     // Cloudinaryにある画像のURLからpublic_Idを取得する

--- a/app/Http/Controllers/CharacterPostController.php
+++ b/app/Http/Controllers/CharacterPostController.php
@@ -153,7 +153,7 @@ class CharacterPostController extends Controller
     }
 
     // 投稿にいいねを行う
-    public function like(CharacterPost $characterPost, $character_id, $character_post_id)
+    public function like($character_id, $character_post_id)
     {
         // 投稿が見つからない場合の処理
         $character_post = CharacterPost::find($character_post_id);
@@ -165,17 +165,15 @@ class CharacterPostController extends Controller
         if ($isLiked) {
             // 既にいいねしている場合
             $character_post->users()->detach(Auth::id());
-            // いいねしたユーザー数の取得
-            $count = count($character_post->users()->pluck('character_post_id')->toArray());
-            return response()->json(['status' => 'unliked', 'like_user' => $count]);
+            $status = 'unliked';
         } else {
             // 初めてのいいねの場合
             $character_post->users()->attach(Auth::id());
-            // いいねしたユーザー数の取得
-            $count = count($character_post->users()->pluck('character_post_id')->toArray());
-            return response()->json(['status' => 'liked', 'like_user' => $count]);
+            $status = 'liked';
         }
-        return back();
+        // いいねしたユーザー数の取得
+        $count = count($character_post->users()->pluck('character_post_id')->toArray());
+        return response()->json(['status' => $status, 'like_user' => $count]);
     }
 
     // Cloudinaryにある画像のURLからpublic_Idを取得する

--- a/app/Http/Controllers/MusicPostController.php
+++ b/app/Http/Controllers/MusicPostController.php
@@ -82,7 +82,7 @@ class MusicPostController extends Controller
     }
 
     // 投稿にいいねを行う
-    public function like(MusicPost $musicPost, $music_id, $music_post_id)
+    public function like($music_id, $music_post_id)
     {
         // 投稿が見つからない場合の処理
         $music_post = MusicPost::find($music_post_id);
@@ -94,17 +94,14 @@ class MusicPostController extends Controller
         if ($isLiked) {
             // 既にいいねしている場合
             $music_post->users()->detach(Auth::id());
-            // いいねしたユーザー数の取得
-            $count = count($music_post->users()->pluck('music_post_id')->toArray());
-            return response()->json(['status' => 'unliked', 'like_user' => $count]);
+            $status = 'unliked';
         } else {
             // 初めてのいいねの場合
             $music_post->users()->attach(Auth::id());
-            // いいねしたユーザー数の取得
-            $count = count($music_post->users()->pluck('music_post_id')->toArray());
-            return response()->json(['status' => 'liked', 'like_user' => $count]);
+            $status = 'liked';
         }
-        return back();
+        // いいねしたユーザー数の取得
+        $count = count($music_post->users()->pluck('music_post_id')->toArray());
+        return response()->json(['status' => $status, 'like_user' => $count]);
     }
-
 }

--- a/app/Http/Controllers/MusicPostController.php
+++ b/app/Http/Controllers/MusicPostController.php
@@ -95,13 +95,15 @@ class MusicPostController extends Controller
             // 既にいいねしている場合
             $music_post->users()->detach(Auth::id());
             $status = 'unliked';
+            $message = 'いいねを解除しました';
         } else {
             // 初めてのいいねの場合
             $music_post->users()->attach(Auth::id());
             $status = 'liked';
+            $message = 'いいねしました';
         }
         // いいねしたユーザー数の取得
         $count = count($music_post->users()->pluck('music_post_id')->toArray());
-        return response()->json(['status' => $status, 'like_user' => $count]);
+        return response()->json(['status' => $status, 'like_user' => $count, 'message' => $message]);
     }
 }

--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -143,7 +143,7 @@ class WorkReviewController extends Controller
         for ($counter = 1; $counter < 5; $counter++) {
             $removed_image_path = $targetworkreview->{'image' . $counter};
             // DBのimageの中身がnullであれば処理をスキップする
-            if(is_null($removed_image_path)) {
+            if (is_null($removed_image_path)) {
                 break;
             }
             $public_id = $this->extractPublicIdFromUrl($removed_image_path);
@@ -155,7 +155,7 @@ class WorkReviewController extends Controller
     }
 
     // 投稿にいいねを行う
-    public function like(WorkReview $workreview, $work_id, $work_review_id)
+    public function like($work_id, $work_review_id)
     {
         // 投稿が見つからない場合の処理
         $work_review = WorkReview::find($work_review_id);
@@ -167,17 +167,16 @@ class WorkReviewController extends Controller
         if ($isLiked) {
             // 既にいいねしている場合
             $work_review->users()->detach(Auth::id());
-            // いいねしたユーザー数の取得
-            $count = count($work_review->users()->pluck('work_review_id')->toArray());
-            return response()->json(['status' => 'unliked', 'like_user' => $count]);
+            $status = 'unliked';
         } else {
             // 初めてのいいねの場合
             $work_review->users()->attach(Auth::id());
-            // いいねしたユーザー数の取得
-            $count = count($work_review->users()->pluck('work_review_id')->toArray());
-            return response()->json(['status' => 'liked', 'like_user' => $count]);
+            $status = 'liked';
         }
-        return back();
+        // いいねしたユーザー数の取得
+        $count = count($work_review->users()->pluck('work_review_id')->toArray());
+
+        return response()->json(['status' => $status, 'like_user' => $count]);
     }
 
     // Cloudinaryにある画像のURLからpublic_Idを取得する

--- a/app/Http/Controllers/WorkReviewController.php
+++ b/app/Http/Controllers/WorkReviewController.php
@@ -168,15 +168,17 @@ class WorkReviewController extends Controller
             // 既にいいねしている場合
             $work_review->users()->detach(Auth::id());
             $status = 'unliked';
+            $message = 'いいねを解除しました';
         } else {
             // 初めてのいいねの場合
             $work_review->users()->attach(Auth::id());
             $status = 'liked';
+            $message = 'いいねしました';
         }
         // いいねしたユーザー数の取得
         $count = count($work_review->users()->pluck('work_review_id')->toArray());
 
-        return response()->json(['status' => $status, 'like_user' => $count]);
+        return response()->json(['status' => $status, 'like_user' => $count, 'message' => $message]);
     }
 
     // Cloudinaryにある画像のURLからpublic_Idを取得する

--- a/app/Http/Controllers/WorkStoryPostController.php
+++ b/app/Http/Controllers/WorkStoryPostController.php
@@ -160,14 +160,16 @@ class WorkStoryPostController extends Controller
             // 既にいいねしている場合
             $work_story_post->users()->detach(Auth::id());
             $status = 'unliked';
+            $message = 'いいねを解除しました';
         } else {
             // 初めてのいいねの場合
             $work_story_post->users()->attach(Auth::id());
             $status = 'liked';
+            $message = 'いいねしました';
         }
         // いいねしたユーザー数の取得
         $count = count($work_story_post->users()->pluck('work_story_post_id')->toArray());
-        return response()->json(['status' => $status, 'like_user' => $count]);
+        return response()->json(['status' => $status, 'like_user' => $count, 'message' => $message]);
     }
 
     // Cloudinaryにある画像のURLからpublic_Idを取得する

--- a/app/Http/Controllers/WorkStoryPostController.php
+++ b/app/Http/Controllers/WorkStoryPostController.php
@@ -159,17 +159,15 @@ class WorkStoryPostController extends Controller
         if ($isLiked) {
             // 既にいいねしている場合
             $work_story_post->users()->detach(Auth::id());
-            // いいねしたユーザー数の取得
-            $count = count($work_story_post->users()->pluck('work_story_post_id')->toArray());
-            return response()->json(['status' => 'unliked', 'like_user' => $count]);
+            $status = 'unliked';
         } else {
             // 初めてのいいねの場合
             $work_story_post->users()->attach(Auth::id());
-            // いいねしたユーザー数の取得
-            $count = count($work_story_post->users()->pluck('work_story_post_id')->toArray());
-            return response()->json(['status' => 'liked', 'like_user' => $count]);
+            $status = 'liked';
         }
-        return back();
+        // いいねしたユーザー数の取得
+        $count = count($work_story_post->users()->pluck('work_story_post_id')->toArray());
+        return response()->json(['status' => $status, 'like_user' => $count]);
     }
 
     // Cloudinaryにある画像のURLからpublic_Idを取得する

--- a/public/js/like_posts/like_anime_pilgrimage_post.js
+++ b/public/js/like_posts/like_anime_pilgrimage_post.js
@@ -1,0 +1,51 @@
+// csrfTokenの取得
+const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+// いいね処理を非同期で行う
+document.addEventListener('DOMContentLoaded', function () {
+    const likeClasses = document.querySelectorAll('.like');
+    const likeMessage = document.getElementById('like-message');
+    likeClasses.forEach(element => {
+        // いいねボタンのクラスの取得
+        let button = element.querySelector('#like_button');
+        // いいねしたユーザー数のクラス取得とpタグの取得
+        let likeClass = element.querySelector('.like_user');
+        let users = likeClass.querySelector('#like_count');
+
+        //いいねボタンクリックによる非同期処理
+        button.addEventListener('click', async function () {
+            const pilgrimageId = button.getAttribute('data-pilgrimage-id');
+            const postId = button.getAttribute('data-post-id');
+            try {
+                const response = await fetch(
+                    `/pilgrimage_posts/${pilgrimageId}/posts/${postId}/like`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': `${csrfToken}`
+                    },
+                });
+                const data = await response.json();
+                if (data.status === 'liked') {
+                    button.innerText = 'いいね取り消し';
+                    users.innerText = data.like_user;
+                } else if (data.status === 'unliked') {
+                    button.innerText = 'いいね';
+                    users.innerText = data.like_user;
+                }
+                // メッセージを表示
+                likeMessage.textContent = data.message;
+                likeMessage.classList.remove('hidden');
+                likeMessage.classList.add('block');
+
+                // 3秒後にメッセージを非表示
+                setTimeout(() => {
+                    likeMessage.classList.add('hidden');
+                    likeMessage.classList.remove('block');
+                }, 3000);
+            } catch (error) {
+                console.error('Error:', error);
+            }
+        });
+    });
+});

--- a/public/js/like_posts/like_character_post.js
+++ b/public/js/like_posts/like_character_post.js
@@ -1,0 +1,51 @@
+// csrfTokenの取得
+const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+// いいね処理を非同期で行う
+document.addEventListener('DOMContentLoaded', function () {
+    const likeClasses = document.querySelectorAll('.like');
+    const likeMessage = document.getElementById('like-message');
+    likeClasses.forEach(element => {
+        // いいねボタンのクラスの取得
+        let button = element.querySelector('#like_button');
+        // いいねしたユーザー数のクラス取得とpタグの取得
+        let likeClass = element.querySelector('.like_user');
+        let users = likeClass.querySelector('#like_count');
+
+        //いいねボタンクリックによる非同期処理
+        button.addEventListener('click', async function () {
+            const characterId = button.getAttribute('data-character-id');
+            const postId = button.getAttribute('data-post-id');
+            try {
+                const response = await fetch(
+                    `/character_posts/${characterId}/posts/${postId}/like`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': `${csrfToken}`
+                    },
+                });
+                const data = await response.json();
+                if (data.status === 'liked') {
+                    button.innerText = 'いいね取り消し';
+                    users.innerText = data.like_user;
+                } else if (data.status === 'unliked') {
+                    button.innerText = 'いいね';
+                    users.innerText = data.like_user;
+                }
+                // メッセージを表示
+                likeMessage.textContent = data.message;
+                likeMessage.classList.remove('hidden');
+                likeMessage.classList.add('block');
+
+                // 3秒後にメッセージを非表示
+                setTimeout(() => {
+                    likeMessage.classList.add('hidden');
+                    likeMessage.classList.remove('block');
+                }, 3000);
+            } catch (error) {
+                console.error('Error:', error);
+            }
+        });
+    });
+});

--- a/public/js/like_posts/like_music_post.js
+++ b/public/js/like_posts/like_music_post.js
@@ -1,0 +1,51 @@
+// csrfTokenの取得
+const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+// いいね処理を非同期で行う
+document.addEventListener('DOMContentLoaded', function () {
+    const likeClasses = document.querySelectorAll('.like');
+    const likeMessage = document.getElementById('like-message');
+    likeClasses.forEach(element => {
+        // いいねボタンのクラスの取得
+        let button = element.querySelector('#like_button');
+        // いいねしたユーザー数のクラス取得とpタグの取得
+        let likeClass = element.querySelector('.like_user');
+        let users = likeClass.querySelector('#like_count');
+
+        //いいねボタンクリックによる非同期処理
+        button.addEventListener('click', async function () {
+            const musicId = button.getAttribute('data-music-id');
+            const postId = button.getAttribute('data-post-id');
+            try {
+                const response = await fetch(
+                    `/music_posts/${musicId}/posts/${postId}/like`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': `${csrfToken}`
+                    },
+                });
+                const data = await response.json();
+                if (data.status === 'liked') {
+                    button.innerText = 'いいね取り消し';
+                    users.innerText = data.like_user;
+                } else if (data.status === 'unliked') {
+                    button.innerText = 'いいね';
+                    users.innerText = data.like_user;
+                }
+                // メッセージを表示
+                likeMessage.textContent = data.message;
+                likeMessage.classList.remove('hidden');
+                likeMessage.classList.add('block');
+
+                // 3秒後にメッセージを非表示
+                setTimeout(() => {
+                    likeMessage.classList.add('hidden');
+                    likeMessage.classList.remove('block');
+                }, 3000);
+            } catch (error) {
+                console.error('Error:', error);
+            }
+        });
+    });
+});

--- a/public/js/like_posts/like_work_post.js
+++ b/public/js/like_posts/like_work_post.js
@@ -1,0 +1,51 @@
+// csrfTokenの取得
+const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+// いいね処理を非同期で行う
+document.addEventListener('DOMContentLoaded', function () {
+    const likeClasses = document.querySelectorAll('.like');
+    const likeMessage = document.getElementById('like-message');
+    likeClasses.forEach(element => {
+        // いいねボタンのクラスの取得
+        let button = element.querySelector('#like_button');
+        // いいねしたユーザー数のクラス取得とpタグの取得
+        let likeClass = element.querySelector('.like_user');
+        let users = likeClass.querySelector('#like_count');
+
+        //いいねボタンクリックによる非同期処理
+        button.addEventListener('click', async function () {
+            const workId = button.getAttribute('data-work-id');
+            const reviewId = button.getAttribute('data-review-id');
+            try {
+                const response = await fetch(
+                    `/work_reviews/${workId}/reviews/${reviewId}/like`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': `${csrfToken}`
+                    },
+                });
+                const data = await response.json();
+                if (data.status === 'liked') {
+                    button.innerText = 'いいね取り消し';
+                    users.innerText = data.like_user;
+                } else if (data.status === 'unliked') {
+                    button.innerText = 'いいね';
+                    users.innerText = data.like_user;
+                }
+                // メッセージを表示
+                likeMessage.textContent = data.message;
+                likeMessage.classList.remove('hidden');
+                likeMessage.classList.add('block');
+
+                // 3秒後にメッセージを非表示
+                setTimeout(() => {
+                    likeMessage.classList.add('hidden');
+                    likeMessage.classList.remove('block');
+                }, 3000);
+            } catch (error) {
+                console.error('Error:', error);
+            }
+        });
+    });
+});

--- a/public/js/like_posts/like_work_story_post.js
+++ b/public/js/like_posts/like_work_story_post.js
@@ -1,0 +1,52 @@
+// csrfTokenの取得
+const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
+
+// いいね処理を非同期で行う
+document.addEventListener('DOMContentLoaded', function () {
+    const likeClasses = document.querySelectorAll('.like');
+    const likeMessage = document.getElementById('like-message');
+    likeClasses.forEach(element => {
+        // いいねボタンのクラスの取得
+        let button = element.querySelector('#like_button');
+        // いいねしたユーザー数のクラス取得とpタグの取得
+        let likeClass = element.querySelector('.like_user');
+        let users = likeClass.querySelector('#like_count');
+
+        //いいねボタンクリックによる非同期処理
+        button.addEventListener('click', async function () {
+            const workId = button.getAttribute('data-work-id');
+            const workStoryId = button.getAttribute('data-work_story-id');
+            const postId = button.getAttribute('data-post-id');
+            try {
+                const response = await fetch(
+                    `/works/${workId}/stories/${workStoryId}/posts/${postId}/like`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': `${csrfToken}`
+                    },
+                });
+                const data = await response.json();
+                if (data.status === 'liked') {
+                    button.innerText = 'いいね取り消し';
+                    users.innerText = data.like_user;
+                } else if (data.status === 'unliked') {
+                    button.innerText = 'いいね';
+                    users.innerText = data.like_user;
+                }
+                // メッセージを表示
+                likeMessage.textContent = data.message;
+                likeMessage.classList.remove('hidden');
+                likeMessage.classList.add('block');
+
+                // 3秒後にメッセージを非表示
+                setTimeout(() => {
+                    likeMessage.classList.add('hidden');
+                    likeMessage.classList.remove('block');
+                }, 3000);
+            } catch (error) {
+                console.error('Error:', error);
+            }
+        });
+    });
+});

--- a/resources/views/anime_pilgrimage_posts/edit.blade.php
+++ b/resources/views/anime_pilgrimage_posts/edit.blade.php
@@ -15,9 +15,9 @@
             </div>
             <div class="title">
                 <h2>タイトル</h2>
-                <input type="text" name="pilgrimage_post[title]" placeholder="タイトル"
-                    value="{{ $pilgrimage_post->title }}" />
-                <p class="title__error" style="color:red">{{ $errors->first('pilgrimage_post.title') }}</p>
+                <input type="text" name="pilgrimage_post[post_title]" placeholder="タイトル"
+                    value="{{ $pilgrimage_post->post_title }}" />
+                <p class="title__error" style="color:red">{{ $errors->first('pilgrimage_post.post_title') }}</p>
             </div>
             <div class="scene">
                 <h2>シーン</h2>

--- a/resources/views/anime_pilgrimage_posts/index.blade.php
+++ b/resources/views/anime_pilgrimage_posts/index.blade.php
@@ -1,64 +1,71 @@
 <x-app-layout>
     <h1>「{{ $pilgrimage_first->animePilgrimage->name }}」の感想投稿一覧</h1>
-    <a href="{{ route('pilgrimage_posts.create', ['pilgrimage_id' => $pilgrimage_first->anime_pilgrimage_id]) }}">新規投稿作成</a>
+    <a
+        href="{{ route('pilgrimage_posts.create', ['pilgrimage_id' => $pilgrimage_first->anime_pilgrimage_id]) }}">新規投稿作成</a>
     <!-- 検索機能 -->
     <div class=serch>
-        <form action="{{ route('pilgrimage_posts.index', ['pilgrimage_id' => $pilgrimage_first->anime_pilgrimage_id]) }}" method="GET">
+        <form action="{{ route('pilgrimage_posts.index', ['pilgrimage_id' => $pilgrimage_first->anime_pilgrimage_id]) }}"
+            method="GET">
             <input type="text" name="search" value="{{ request('search') }}" placeholder="キーワードを検索" aria-label="検索...">
             <input type="submit" value="キーワード検索">
         </form>
         <div class="cancel">
-            <a href="{{ route('pilgrimage_posts.index', ['pilgrimage_id' => $pilgrimage_first->anime_pilgrimage_id]) }}">キャンセル</a>
+            <a
+                href="{{ route('pilgrimage_posts.index', ['pilgrimage_id' => $pilgrimage_first->anime_pilgrimage_id]) }}">キャンセル</a>
         </div>
     </div>
     <div class='pilgrimage_posts'>
-        @if($pilgrimage_posts->isEmpty())
-        <h2 class='no_result'>結果がありません。</h2>
+        @if ($pilgrimage_posts->isEmpty())
+            <h2 class='no_result'>結果がありません。</h2>
         @else
-        <div class='character_post'>
-            @foreach ($pilgrimage_posts as $pilgrimage_post)
-            <div class='pilgrimage_post'>
-                <h2 class='title'>
-                    <a href="{{ route('pilgrimage_posts.show', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimage_post->id]) }}">{{ $pilgrimage_post->title }}</a>
-                </h2>
-                <h3 class='user'>
-                    {{ $pilgrimage_post->user->name }}
-                </h3>
-                <h3 class='scene'>
-                    {{ $pilgrimage_post->scene }}
-                </h3>
-                <div class="like">
-                    <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
-                    <button id="like_button"
-                        data-pilgrimage-id="{{ $pilgrimage_post->anime_pilgrimage_id }}"
-                        data-post-id="{{ $pilgrimage_post->id }}"
-                        type="submit">
-                        {{ $pilgrimage_post->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
-                    </button>
-                    <div class="like_user">
-                        <a href="{{ route('pilgrimage_post_like.index', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimage_post->id]) }}">
-                            <p id="like_count">{{ $pilgrimage_post->users->count() }}</p>
-                        </a>
+            <div class='character_post'>
+                @foreach ($pilgrimage_posts as $pilgrimage_post)
+                    <div class='pilgrimage_post'>
+                        <h2 class='title'>
+                            <a
+                                href="{{ route('pilgrimage_posts.show', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimage_post->id]) }}">{{ $pilgrimage_post->post_title }}</a>
+                        </h2>
+                        <h3 class='user'>
+                            {{ $pilgrimage_post->user->name }}
+                        </h3>
+                        <h3 class='scene'>
+                            {{ $pilgrimage_post->scene }}
+                        </h3>
+                        <div class="like">
+                            <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
+                            <button id="like_button" data-pilgrimage-id="{{ $pilgrimage_post->anime_pilgrimage_id }}"
+                                data-post-id="{{ $pilgrimage_post->id }}" type="submit">
+                                {{ $pilgrimage_post->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
+                            </button>
+                            <div class="like_user">
+                                <a
+                                    href="{{ route('pilgrimage_post_like.index', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimage_post->id]) }}">
+                                    <p id="like_count">{{ $pilgrimage_post->users->count() }}</p>
+                                </a>
+                            </div>
+                        </div>
+                        <p class='body'>{{ $pilgrimage_post->body }}</p>
+                        @if ($pilgrimage_post->image1)
+                            <div>
+                                <img src="{{ $pilgrimage_post->image1 }}" alt="画像が読み込めません。">
+                            </div>
+                        @endif
+                        <form
+                            action="{{ route('pilgrimage_posts.delete', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimage_post->id]) }}"
+                            id="form_{{ $pilgrimage_post->id }}" method="post">
+                            @csrf
+                            @method('DELETE')
+                            <button type="button" data-post-id="{{ $pilgrimage_post->id }}"
+                                class="delete-button">投稿を削除する</button>
+                        </form>
                     </div>
-                </div>
-                <p class='body'>{{ $pilgrimage_post->body }}</p>
-                @if($pilgrimage_post->image1)
-                <div>
-                    <img src="{{ $pilgrimage_post->image1 }}" alt="画像が読み込めません。">
-                </div>
-                @endif
-                <form action="{{ route('pilgrimage_posts.delete', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimage_post->id]) }}" id="form_{{ $pilgrimage_post->id }}" method="post">
-                    @csrf
-                    @method('DELETE')
-                    <button type="button" data-post-id="{{ $pilgrimage_post->id }}" class="delete-button">投稿を削除する</button>
-                </form>
+                @endforeach
             </div>
-            @endforeach
-        </div>
         @endif
     </div>
     <div class="footer">
-        <a href="{{ route('pilgrimages.show', ['pilgrimage_id' => $pilgrimage_first->anime_pilgrimage_id]) }}">聖地詳細画面へ</a>
+        <a
+            href="{{ route('pilgrimages.show', ['pilgrimage_id' => $pilgrimage_first->anime_pilgrimage_id]) }}">聖地詳細画面へ</a>
     </div>
     <div class='paginate'>
         {{ $pilgrimage_posts->appends(request()->query())->links() }}
@@ -100,13 +107,14 @@
                     const pilgrimageId = button.getAttribute('data-pilgrimage-id');
                     const postId = button.getAttribute('data-post-id');
                     try {
-                        const response = await fetch(`/pilgrimage_posts/${pilgrimageId}/posts/${postId}/like`, {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                                'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                            },
-                        });
+                        const response = await fetch(
+                            `/pilgrimage_posts/${pilgrimageId}/posts/${postId}/like`, {
+                                method: 'POST',
+                                headers: {
+                                    'Content-Type': 'application/json',
+                                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                                },
+                            });
                         const data = await response.json();
                         if (data.status === 'liked') {
                             button.innerText = 'いいね取り消し';

--- a/resources/views/anime_pilgrimage_posts/index.blade.php
+++ b/resources/views/anime_pilgrimage_posts/index.blade.php
@@ -74,6 +74,8 @@
     <div class='paginate'>
         {{ $pilgrimage_posts->appends(request()->query())->links() }}
     </div>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <script src="{{ asset('/js/like_posts/like_anime_pilgrimage_post.js') }}"></script>
 
     <script>
         // DOMツリー読み取り完了後にイベント発火
@@ -95,54 +97,5 @@
                 document.getElementById(`form_${postId}`).submit();
             }
         }
-
-        // いいね処理を非同期で行う
-        document.addEventListener('DOMContentLoaded', function() {
-            const likeClasses = document.querySelectorAll('.like');
-            const likeMessage = document.getElementById('like-message');
-            likeClasses.forEach(element => {
-                // いいねボタンのクラスの取得
-                let button = element.querySelector('#like_button');
-                // いいねしたユーザー数のクラス取得とpタグの取得
-                let likeClass = element.querySelector('.like_user');
-                let users = likeClass.querySelector('#like_count');
-
-                //いいねボタンクリックによる非同期処理
-                button.addEventListener('click', async function() {
-                    const pilgrimageId = button.getAttribute('data-pilgrimage-id');
-                    const postId = button.getAttribute('data-post-id');
-                    try {
-                        const response = await fetch(
-                            `/pilgrimage_posts/${pilgrimageId}/posts/${postId}/like`, {
-                                method: 'POST',
-                                headers: {
-                                    'Content-Type': 'application/json',
-                                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                                },
-                            });
-                        const data = await response.json();
-                        if (data.status === 'liked') {
-                            button.innerText = 'いいね取り消し';
-                            users.innerText = data.like_user;
-                        } else if (data.status === 'unliked') {
-                            button.innerText = 'いいね';
-                            users.innerText = data.like_user;
-                        }
-                        // メッセージを表示
-                        likeMessage.textContent = data.message;
-                        likeMessage.classList.remove('hidden');
-                        likeMessage.classList.add('block');
-
-                        // 3秒後にメッセージを非表示
-                        setTimeout(() => {
-                            likeMessage.classList.add('hidden');
-                            likeMessage.classList.remove('block');
-                        }, 3000);
-                    } catch (error) {
-                        console.error('Error:', error);
-                    }
-                });
-            });
-        });
     </script>
 </x-app-layout>

--- a/resources/views/anime_pilgrimage_posts/index.blade.php
+++ b/resources/views/anime_pilgrimage_posts/index.blade.php
@@ -1,4 +1,8 @@
 <x-app-layout>
+    <div id="like-message"
+        class="hidden fixed top-[15%] left-1/2 transform -translate-x-1/2 bg-green-500/50 text-white px-6 py-3 rounded-lg shadow-lg flex items-center space-x-4 z-50">
+    </div>
+
     <h1>「{{ $pilgrimage_first->animePilgrimage->name }}」の感想投稿一覧</h1>
     <a
         href="{{ route('pilgrimage_posts.create', ['pilgrimage_id' => $pilgrimage_first->anime_pilgrimage_id]) }}">新規投稿作成</a>
@@ -95,6 +99,7 @@
         // いいね処理を非同期で行う
         document.addEventListener('DOMContentLoaded', function() {
             const likeClasses = document.querySelectorAll('.like');
+            const likeMessage = document.getElementById('like-message');
             likeClasses.forEach(element => {
                 // いいねボタンのクラスの取得
                 let button = element.querySelector('#like_button');
@@ -123,6 +128,16 @@
                             button.innerText = 'いいね';
                             users.innerText = data.like_user;
                         }
+                        // メッセージを表示
+                        likeMessage.textContent = data.message;
+                        likeMessage.classList.remove('hidden');
+                        likeMessage.classList.add('block');
+
+                        // 3秒後にメッセージを非表示
+                        setTimeout(() => {
+                            likeMessage.classList.add('hidden');
+                            likeMessage.classList.remove('block');
+                        }, 3000);
                     } catch (error) {
                         console.error('Error:', error);
                     }

--- a/resources/views/anime_pilgrimage_posts/show.blade.php
+++ b/resources/views/anime_pilgrimage_posts/show.blade.php
@@ -4,14 +4,13 @@
     </h1>
     <div class="like">
         <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
-        <button id="like_button"
-            data-pilgrimage-id="{{ $pilgrimage_post->anime_pilgrimage_id }}"
-            data-post-id="{{ $pilgrimage_post->id }}"
-            type="submit">
+        <button id="like_button" data-pilgrimage-id="{{ $pilgrimage_post->anime_pilgrimage_id }}"
+            data-post-id="{{ $pilgrimage_post->id }}" type="submit">
             {{ $pilgrimage_post->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
         </button>
         <div class="like_user">
-            <a href="{{ route('pilgrimage_post_like.index', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimage_post->id]) }}">
+            <a
+                href="{{ route('pilgrimage_post_like.index', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimage_post->id]) }}">
                 <p id="like_count">{{ $pilgrimage_post->users->count() }}</p>
             </a>
         </div>
@@ -23,7 +22,7 @@
             <h3>投稿者</h3>
             <p>{{ $pilgrimage_post->user->name }}</p>
             <h3>タイトル</h3>
-            <p>{{ $pilgrimage_post->title }}</p>
+            <p>{{ $pilgrimage_post->post_title }}</p>
             <h3>シーン</h3>
             <p>{{ $pilgrimage_post->scene }}</p>
             <h3>本文</h3>
@@ -31,30 +30,34 @@
             <h3>作成日</h3>
             <p>{{ $pilgrimage_post->created_at }}</p>
             @php
-            $numbers = array(1, 2, 3, 4);
+                $numbers = [1, 2, 3, 4];
             @endphp
-            @foreach($numbers as $number)
-            @php
-            $image = "image".$number;
-            @endphp
-            @if($pilgrimage_post->$image)
-            <div>
-                <img src="{{ $pilgrimage_post->$image }}" alt="画像が読み込めません。">
-            </div>
-            @endif
+            @foreach ($numbers as $number)
+                @php
+                    $image = 'image' . $number;
+                @endphp
+                @if ($pilgrimage_post->$image)
+                    <div>
+                        <img src="{{ $pilgrimage_post->$image }}" alt="画像が読み込めません。">
+                    </div>
+                @endif
             @endforeach
         </div>
     </div>
     <div class="edit">
-        <a href="{{ route('pilgrimage_posts.edit', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimage_post->id]) }}">編集する</a>
+        <a
+            href="{{ route('pilgrimage_posts.edit', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimage_post->id]) }}">編集する</a>
     </div>
-    <form action="{{ route('pilgrimage_posts.delete', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimage_post->id]) }}" id="form_{{ $pilgrimage_post->id }}" method="post">
+    <form
+        action="{{ route('pilgrimage_posts.delete', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id, 'pilgrimage_post_id' => $pilgrimage_post->id]) }}"
+        id="form_{{ $pilgrimage_post->id }}" method="post">
         @csrf
         @method('DELETE')
         <button type="button" data-post-id="{{ $pilgrimage_post->id }}" class="delete-button">投稿を削除する</button>
     </form>
     <div class="footer">
-        <a href="{{ route('pilgrimage_posts.index', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id]) }}">戻る</a>
+        <a
+            href="{{ route('pilgrimage_posts.index', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id]) }}">戻る</a>
     </div>
 
     <script>
@@ -93,13 +96,14 @@
                     const pilgrimageId = button.getAttribute('data-pilgrimage-id');
                     const postId = button.getAttribute('data-post-id');
                     try {
-                        const response = await fetch(`/pilgrimage_posts/${pilgrimageId}/posts/${postId}/like`, {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                                'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                            },
-                        });
+                        const response = await fetch(
+                            `/pilgrimage_posts/${pilgrimageId}/posts/${postId}/like`, {
+                                method: 'POST',
+                                headers: {
+                                    'Content-Type': 'application/json',
+                                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                                },
+                            });
                         const data = await response.json();
                         if (data.status === 'liked') {
                             button.innerText = 'いいね取り消し';

--- a/resources/views/anime_pilgrimage_posts/show.blade.php
+++ b/resources/views/anime_pilgrimage_posts/show.blade.php
@@ -1,4 +1,8 @@
 <x-app-layout>
+    <div id="like-message"
+        class="hidden fixed top-[15%] left-1/2 transform -translate-x-1/2 bg-green-500/50 text-white px-6 py-3 rounded-lg shadow-lg flex items-center space-x-4 z-50">
+    </div>
+
     <h1 class="title">
         {{ $pilgrimage_post->title }}
     </h1>
@@ -84,6 +88,7 @@
         // いいね処理を非同期で行う
         document.addEventListener('DOMContentLoaded', function() {
             const likeClasses = document.querySelectorAll('.like');
+            const likeMessage = document.getElementById('like-message');
             likeClasses.forEach(element => {
                 // いいねボタンのクラスの取得
                 let button = element.querySelector('#like_button');
@@ -112,6 +117,16 @@
                             button.innerText = 'いいね';
                             users.innerText = data.like_user;
                         }
+                        // メッセージを表示
+                        likeMessage.textContent = data.message;
+                        likeMessage.classList.remove('hidden');
+                        likeMessage.classList.add('block');
+
+                        // 3秒後にメッセージを非表示
+                        setTimeout(() => {
+                            likeMessage.classList.add('hidden');
+                            likeMessage.classList.remove('block');
+                        }, 3000);
                     } catch (error) {
                         console.error('Error:', error);
                     }

--- a/resources/views/anime_pilgrimage_posts/show.blade.php
+++ b/resources/views/anime_pilgrimage_posts/show.blade.php
@@ -63,6 +63,8 @@
         <a
             href="{{ route('pilgrimage_posts.index', ['pilgrimage_id' => $pilgrimage_post->anime_pilgrimage_id]) }}">戻る</a>
     </div>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <script src="{{ asset('/js/like_posts/like_anime_pilgrimage_post.js') }}"></script>
 
     <script>
         // DOMツリー読み取り完了後にイベント発火
@@ -84,54 +86,5 @@
                 document.getElementById(`form_${postId}`).submit();
             }
         }
-
-        // いいね処理を非同期で行う
-        document.addEventListener('DOMContentLoaded', function() {
-            const likeClasses = document.querySelectorAll('.like');
-            const likeMessage = document.getElementById('like-message');
-            likeClasses.forEach(element => {
-                // いいねボタンのクラスの取得
-                let button = element.querySelector('#like_button');
-                // いいねしたユーザー数のクラス取得とpタグの取得
-                let likeClass = element.querySelector('.like_user');
-                let users = likeClass.querySelector('#like_count');
-
-                //いいねボタンクリックによる非同期処理
-                button.addEventListener('click', async function() {
-                    const pilgrimageId = button.getAttribute('data-pilgrimage-id');
-                    const postId = button.getAttribute('data-post-id');
-                    try {
-                        const response = await fetch(
-                            `/pilgrimage_posts/${pilgrimageId}/posts/${postId}/like`, {
-                                method: 'POST',
-                                headers: {
-                                    'Content-Type': 'application/json',
-                                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                                },
-                            });
-                        const data = await response.json();
-                        if (data.status === 'liked') {
-                            button.innerText = 'いいね取り消し';
-                            users.innerText = data.like_user;
-                        } else if (data.status === 'unliked') {
-                            button.innerText = 'いいね';
-                            users.innerText = data.like_user;
-                        }
-                        // メッセージを表示
-                        likeMessage.textContent = data.message;
-                        likeMessage.classList.remove('hidden');
-                        likeMessage.classList.add('block');
-
-                        // 3秒後にメッセージを非表示
-                        setTimeout(() => {
-                            likeMessage.classList.add('hidden');
-                            likeMessage.classList.remove('block');
-                        }, 3000);
-                    } catch (error) {
-                        console.error('Error:', error);
-                    }
-                });
-            });
-        });
     </script>
 </x-app-layout>

--- a/resources/views/character_posts/index.blade.php
+++ b/resources/views/character_posts/index.blade.php
@@ -1,9 +1,14 @@
 <x-app-layout>
+    <div id="like-message"
+        class="hidden fixed top-[15%] left-1/2 transform -translate-x-1/2 bg-green-500/50 text-white px-6 py-3 rounded-lg shadow-lg flex items-center space-x-4 z-50">
+    </div>
+
     <h1>「{{ $character_first->character->name }}」の感想投稿一覧</h1>
     <a href="{{ route('character_posts.create', ['character_id' => $character_first->character_id]) }}">新規投稿作成</a>
     <!-- 検索機能 -->
     <div class=serch>
-        <form action="{{ route('character_posts.index', ['character_id' => $character_first->character_id]) }}" method="GET">
+        <form action="{{ route('character_posts.index', ['character_id' => $character_first->character_id]) }}"
+            method="GET">
             <input type="text" name="search" value="{{ request('search') }}" placeholder="キーワードを検索" aria-label="検索...">
             <input type="submit" value="キーワード検索">
         </form>
@@ -12,49 +17,52 @@
         </div>
     </div>
     <div class='character_posts'>
-        @if($character_posts->isEmpty())
-        <h2 class='no_result'>結果がありません。</h2>
+        @if ($character_posts->isEmpty())
+            <h2 class='no_result'>結果がありません。</h2>
         @else
-        <div class='character_post'>
-            @foreach ($character_posts as $character_post)
             <div class='character_post'>
-                <h2 class='title'>
-                    <a href="{{ route('character_posts.show', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}">{{ $character_post->post_title }}</a>
-                </h2>
-                <div class="like">
-                    <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
-                    <button id="like_button"
-                        data-character-id="{{ $character_post->character_id }}"
-                        data-post-id="{{ $character_post->id }}"
-                        type="submit">
-                        {{ $character_post->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
-                    </button>
-                    <div class="like_user">
-                        <a href="{{ route('character_post_like.index', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}">
-                            <p id="like_count">{{ $character_post->users->count() }}</p>
-                        </a>
-                    </div>
-                </div>
+                @foreach ($character_posts as $character_post)
+                    <div class='character_post'>
+                        <h2 class='title'>
+                            <a
+                                href="{{ route('character_posts.show', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}">{{ $character_post->post_title }}</a>
+                        </h2>
+                        <div class="like">
+                            <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
+                            <button id="like_button" data-character-id="{{ $character_post->character_id }}"
+                                data-post-id="{{ $character_post->id }}" type="submit">
+                                {{ $character_post->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
+                            </button>
+                            <div class="like_user">
+                                <a
+                                    href="{{ route('character_post_like.index', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}">
+                                    <p id="like_count">{{ $character_post->users->count() }}</p>
+                                </a>
+                            </div>
+                        </div>
 
-                <h5 class='category'>
-                    @foreach($character_post->categories as $category)
-                    {{ $category->name }}
-                    @endforeach
-                </h5>
-                <p class='body'>{{ $character_post->body }}</p>
-                @if($character_post->image1)
-                <div>
-                    <img src="{{ $character_post->image1 }}" alt="画像が読み込めません。">
-                </div>
-                @endif
-                <form action="{{ route('character_posts.delete', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}" id="form_{{ $character_post->id }}" method="post">
-                    @csrf
-                    @method('DELETE')
-                    <button type="button" data-post-id="{{ $character_post->id }}" class="delete-button">投稿を削除する</button>
-                </form>
+                        <h5 class='category'>
+                            @foreach ($character_post->categories as $category)
+                                {{ $category->name }}
+                            @endforeach
+                        </h5>
+                        <p class='body'>{{ $character_post->body }}</p>
+                        @if ($character_post->image1)
+                            <div>
+                                <img src="{{ $character_post->image1 }}" alt="画像が読み込めません。">
+                            </div>
+                        @endif
+                        <form
+                            action="{{ route('character_posts.delete', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}"
+                            id="form_{{ $character_post->id }}" method="post">
+                            @csrf
+                            @method('DELETE')
+                            <button type="button" data-post-id="{{ $character_post->id }}"
+                                class="delete-button">投稿を削除する</button>
+                        </form>
+                    </div>
+                @endforeach
             </div>
-            @endforeach
-        </div>
         @endif
     </div>
     <div class="footer">
@@ -88,6 +96,7 @@
         // いいね処理を非同期で行う
         document.addEventListener('DOMContentLoaded', function() {
             const likeClasses = document.querySelectorAll('.like');
+            const likeMessage = document.getElementById('like-message');
             likeClasses.forEach(element => {
                 // いいねボタンのクラスの取得
                 let button = element.querySelector('#like_button');
@@ -100,13 +109,14 @@
                     const characterId = button.getAttribute('data-character-id');
                     const postId = button.getAttribute('data-post-id');
                     try {
-                        const response = await fetch(`/character_posts/${characterId}/posts/${postId}/like`, {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                                'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                            },
-                        });
+                        const response = await fetch(
+                            `/character_posts/${characterId}/posts/${postId}/like`, {
+                                method: 'POST',
+                                headers: {
+                                    'Content-Type': 'application/json',
+                                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                                },
+                            });
                         const data = await response.json();
                         if (data.status === 'liked') {
                             button.innerText = 'いいね取り消し';
@@ -115,6 +125,16 @@
                             button.innerText = 'いいね';
                             users.innerText = data.like_user;
                         }
+                        // メッセージを表示
+                        likeMessage.textContent = data.message;
+                        likeMessage.classList.remove('hidden');
+                        likeMessage.classList.add('block');
+
+                        // 3秒後にメッセージを非表示
+                        setTimeout(() => {
+                            likeMessage.classList.add('hidden');
+                            likeMessage.classList.remove('block');
+                        }, 3000);
                     } catch (error) {
                         console.error('Error:', error);
                     }

--- a/resources/views/character_posts/index.blade.php
+++ b/resources/views/character_posts/index.blade.php
@@ -71,7 +71,8 @@
     <div class='paginate'>
         {{ $character_posts->appends(request()->query())->links() }}
     </div>
-
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <script src="{{ asset('/js/like_posts/like_character_post.js') }}"></script>
     <script>
         // DOMツリー読み取り完了後にイベント発火
         document.addEventListener('DOMContentLoaded', function() {
@@ -92,54 +93,5 @@
                 document.getElementById(`form_${postId}`).submit();
             }
         }
-
-        // いいね処理を非同期で行う
-        document.addEventListener('DOMContentLoaded', function() {
-            const likeClasses = document.querySelectorAll('.like');
-            const likeMessage = document.getElementById('like-message');
-            likeClasses.forEach(element => {
-                // いいねボタンのクラスの取得
-                let button = element.querySelector('#like_button');
-                // いいねしたユーザー数のクラス取得とpタグの取得
-                let likeClass = element.querySelector('.like_user');
-                let users = likeClass.querySelector('#like_count');
-
-                //いいねボタンクリックによる非同期処理
-                button.addEventListener('click', async function() {
-                    const characterId = button.getAttribute('data-character-id');
-                    const postId = button.getAttribute('data-post-id');
-                    try {
-                        const response = await fetch(
-                            `/character_posts/${characterId}/posts/${postId}/like`, {
-                                method: 'POST',
-                                headers: {
-                                    'Content-Type': 'application/json',
-                                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                                },
-                            });
-                        const data = await response.json();
-                        if (data.status === 'liked') {
-                            button.innerText = 'いいね取り消し';
-                            users.innerText = data.like_user;
-                        } else if (data.status === 'unliked') {
-                            button.innerText = 'いいね';
-                            users.innerText = data.like_user;
-                        }
-                        // メッセージを表示
-                        likeMessage.textContent = data.message;
-                        likeMessage.classList.remove('hidden');
-                        likeMessage.classList.add('block');
-
-                        // 3秒後にメッセージを非表示
-                        setTimeout(() => {
-                            likeMessage.classList.add('hidden');
-                            likeMessage.classList.remove('block');
-                        }, 3000);
-                    } catch (error) {
-                        console.error('Error:', error);
-                    }
-                });
-            });
-        });
     </script>
 </x-app-layout>

--- a/resources/views/character_posts/show.blade.php
+++ b/resources/views/character_posts/show.blade.php
@@ -1,17 +1,20 @@
 <x-app-layout>
+    <div id="like-message"
+        class="hidden fixed top-[15%] left-1/2 transform -translate-x-1/2 bg-green-500/50 text-white px-6 py-3 rounded-lg shadow-lg flex items-center space-x-4 z-50">
+    </div>
+
     <h1 class="title">
         {{ $character_post->post_title }}
     </h1>
     <div class="like">
         <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
-        <button id="like_button"
-            data-character-id="{{ $character_post->character_id }}"
-            data-post-id="{{ $character_post->id }}"
-            type="submit">
+        <button id="like_button" data-character-id="{{ $character_post->character_id }}"
+            data-post-id="{{ $character_post->id }}" type="submit">
             {{ $character_post->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
         </button>
         <div class="like_user">
-            <a href="{{ route('character_post_like.index', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}">
+            <a
+                href="{{ route('character_post_like.index', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}">
                 <p id="like_count">{{ $character_post->users->count() }}</p>
             </a>
         </div>
@@ -26,13 +29,13 @@
             <p>{{ $character_post->post_title }}</p>
             <h3>カテゴリー</h3>
             <h5 class='category'>
-                @foreach($character_post->categories as $category)
-                {{ $category->name }}
+                @foreach ($character_post->categories as $category)
+                    {{ $category->name }}
                 @endforeach
             </h5>
             <h3>評価</h3>
             @php
-            $numbers = array(1 => '★', 2 => '★★', 3 => '★★★', 4 => '★★★★', 5 => '★★★★★');
+                $numbers = [1 => '★', 2 => '★★', 3 => '★★★', 4 => '★★★★', 5 => '★★★★★'];
             @endphp
             <p>{{ $numbers[$character_post->star_num] }}</p>
             <h3>本文</h3>
@@ -40,24 +43,27 @@
             <h3>作成日</h3>
             <p>{{ $character_post->created_at }}</p>
             @php
-            $numbers = array(1, 2, 3, 4);
+                $numbers = [1, 2, 3, 4];
             @endphp
-            @foreach($numbers as $number)
-            @php
-            $image = "image".$number;
-            @endphp
-            @if($character_post->$image)
-            <div>
-                <img src="{{ $character_post->$image }}" alt="画像が読み込めません。">
-            </div>
-            @endif
+            @foreach ($numbers as $number)
+                @php
+                    $image = 'image' . $number;
+                @endphp
+                @if ($character_post->$image)
+                    <div>
+                        <img src="{{ $character_post->$image }}" alt="画像が読み込めません。">
+                    </div>
+                @endif
             @endforeach
         </div>
     </div>
     <div class="edit">
-        <a href="{{ route('character_posts.edit', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}">編集する</a>
+        <a
+            href="{{ route('character_posts.edit', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}">編集する</a>
     </div>
-    <form action="{{ route('character_posts.delete', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}" id="form_{{ $character_post->id }}" method="post">
+    <form
+        action="{{ route('character_posts.delete', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}"
+        id="form_{{ $character_post->id }}" method="post">
         @csrf
         @method('DELETE')
         <button type="button" data-post-id="{{ $character_post->id }}" class="delete-button">投稿を削除する</button>
@@ -90,6 +96,7 @@
         // いいね処理を非同期で行う
         document.addEventListener('DOMContentLoaded', function() {
             const likeClasses = document.querySelectorAll('.like');
+            const likeMessage = document.getElementById('like-message');
             likeClasses.forEach(element => {
                 // いいねボタンのクラスの取得
                 let button = element.querySelector('#like_button');
@@ -102,13 +109,14 @@
                     const characterId = button.getAttribute('data-character-id');
                     const postId = button.getAttribute('data-post-id');
                     try {
-                        const response = await fetch(`/character_posts/${characterId}/posts/${postId}/like`, {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                                'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                            },
-                        });
+                        const response = await fetch(
+                            `/character_posts/${characterId}/posts/${postId}/like`, {
+                                method: 'POST',
+                                headers: {
+                                    'Content-Type': 'application/json',
+                                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                                },
+                            });
                         const data = await response.json();
                         if (data.status === 'liked') {
                             button.innerText = 'いいね取り消し';
@@ -117,6 +125,16 @@
                             button.innerText = 'いいね';
                             users.innerText = data.like_user;
                         }
+                        // メッセージを表示
+                        likeMessage.textContent = data.message;
+                        likeMessage.classList.remove('hidden');
+                        likeMessage.classList.add('block');
+
+                        // 3秒後にメッセージを非表示
+                        setTimeout(() => {
+                            likeMessage.classList.add('hidden');
+                            likeMessage.classList.remove('block');
+                        }, 3000);
                     } catch (error) {
                         console.error('Error:', error);
                     }

--- a/resources/views/character_posts/show.blade.php
+++ b/resources/views/character_posts/show.blade.php
@@ -71,6 +71,8 @@
     <div class="footer">
         <a href="{{ route('character_posts.index', ['character_id' => $character_post->character_id]) }}">戻る</a>
     </div>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <script src="{{ asset('/js/like_posts/like_character_post.js') }}"></script>
 
     <script>
         // DOMツリー読み取り完了後にイベント発火
@@ -92,54 +94,5 @@
                 document.getElementById(`form_${postId}`).submit();
             }
         }
-
-        // いいね処理を非同期で行う
-        document.addEventListener('DOMContentLoaded', function() {
-            const likeClasses = document.querySelectorAll('.like');
-            const likeMessage = document.getElementById('like-message');
-            likeClasses.forEach(element => {
-                // いいねボタンのクラスの取得
-                let button = element.querySelector('#like_button');
-                // いいねしたユーザー数のクラス取得とpタグの取得
-                let likeClass = element.querySelector('.like_user');
-                let users = likeClass.querySelector('#like_count');
-
-                //いいねボタンクリックによる非同期処理
-                button.addEventListener('click', async function() {
-                    const characterId = button.getAttribute('data-character-id');
-                    const postId = button.getAttribute('data-post-id');
-                    try {
-                        const response = await fetch(
-                            `/character_posts/${characterId}/posts/${postId}/like`, {
-                                method: 'POST',
-                                headers: {
-                                    'Content-Type': 'application/json',
-                                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                                },
-                            });
-                        const data = await response.json();
-                        if (data.status === 'liked') {
-                            button.innerText = 'いいね取り消し';
-                            users.innerText = data.like_user;
-                        } else if (data.status === 'unliked') {
-                            button.innerText = 'いいね';
-                            users.innerText = data.like_user;
-                        }
-                        // メッセージを表示
-                        likeMessage.textContent = data.message;
-                        likeMessage.classList.remove('hidden');
-                        likeMessage.classList.add('block');
-
-                        // 3秒後にメッセージを非表示
-                        setTimeout(() => {
-                            likeMessage.classList.add('hidden');
-                            likeMessage.classList.remove('block');
-                        }, 3000);
-                    } catch (error) {
-                        console.error('Error:', error);
-                    }
-                });
-            });
-        });
     </script>
 </x-app-layout>

--- a/resources/views/music_posts/index.blade.php
+++ b/resources/views/music_posts/index.blade.php
@@ -1,4 +1,8 @@
 <x-app-layout>
+    <div id="like-message"
+        class="hidden fixed top-[15%] left-1/2 transform -translate-x-1/2 bg-green-500/50 text-white px-6 py-3 rounded-lg shadow-lg flex items-center space-x-4 z-50">
+    </div>
+
     <h1>「{{ $music_first->music->name }}」の感想投稿一覧</h1>
     <a href="{{ route('music_posts.create', ['music_id' => $music_first->music_id]) }}">新規投稿作成</a>
     <!-- 検索機能 -->
@@ -81,6 +85,7 @@
         // いいね処理を非同期で行う
         document.addEventListener('DOMContentLoaded', function() {
             const likeClasses = document.querySelectorAll('.like');
+            const likeMessage = document.getElementById('like-message');
             likeClasses.forEach(element => {
                 // いいねボタンのクラスの取得
                 let button = element.querySelector('#like_button');
@@ -109,6 +114,16 @@
                             button.innerText = 'いいね';
                             users.innerText = data.like_user;
                         }
+                        // メッセージを表示
+                        likeMessage.textContent = data.message;
+                        likeMessage.classList.remove('hidden');
+                        likeMessage.classList.add('block');
+
+                        // 3秒後にメッセージを非表示
+                        setTimeout(() => {
+                            likeMessage.classList.add('hidden');
+                            likeMessage.classList.remove('block');
+                        }, 3000);
                     } catch (error) {
                         console.error('Error:', error);
                     }

--- a/resources/views/music_posts/index.blade.php
+++ b/resources/views/music_posts/index.blade.php
@@ -12,38 +12,42 @@
         </div>
     </div>
     <div class='music_posts'>
-        @if($music_posts->isEmpty())
-        <h2 class='no_result'>結果がありません。</h2>
+        @if ($music_posts->isEmpty())
+            <h2 class='no_result'>結果がありません。</h2>
         @else
-        <div class='music_post'>
-            @foreach ($music_posts as $music_post)
             <div class='music_post'>
-                <h2 class='title'>
-                    <a href="{{ route('music_posts.show', ['music_id' => $music_post->music_id, 'music_post_id' => $music_post->id]) }}">{{ $music_post->post_title }}</a>
-                </h2>
-                <div class="like">
-                    <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
-                    <button id="like_button"
-                        data-music-id="{{ $music_post->music_id }}"
-                        data-post-id="{{ $music_post->id }}"
-                        type="submit">
-                        {{ $music_post->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
-                    </button>
-                    <div class="like_user">
-                        <a href="{{ route('music_post_like.index', ['music_id' => $music_post->music_id, 'music_post_id' => $music_post->id]) }}">
-                            <p id="like_count">{{ $music_post->users->count() }}</p>
-                        </a>
+                @foreach ($music_posts as $music_post)
+                    <div class='music_post'>
+                        <h2 class='title'>
+                            <a
+                                href="{{ route('music_posts.show', ['music_id' => $music_post->music_id, 'music_post_id' => $music_post->id]) }}">{{ $music_post->post_title }}</a>
+                        </h2>
+                        <p>{{ $music_post->user->name }}</p>
+                        <div class="like">
+                            <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
+                            <button id="like_button" data-music-id="{{ $music_post->music_id }}"
+                                data-post-id="{{ $music_post->id }}" type="submit">
+                                {{ $music_post->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
+                            </button>
+                            <div class="like_user">
+                                <a
+                                    href="{{ route('music_post_like.index', ['music_id' => $music_post->music_id, 'music_post_id' => $music_post->id]) }}">
+                                    <p id="like_count">{{ $music_post->users->count() }}</p>
+                                </a>
+                            </div>
+                        </div>
+                        <p class='body'>{{ $music_post->body }}</p>
+                        <form
+                            action="{{ route('music_posts.delete', ['music_id' => $music_post->music_id, 'music_post_id' => $music_post->id]) }}"
+                            id="form_{{ $music_post->id }}" method="post">
+                            @csrf
+                            @method('DELETE')
+                            <button type="button" data-post-id="{{ $music_post->id }}"
+                                class="delete-button">投稿を削除する</button>
+                        </form>
                     </div>
-                </div>
-                <p class='body'>{{ $music_post->body }}</p>
-                <form action="{{ route('music_posts.delete', ['music_id' => $music_post->music_id, 'music_post_id' => $music_post->id]) }}" id="form_{{ $music_post->id }}" method="post">
-                    @csrf
-                    @method('DELETE')
-                    <button type="button" data-post-id="{{ $music_post->id }}" class="delete-button">投稿を削除する</button>
-                </form>
+                @endforeach
             </div>
-            @endforeach
-        </div>
         @endif
     </div>
     <div class="footer">
@@ -89,13 +93,14 @@
                     const musicId = button.getAttribute('data-music-id');
                     const postId = button.getAttribute('data-post-id');
                     try {
-                        const response = await fetch(`/music_posts/${musicId}/posts/${postId}/like`, {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                                'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                            },
-                        });
+                        const response = await fetch(
+                            `/music_posts/${musicId}/posts/${postId}/like`, {
+                                method: 'POST',
+                                headers: {
+                                    'Content-Type': 'application/json',
+                                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                                },
+                            });
                         const data = await response.json();
                         if (data.status === 'liked') {
                             button.innerText = 'いいね取り消し';

--- a/resources/views/music_posts/index.blade.php
+++ b/resources/views/music_posts/index.blade.php
@@ -60,6 +60,8 @@
     <div class='paginate'>
         {{ $music_posts->appends(request()->query())->links() }}
     </div>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <script src="{{ asset('/js/like_posts/like_music_post.js') }}"></script>
 
     <script>
         // DOMツリー読み取り完了後にイベント発火
@@ -81,54 +83,5 @@
                 document.getElementById(`form_${postId}`).submit();
             }
         }
-
-        // いいね処理を非同期で行う
-        document.addEventListener('DOMContentLoaded', function() {
-            const likeClasses = document.querySelectorAll('.like');
-            const likeMessage = document.getElementById('like-message');
-            likeClasses.forEach(element => {
-                // いいねボタンのクラスの取得
-                let button = element.querySelector('#like_button');
-                // いいねしたユーザー数のクラス取得とpタグの取得
-                let likeClass = element.querySelector('.like_user');
-                let users = likeClass.querySelector('#like_count');
-
-                //いいねボタンクリックによる非同期処理
-                button.addEventListener('click', async function() {
-                    const musicId = button.getAttribute('data-music-id');
-                    const postId = button.getAttribute('data-post-id');
-                    try {
-                        const response = await fetch(
-                            `/music_posts/${musicId}/posts/${postId}/like`, {
-                                method: 'POST',
-                                headers: {
-                                    'Content-Type': 'application/json',
-                                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                                },
-                            });
-                        const data = await response.json();
-                        if (data.status === 'liked') {
-                            button.innerText = 'いいね取り消し';
-                            users.innerText = data.like_user;
-                        } else if (data.status === 'unliked') {
-                            button.innerText = 'いいね';
-                            users.innerText = data.like_user;
-                        }
-                        // メッセージを表示
-                        likeMessage.textContent = data.message;
-                        likeMessage.classList.remove('hidden');
-                        likeMessage.classList.add('block');
-
-                        // 3秒後にメッセージを非表示
-                        setTimeout(() => {
-                            likeMessage.classList.add('hidden');
-                            likeMessage.classList.remove('block');
-                        }, 3000);
-                    } catch (error) {
-                        console.error('Error:', error);
-                    }
-                });
-            });
-        });
     </script>
 </x-app-layout>

--- a/resources/views/music_posts/show.blade.php
+++ b/resources/views/music_posts/show.blade.php
@@ -1,17 +1,20 @@
 <x-app-layout>
+    <div id="like-message"
+        class="hidden fixed top-[15%] left-1/2 transform -translate-x-1/2 bg-green-500/50 text-white px-6 py-3 rounded-lg shadow-lg flex items-center space-x-4 z-50">
+    </div>
+
     <h1 class="title">
         {{ $music_post->post_title }}
     </h1>
     <div class="like">
         <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
-        <button id="like_button"
-            data-music-id="{{ $music_post->music_id }}"
-            data-post-id="{{ $music_post->id }}"
+        <button id="like_button" data-music-id="{{ $music_post->music_id }}" data-post-id="{{ $music_post->id }}"
             type="submit">
             {{ $music_post->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
         </button>
         <div class="like_user">
-            <a href="{{ route('music_post_like.index', ['music_id' => $music_post->music_id, 'music_post_id' => $music_post->id]) }}">
+            <a
+                href="{{ route('music_post_like.index', ['music_id' => $music_post->music_id, 'music_post_id' => $music_post->id]) }}">
                 <p id="like_count">{{ $music_post->users->count() }}</p>
             </a>
         </div>
@@ -28,7 +31,7 @@
             <p>{{ $music_post->post_title }}</p>
             <h3>評価</h3>
             @php
-            $numbers = array(1 => '★', 2 => '★★', 3 => '★★★', 4 => '★★★★', 5 => '★★★★★');
+                $numbers = [1 => '★', 2 => '★★', 3 => '★★★', 4 => '★★★★', 5 => '★★★★★'];
             @endphp
             <p>{{ $numbers[$music_post->star_num] }}</p>
             <h3>本文</h3>
@@ -38,9 +41,12 @@
         </div>
     </div>
     <div class="edit">
-        <a href="{{ route('music_posts.edit', ['music_id' => $music_post->music_id, 'music_post_id' => $music_post->id]) }}">編集する</a>
+        <a
+            href="{{ route('music_posts.edit', ['music_id' => $music_post->music_id, 'music_post_id' => $music_post->id]) }}">編集する</a>
     </div>
-    <form action="{{ route('music_posts.delete', ['music_id' => $music_post->music_id, 'music_post_id' => $music_post->id]) }}" id="form_{{ $music_post->id }}" method="post">
+    <form
+        action="{{ route('music_posts.delete', ['music_id' => $music_post->music_id, 'music_post_id' => $music_post->id]) }}"
+        id="form_{{ $music_post->id }}" method="post">
         @csrf
         @method('DELETE')
         <button type="button" data-post-id="{{ $music_post->id }}" class="delete-button">投稿を削除する</button>
@@ -73,6 +79,7 @@
         // いいね処理を非同期で行う
         document.addEventListener('DOMContentLoaded', function() {
             const likeClasses = document.querySelectorAll('.like');
+            const likeMessage = document.getElementById('like-message');
             likeClasses.forEach(element => {
                 // いいねボタンのクラスの取得
                 let button = element.querySelector('#like_button');
@@ -85,13 +92,14 @@
                     const musicId = button.getAttribute('data-music-id');
                     const postId = button.getAttribute('data-post-id');
                     try {
-                        const response = await fetch(`/music_posts/${musicId}/posts/${postId}/like`, {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                                'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                            },
-                        });
+                        const response = await fetch(
+                            `/music_posts/${musicId}/posts/${postId}/like`, {
+                                method: 'POST',
+                                headers: {
+                                    'Content-Type': 'application/json',
+                                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                                },
+                            });
                         const data = await response.json();
                         if (data.status === 'liked') {
                             button.innerText = 'いいね取り消し';
@@ -100,6 +108,16 @@
                             button.innerText = 'いいね';
                             users.innerText = data.like_user;
                         }
+                        // メッセージを表示
+                        likeMessage.textContent = data.message;
+                        likeMessage.classList.remove('hidden');
+                        likeMessage.classList.add('block');
+
+                        // 3秒後にメッセージを非表示
+                        setTimeout(() => {
+                            likeMessage.classList.add('hidden');
+                            likeMessage.classList.remove('block');
+                        }, 3000);
                     } catch (error) {
                         console.error('Error:', error);
                     }

--- a/resources/views/music_posts/show.blade.php
+++ b/resources/views/music_posts/show.blade.php
@@ -54,6 +54,8 @@
     <div class="footer">
         <a href="{{ route('music_posts.index', ['music_id' => $music_post->music_id]) }}">戻る</a>
     </div>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <script src="{{ asset('/js/like_posts/like_music_post.js') }}"></script>
 
     <script>
         // DOMツリー読み取り完了後にイベント発火
@@ -75,54 +77,5 @@
                 document.getElementById(`form_${postId}`).submit();
             }
         }
-
-        // いいね処理を非同期で行う
-        document.addEventListener('DOMContentLoaded', function() {
-            const likeClasses = document.querySelectorAll('.like');
-            const likeMessage = document.getElementById('like-message');
-            likeClasses.forEach(element => {
-                // いいねボタンのクラスの取得
-                let button = element.querySelector('#like_button');
-                // いいねしたユーザー数のクラス取得とpタグの取得
-                let likeClass = element.querySelector('.like_user');
-                let users = likeClass.querySelector('#like_count');
-
-                //いいねボタンクリックによる非同期処理
-                button.addEventListener('click', async function() {
-                    const musicId = button.getAttribute('data-music-id');
-                    const postId = button.getAttribute('data-post-id');
-                    try {
-                        const response = await fetch(
-                            `/music_posts/${musicId}/posts/${postId}/like`, {
-                                method: 'POST',
-                                headers: {
-                                    'Content-Type': 'application/json',
-                                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                                },
-                            });
-                        const data = await response.json();
-                        if (data.status === 'liked') {
-                            button.innerText = 'いいね取り消し';
-                            users.innerText = data.like_user;
-                        } else if (data.status === 'unliked') {
-                            button.innerText = 'いいね';
-                            users.innerText = data.like_user;
-                        }
-                        // メッセージを表示
-                        likeMessage.textContent = data.message;
-                        likeMessage.classList.remove('hidden');
-                        likeMessage.classList.add('block');
-
-                        // 3秒後にメッセージを非表示
-                        setTimeout(() => {
-                            likeMessage.classList.add('hidden');
-                            likeMessage.classList.remove('block');
-                        }, 3000);
-                    } catch (error) {
-                        console.error('Error:', error);
-                    }
-                });
-            });
-        });
     </script>
 </x-app-layout>

--- a/resources/views/work_reviews/index.blade.php
+++ b/resources/views/work_reviews/index.blade.php
@@ -1,4 +1,8 @@
 <x-app-layout>
+    <div id="like-message"
+        class="hidden fixed top-[15%] left-1/2 transform -translate-x-1/2 bg-green-500/50 text-white px-6 py-3 rounded-lg shadow-lg flex items-center space-x-4 z-50">
+    </div>
+
     <h1>「{{ $work->work->name }}」の感想投稿一覧</h1>
     <a href="{{ route('work_reviews.create', ['work_id' => $work->work_id]) }}">新規投稿作成</a>
     <!-- 検索機能 -->
@@ -22,6 +26,9 @@
                             <a
                                 href="{{ route('work_reviews.show', ['work_id' => $work_review->work_id, 'work_review_id' => $work_review->id]) }}">{{ $work_review->post_title }}</a>
                         </h2>
+                        <div class='user'>
+                            <p>{{ $work_review->user->name }}</p>
+                        </div>
                         <div class="like">
 
                             <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
@@ -66,7 +73,8 @@
     <div class='paginate'>
         {{ $work_reviews->appends(request()->query())->links() }}
     </div>
-
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <script src="{{ asset('/js/like_posts/like_work_post.js') }}"></script>
     <script>
         // DOMツリー読み取り完了後にイベント発火
         document.addEventListener('DOMContentLoaded', function() {
@@ -87,43 +95,5 @@
                 document.getElementById(`form_${postId}`).submit();
             }
         }
-
-        // いいね処理を非同期で行う
-        document.addEventListener('DOMContentLoaded', function() {
-            const likeClasses = document.querySelectorAll('.like');
-            likeClasses.forEach(element => {
-                // いいねボタンのクラスの取得
-                let button = element.querySelector('#like_button');
-                // いいねしたユーザー数のクラス取得とpタグの取得
-                let likeClass = element.querySelector('.like_user');
-                let users = likeClass.querySelector('#like_count');
-
-                //いいねボタンクリックによる非同期処理
-                button.addEventListener('click', async function() {
-                    const workId = button.getAttribute('data-work-id');
-                    const reviewId = button.getAttribute('data-review-id');
-                    try {
-                        const response = await fetch(
-                            `/work_reviews/${workId}/reviews/${reviewId}/like`, {
-                                method: 'POST',
-                                headers: {
-                                    'Content-Type': 'application/json',
-                                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                                },
-                            });
-                        const data = await response.json();
-                        if (data.status === 'liked') {
-                            button.innerText = 'いいね取り消し';
-                            users.innerText = data.like_user;
-                        } else if (data.status === 'unliked') {
-                            button.innerText = 'いいね';
-                            users.innerText = data.like_user;
-                        }
-                    } catch (error) {
-                        console.error('Error:', error);
-                    }
-                });
-            });
-        });
     </script>
 </x-app-layout>

--- a/resources/views/work_reviews/show.blade.php
+++ b/resources/views/work_reviews/show.blade.php
@@ -1,4 +1,8 @@
 <x-app-layout>
+    <div id="like-message"
+        class="hidden fixed top-[15%] left-1/2 transform -translate-x-1/2 bg-green-500/50 text-white px-6 py-3 rounded-lg shadow-lg flex items-center space-x-4 z-50">
+    </div>
+
     <h1 class="title">
         {{ $work_review->post_title }}
     </h1>
@@ -60,7 +64,8 @@
     <div class="footer">
         <a href="{{ route('work_reviews.index', ['work_id' => $work_review->work_id]) }}">戻る</a>
     </div>
-
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <script src="{{ asset('/js/like_posts/like_work_post.js') }}"></script>
     <script>
         // DOMツリー読み取り完了後にイベント発火
         document.addEventListener('DOMContentLoaded', function() {
@@ -81,43 +86,5 @@
                 document.getElementById(`form_${postId}`).submit();
             }
         }
-
-        // いいね処理を非同期で行う
-        document.addEventListener('DOMContentLoaded', function() {
-            const likeClasses = document.querySelectorAll('.like');
-            likeClasses.forEach(element => {
-                // いいねボタンのクラスの取得
-                let button = element.querySelector('#like_button');
-                // いいねしたユーザー数のクラス取得とpタグの取得
-                let likeClass = element.querySelector('.like_user');
-                let users = likeClass.querySelector('#like_count');
-
-                //いいねボタンクリックによる非同期処理
-                button.addEventListener('click', async function() {
-                    const workId = button.getAttribute('data-work-id');
-                    const reviewId = button.getAttribute('data-review-id');
-                    try {
-                        const response = await fetch(
-                            `/work_reviews/${workId}/reviews/${reviewId}/like`, {
-                                method: 'POST',
-                                headers: {
-                                    'Content-Type': 'application/json',
-                                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                                },
-                            });
-                        const data = await response.json();
-                        if (data.status === 'liked') {
-                            button.innerText = 'いいね取り消し';
-                            users.innerText = data.like_user;
-                        } else if (data.status === 'unliked') {
-                            button.innerText = 'いいね';
-                            users.innerText = data.like_user;
-                        }
-                    } catch (error) {
-                        console.error('Error:', error);
-                    }
-                });
-            });
-        });
     </script>
 </x-app-layout>

--- a/resources/views/work_story_posts/index.blade.php
+++ b/resources/views/work_story_posts/index.blade.php
@@ -1,4 +1,8 @@
 <x-app-layout>
+    <div id="like-message"
+        class="hidden fixed top-[15%] left-1/2 transform -translate-x-1/2 bg-green-500/50 text-white px-6 py-3 rounded-lg shadow-lg flex items-center space-x-4 z-50">
+    </div>
+
     @if (is_null($work_story_post_first))
         <h2 class='no_post_result'>投稿はまだありません。<br>1人目の投稿者になってみましょう！</h2>
         <a
@@ -78,7 +82,6 @@
         <div class='paginate'>
             {{ $work_story_posts->appends(request()->query())->links() }}
         </div>
-
         <script>
             // DOMツリー読み取り完了後にイベント発火
             document.addEventListener('DOMContentLoaded', function() {
@@ -103,6 +106,7 @@
             // いいね処理を非同期で行う
             document.addEventListener('DOMContentLoaded', function() {
                 const likeClasses = document.querySelectorAll('.like');
+                const likeMessage = document.getElementById('like-message');
                 likeClasses.forEach(element => {
                     // いいねボタンのクラスの取得
                     let button = element.querySelector('#like_button');
@@ -132,6 +136,16 @@
                                 button.innerText = 'いいね';
                                 users.innerText = data.like_user;
                             }
+                            // メッセージを表示
+                            likeMessage.textContent = data.message;
+                            likeMessage.classList.remove('hidden');
+                            likeMessage.classList.add('block');
+
+                            // 3秒後にメッセージを非表示
+                            setTimeout(() => {
+                                likeMessage.classList.add('hidden');
+                                likeMessage.classList.remove('block');
+                            }, 3000);
                         } catch (error) {
                             console.error('Error:', error);
                         }

--- a/resources/views/work_story_posts/index.blade.php
+++ b/resources/views/work_story_posts/index.blade.php
@@ -82,6 +82,8 @@
         <div class='paginate'>
             {{ $work_story_posts->appends(request()->query())->links() }}
         </div>
+        <meta name="csrf-token" content="{{ csrf_token() }}">
+        <script src="{{ asset('/js/like_posts/like_work_story_post.js') }}"></script>
         <script>
             // DOMツリー読み取り完了後にイベント発火
             document.addEventListener('DOMContentLoaded', function() {
@@ -102,56 +104,6 @@
                     document.getElementById(`form_${postId}`).submit();
                 }
             }
-
-            // いいね処理を非同期で行う
-            document.addEventListener('DOMContentLoaded', function() {
-                const likeClasses = document.querySelectorAll('.like');
-                const likeMessage = document.getElementById('like-message');
-                likeClasses.forEach(element => {
-                    // いいねボタンのクラスの取得
-                    let button = element.querySelector('#like_button');
-                    // いいねしたユーザー数のクラス取得とpタグの取得
-                    let likeClass = element.querySelector('.like_user');
-                    let users = likeClass.querySelector('#like_count');
-
-                    //いいねボタンクリックによる非同期処理
-                    button.addEventListener('click', async function() {
-                        const workId = button.getAttribute('data-work-id');
-                        const workStoryId = button.getAttribute('data-work_story-id');
-                        const postId = button.getAttribute('data-post-id');
-                        try {
-                            const response = await fetch(
-                                `/works/${workId}/stories/${workStoryId}/posts/${postId}/like`, {
-                                    method: 'POST',
-                                    headers: {
-                                        'Content-Type': 'application/json',
-                                        'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                                    },
-                                });
-                            const data = await response.json();
-                            if (data.status === 'liked') {
-                                button.innerText = 'いいね取り消し';
-                                users.innerText = data.like_user;
-                            } else if (data.status === 'unliked') {
-                                button.innerText = 'いいね';
-                                users.innerText = data.like_user;
-                            }
-                            // メッセージを表示
-                            likeMessage.textContent = data.message;
-                            likeMessage.classList.remove('hidden');
-                            likeMessage.classList.add('block');
-
-                            // 3秒後にメッセージを非表示
-                            setTimeout(() => {
-                                likeMessage.classList.add('hidden');
-                                likeMessage.classList.remove('block');
-                            }, 3000);
-                        } catch (error) {
-                            console.error('Error:', error);
-                        }
-                    });
-                });
-            });
         </script>
     @endif
 </x-app-layout>

--- a/resources/views/work_story_posts/show.blade.php
+++ b/resources/views/work_story_posts/show.blade.php
@@ -1,18 +1,21 @@
 <x-app-layout>
+    <div id="like-message"
+        class="hidden fixed top-[15%] left-1/2 transform -translate-x-1/2 bg-green-500/50 text-white px-6 py-3 rounded-lg shadow-lg flex items-center space-x-4 z-50">
+    </div>
+
     <h1 class="title">
         {{ $work_story_post->post_title }}
     </h1>
     <div class="like">
         <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
-        <button id="like_button"
-            data-work-id="{{ $work_story_post->work_id }}"
-            data-work_story-id="{{ $work_story_post->sub_title_id }}"
-            data-post-id="{{ $work_story_post->id }}"
+        <button id="like_button" data-work-id="{{ $work_story_post->work_id }}"
+            data-work_story-id="{{ $work_story_post->sub_title_id }}" data-post-id="{{ $work_story_post->id }}"
             type="submit">
             {{ $work_story_post->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
         </button>
         <div class="like_user">
-            <a href="{{ route('work_story_post_like.index', ['work_id' => $work_story_post->work_id, 'work_story_id' => $work_story_post->sub_title_id, 'work_story_post_id' => $work_story_post->id]) }}">
+            <a
+                href="{{ route('work_story_post_like.index', ['work_id' => $work_story_post->work_id, 'work_story_id' => $work_story_post->sub_title_id, 'work_story_post_id' => $work_story_post->id]) }}">
                 <p id="like_count">{{ $work_story_post->users->count() }}</p>
             </a>
         </div>
@@ -32,32 +35,35 @@
             <h3>作成日</h3>
             <p>{{ $work_story_post->created_at }}</p>
             @php
-            $numbers = array(1, 2, 3, 4);
+                $numbers = [1, 2, 3, 4];
             @endphp
-            @foreach($numbers as $number)
-            @php
-            $image = "image".$number;
-            @endphp
-            @if($work_story_post->$image)
-            <div>
-                <img src="{{ $work_story_post->$image }}" alt="画像が読み込めません。">
-            </div>
-            @endif
+            @foreach ($numbers as $number)
+                @php
+                    $image = 'image' . $number;
+                @endphp
+                @if ($work_story_post->$image)
+                    <div>
+                        <img src="{{ $work_story_post->$image }}" alt="画像が読み込めません。">
+                    </div>
+                @endif
             @endforeach
         </div>
     </div>
     <div class="edit">
-        <a href="{{ route('work_story_posts.edit', ['work_id' => $work_story_post->work_id, 'work_story_id' => $work_story_post->sub_title_id, 'work_story_post_id' => $work_story_post->id]) }}">編集する</a>
+        <a
+            href="{{ route('work_story_posts.edit', ['work_id' => $work_story_post->work_id, 'work_story_id' => $work_story_post->sub_title_id, 'work_story_post_id' => $work_story_post->id]) }}">編集する</a>
     </div>
-    <form action="{{ route('work_story_posts.delete', ['work_id' => $work_story_post->work_id, 'work_story_id' => $work_story_post->sub_title_id, 'work_story_post_id' => $work_story_post->id]) }}" id="form_{{ $work_story_post->id }}" method="post">
+    <form
+        action="{{ route('work_story_posts.delete', ['work_id' => $work_story_post->work_id, 'work_story_id' => $work_story_post->sub_title_id, 'work_story_post_id' => $work_story_post->id]) }}"
+        id="form_{{ $work_story_post->id }}" method="post">
         @csrf
         @method('DELETE')
         <button type="button" data-post-id="{{ $work_story_post->id }}" class="delete-button">投稿を削除する</button>
     </form>
     <div class="footer">
-        <a href="{{ route('work_story_posts.index', ['work_id' => $work_story_post->work_id, 'work_story_id' => $work_story_post->sub_title_id]) }}">戻る</a>
+        <a
+            href="{{ route('work_story_posts.index', ['work_id' => $work_story_post->work_id, 'work_story_id' => $work_story_post->sub_title_id]) }}">戻る</a>
     </div>
-
     <script>
         // DOMツリー読み取り完了後にイベント発火
         document.addEventListener('DOMContentLoaded', function() {
@@ -82,6 +88,7 @@
         // いいね処理を非同期で行う
         document.addEventListener('DOMContentLoaded', function() {
             const likeClasses = document.querySelectorAll('.like');
+            const likeMessage = document.getElementById('like-message');
             likeClasses.forEach(element => {
                 // いいねボタンのクラスの取得
                 let button = element.querySelector('#like_button');
@@ -95,13 +102,14 @@
                     const workStoryId = button.getAttribute('data-work_story-id');
                     const postId = button.getAttribute('data-post-id');
                     try {
-                        const response = await fetch(`/works/${workId}/stories/${workStoryId}/posts/${postId}/like`, {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                                'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                            },
-                        });
+                        const response = await fetch(
+                            `/works/${workId}/stories/${workStoryId}/posts/${postId}/like`, {
+                                method: 'POST',
+                                headers: {
+                                    'Content-Type': 'application/json',
+                                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
+                                },
+                            });
                         const data = await response.json();
                         if (data.status === 'liked') {
                             button.innerText = 'いいね取り消し';
@@ -110,6 +118,16 @@
                             button.innerText = 'いいね';
                             users.innerText = data.like_user;
                         }
+                        // メッセージを表示
+                        likeMessage.textContent = data.message;
+                        likeMessage.classList.remove('hidden');
+                        likeMessage.classList.add('block');
+
+                        // 3秒後にメッセージを非表示
+                        setTimeout(() => {
+                            likeMessage.classList.add('hidden');
+                            likeMessage.classList.remove('block');
+                        }, 3000);
                     } catch (error) {
                         console.error('Error:', error);
                     }

--- a/resources/views/work_story_posts/show.blade.php
+++ b/resources/views/work_story_posts/show.blade.php
@@ -64,6 +64,8 @@
         <a
             href="{{ route('work_story_posts.index', ['work_id' => $work_story_post->work_id, 'work_story_id' => $work_story_post->sub_title_id]) }}">戻る</a>
     </div>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <script src="{{ asset('/js/like_posts/like_work_story_post.js') }}"></script>
     <script>
         // DOMツリー読み取り完了後にイベント発火
         document.addEventListener('DOMContentLoaded', function() {
@@ -84,55 +86,5 @@
                 document.getElementById(`form_${postId}`).submit();
             }
         }
-
-        // いいね処理を非同期で行う
-        document.addEventListener('DOMContentLoaded', function() {
-            const likeClasses = document.querySelectorAll('.like');
-            const likeMessage = document.getElementById('like-message');
-            likeClasses.forEach(element => {
-                // いいねボタンのクラスの取得
-                let button = element.querySelector('#like_button');
-                // いいねしたユーザー数のクラス取得とpタグの取得
-                let likeClass = element.querySelector('.like_user');
-                let users = likeClass.querySelector('#like_count');
-
-                //いいねボタンクリックによる非同期処理
-                button.addEventListener('click', async function() {
-                    const workId = button.getAttribute('data-work-id');
-                    const workStoryId = button.getAttribute('data-work_story-id');
-                    const postId = button.getAttribute('data-post-id');
-                    try {
-                        const response = await fetch(
-                            `/works/${workId}/stories/${workStoryId}/posts/${postId}/like`, {
-                                method: 'POST',
-                                headers: {
-                                    'Content-Type': 'application/json',
-                                    'X-CSRF-TOKEN': '{{ csrf_token() }}'
-                                },
-                            });
-                        const data = await response.json();
-                        if (data.status === 'liked') {
-                            button.innerText = 'いいね取り消し';
-                            users.innerText = data.like_user;
-                        } else if (data.status === 'unliked') {
-                            button.innerText = 'いいね';
-                            users.innerText = data.like_user;
-                        }
-                        // メッセージを表示
-                        likeMessage.textContent = data.message;
-                        likeMessage.classList.remove('hidden');
-                        likeMessage.classList.add('block');
-
-                        // 3秒後にメッセージを非表示
-                        setTimeout(() => {
-                            likeMessage.classList.add('hidden');
-                            likeMessage.classList.remove('block');
-                        }, 3000);
-                    } catch (error) {
-                        console.error('Error:', error);
-                    }
-                });
-            });
-        });
     </script>
 </x-app-layout>


### PR DESCRIPTION
### いいね機能のリファクタリング

- #80

・各画面のコントローラーのいいね機能の記述を簡略化
・各blade.phpファイルに記述していた、いいねに関するjsのコードを外部のjsファイルに移動
・各感想投稿のいいねボタン押下でフラッシュメッセージが表示されるように修正
（いいね押下で「いいねしました」、いいね解除で「いいねを解除しました」と表示）

・いいねボタン押下の場合
![image](https://github.com/user-attachments/assets/20c9ab83-1e91-4313-a15b-6d0f492ed6db)

・いいね解除ボタン押下の場合
![image](https://github.com/user-attachments/assets/31de0020-f517-4262-a886-67711ccc3202)
