### PR TITLE
Feat：MVCを意識し、検索に関わる記述をコントローラーからモデルに移す

### DIFF
--- a/app/Http/Controllers/AnimePilgrimageController.php
+++ b/app/Http/Controllers/AnimePilgrimageController.php
@@ -9,33 +9,17 @@ use App\Models\Prefecture;
 class AnimePilgrimageController extends Controller
 {
     // 聖地一覧画面の表示
-    public function index(Prefecture $prefecture)
+    public function index(Request $request, AnimePilgrimage $animePilgrimage, Prefecture $prefecture)
     {
         // 県名モデルのカラム取得
         $prefectures = $prefecture->getLists();
         // 県名検索の値を取得
         $prefecture_search = request('prefecture_search');
 
-        $pilgrimages = AnimePilgrimage::orderBy('id', 'ASC')->where(function ($query) {
-            // キーワード検索がなされた場合
-            if ($search = request('search')) {
-                // 検索語のスペースを半角に統一
-                $search_split = mb_convert_kana($search, 's');
-                // 半角スペースで単語ごとに分割して配列にする
-                $search_array = preg_split('/[\s]+/', $search_split);
-                foreach ($search_array as $search_word) {
-                    $query->where(function ($query) use ($search_word) {
-                        $query->where('name', 'LIKE', "%{$search_word}%")
-                            ->orWhere('place', 'LIKE', "%{$search_word}%");
-                    });
-                }
-            }
-
-            // 県名検索がなされた場合
-            if ($search = request('prefecture_search')) {
-                $query->where('prefecture_id', $search);
-            }
-        })->paginate(5);
+        // 検索キーワードがあれば取得
+        $search = $request->input('search', '');
+        // キーワードに部分一致する聖地を取得
+        $pilgrimages = $animePilgrimage->fetchAnimePilgrimages($search, $prefecture_search);
         return view('pilgrimages.index')->with(['pilgrimages' => $pilgrimages, 'prefectures' => $prefectures, 'prefecture_search' => $prefecture_search]);
     }
 

--- a/app/Http/Controllers/AnimePilgrimagePostController.php
+++ b/app/Http/Controllers/AnimePilgrimagePostController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Http\Request;
 use App\Http\Requests\PilgrimagePostRequest;
 use App\Models\AnimePilgrimagePost;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -13,25 +14,13 @@ class AnimePilgrimagePostController extends Controller
     use SoftDeletes;
 
     // 聖地感想投稿一覧の表示
-    public function index($pilgrimage_id)
+    public function index(Request $request, AnimePilgrimagePost $anime_pilgrimage_posts, $pilgrimage_id)
     {
-        // 指定したidの聖地の投稿のみを表示
-        $pilgrimage_posts = AnimePilgrimagePost::where('anime_pilgrimage_id', $pilgrimage_id)->orderBy('id', 'DESC')->where(function ($query) {
-            // キーワード検索がなされた場合
-            if ($search = request('search')) {
-                // 検索語のスペースを半角に統一
-                $search_split = mb_convert_kana($search, 's');
-                // 半角スペースで単語ごとに分割して配列にする
-                $search_array = preg_split('/[\s]+/', $search_split);
-                foreach ($search_array as $search_word) {
-                    $query->where(function ($query) use ($search_word) {
-                        $query->where('title', 'LIKE', "%{$search_word}%")
-                            ->orwhere('scene', 'LIKE', "%{$search_word}%")
-                            ->orWhere('body', 'LIKE', "%{$search_word}%");
-                    });
-                }
-            }
-        })->paginate(5);
+        // 検索キーワードがあれば取得
+        $search = $request->input('search', '');
+        // キーワードに部分一致する投稿を取得
+        $pilgrimage_posts = $anime_pilgrimage_posts->fetchAnimePilgrimagePosts($pilgrimage_id, $search);
+        // 単体のオブジェクトを取得
         $pilgrimage_first = AnimePilgrimagePost::where('anime_pilgrimage_id', $pilgrimage_id)->first();
         return view('anime_pilgrimage_posts.index')->with(['pilgrimage_posts' => $pilgrimage_posts, 'pilgrimage_first' => $pilgrimage_first]);
     }

--- a/app/Http/Controllers/CharacterController.php
+++ b/app/Http/Controllers/CharacterController.php
@@ -8,22 +8,12 @@ use App\Models\Character;
 class CharacterController extends Controller
 {
     // 作品一覧画面の表示
-    public function index()
+    public function index(Request $request, Character $character)
     {
-        $characters = Character::orderBy('id', 'ASC')->where(function($query) {
-            // キーワード検索がなされた場合
-            if ($search = request('search')) {
-                // 検索語のスペースを半角に統一
-                $search_split = mb_convert_kana($search, 's');
-                // 半角スペースで単語ごとに分割して配列にする
-                $search_array = preg_split('/[\s]+/', $search_split);
-                foreach ($search_array as $search_word) {
-                    $query->where(function ($query) use ($search_word) {
-                        $query->where('name', 'LIKE', "%{$search_word}%");
-                    });
-                }
-            }
-        })->paginate(5);
+        // 検索キーワードがあれば取得
+        $search = $request->input('search', '');
+        // キーワードに部分一致する音楽を取得
+        $characters = $character->fetchCharacters($search);
         return view('characters.index')->with(['characters' => $characters]);
     }
 

--- a/app/Http/Controllers/MusicController.php
+++ b/app/Http/Controllers/MusicController.php
@@ -8,22 +8,12 @@ use App\Models\Music;
 class MusicController extends Controller
 {
     // 音楽画面の表示
-    public function index()
+    public function index(Request $request, Music $music)
     {
-        $music = Music::orderBy('id', 'ASC')->where(function($query) {
-            // キーワード検索がなされた場合
-            if ($search = request('search')) {
-                // 検索語のスペースを半角に統一
-                $search_split = mb_convert_kana($search, 's');
-                // 半角スペースで単語ごとに分割して配列にする
-                $search_array = preg_split('/[\s]+/', $search_split);
-                foreach ($search_array as $search_word) {
-                    $query->where(function ($query) use ($search_word) {
-                        $query->where('name', 'LIKE', "%{$search_word}%");
-                    });
-                }
-            }
-        })->paginate(5);
+        // 検索キーワードがあれば取得
+        $search = $request->input('search', '');
+        // キーワードに部分一致する音楽を取得
+        $music = $music->fetchMusic($search);
         return view('music.index')->with(['music' => $music]);
     }
 

--- a/app/Http/Controllers/WorkController.php
+++ b/app/Http/Controllers/WorkController.php
@@ -8,22 +8,12 @@ use Illuminate\Http\Request;
 class WorkController extends Controller
 {
     // 作品一覧画面の表示
-    public function index()
+    public function index(Request $request, Work $work)
     {
-        $works = Work::orderBy('id', 'ASC')->where(function($query) {
-            // キーワード検索がなされた場合
-            if ($search = request('search')) {
-                // 検索語のスペースを半角に統一
-                $search_split = mb_convert_kana($search, 's');
-                // 半角スペースで単語ごとに分割して配列にする
-                $search_array = preg_split('/[\s]+/', $search_split);
-                foreach ($search_array as $search_word) {
-                    $query->where(function ($query) use ($search_word) {
-                        $query->where('name', 'LIKE', "%{$search_word}%");
-                    });
-                }
-            }
-        })->paginate(5);
+        // 検索キーワードがあれば取得
+        $search = $request->input('search', '');
+        // キーワードに部分一致する作品を取得
+        $works = $work->fetchWorks($search);
         return view('works.index')->with(['works' => $works]);
     }
 

--- a/app/Http/Controllers/WorkStoryController.php
+++ b/app/Http/Controllers/WorkStoryController.php
@@ -8,26 +8,13 @@ use App\Models\WorkStory;
 class WorkStoryController extends Controller
 {
     // あらすじ一覧画面の表示
-    public function index($work_id)
+    public function index(Request $request, WorkStory $workStory, $work_id)
     {
-        $work_stories = WorkStory::where('work_id', '=', $work_id)->orderBy('id', 'ASC')->where(function($query) {
-            
-            // キーワード検索がなされた場合
-            if ($search = request('search')) {
-                // 検索語のスペースを半角に統一
-                $search_split = mb_convert_kana($search, 's');
-                // 半角スペースで単語ごとに分割して配列にする
-                $search_array = preg_split('/[\s]+/', $search_split);
-                foreach ($search_array as $search_word) {
-                    $query->where(function ($query) use ($search_word) {
-                        $query->where('episode', 'LIKE', "%{$search_word}%")
-                        ->orWhere('sub_title', 'LIKE', "%{$search_word}%")
-                        ->orWhere('body', 'LIKE', "%{$search_word}%");
-                    });
-                }
-            }
-        })->paginate(20);
-        // あらすじのモデルを1つ取得
+        // 検索キーワードがあれば取得
+        $search = $request->input('search', '');
+        // キーワードに部分一致するあらすじを取得
+        $work_stories = $workStory->fetchWorkStories($search, $work_id);
+        // あらすじのオブジェクトを1つ取得
         $work_story_model = WorkStory::where('work_id', '=', $work_id)->first();
         return view('work_stories.index')->with(['work_stories' => $work_stories, 'work_story_model' => $work_story_model]);
     }

--- a/app/Models/AnimePilgrimage.php
+++ b/app/Models/AnimePilgrimage.php
@@ -12,6 +12,32 @@ class AnimePilgrimage extends Model
     // 参照させたいanime_pilgrimagesを指定
     protected $table = 'anime_pilgrimages';
 
+    // 聖地の検索処理
+    public function fetchAnimePilgrimages($search, $prefecture_search)
+    {
+        $pilgrimages = AnimePilgrimage::orderBy('id', 'ASC')->where(function ($query) use ($search, $prefecture_search) {
+            // キーワード検索がなされた場合
+            if ($search) {
+                // 検索語のスペースを半角に統一
+                $search_split = mb_convert_kana($search, 's');
+                // 半角スペースで単語ごとに分割して配列にする
+                $search_array = preg_split('/[\s]+/', $search_split);
+                foreach ($search_array as $search_word) {
+                    $query->where(function ($query) use ($search_word) {
+                        $query->where('name', 'LIKE', "%{$search_word}%")
+                            ->orWhere('place', 'LIKE', "%{$search_word}%");
+                    });
+                }
+            }
+
+            // 県名検索がなされた場合
+            if ($prefecture_search) {
+                $query->where('prefecture_id', $prefecture_search);
+            }
+        })->paginate(5);
+        return $pilgrimages;
+    }
+
     // Workに対するリレーション 1対多の関係
     public function work()
     {

--- a/app/Models/AnimePilgrimagePost.php
+++ b/app/Models/AnimePilgrimagePost.php
@@ -30,6 +30,29 @@ class AnimePilgrimagePost extends Model
         'created_at' => 'datetime:Y/m/d H:i',
     ];
 
+    // 聖地投稿の検索処理
+    public function fetchAnimePilgrimagePosts($pilgrimage_id, $search)
+    {
+        // 指定したidの聖地の投稿のみを表示
+        $pilgrimage_posts = AnimePilgrimagePost::where('anime_pilgrimage_id', $pilgrimage_id)->orderBy('id', 'DESC')->where(function ($query) use ($search) {
+            // キーワード検索がなされた場合
+            if ($search) {
+                // 検索語のスペースを半角に統一
+                $search_split = mb_convert_kana($search, 's');
+                // 半角スペースで単語ごとに分割して配列にする
+                $search_array = preg_split('/[\s]+/', $search_split);
+                foreach ($search_array as $search_word) {
+                    $query->where(function ($query) use ($search_word) {
+                        $query->where('post_title', 'LIKE', "%{$search_word}%")
+                            ->orwhere('scene', 'LIKE', "%{$search_word}%")
+                            ->orWhere('body', 'LIKE', "%{$search_word}%");
+                    });
+                }
+            }
+        })->paginate(5);
+        return $pilgrimage_posts;
+    }
+
     // 聖地idと投稿idを指定して、投稿の詳細表示を行う
     public function getDetailPost($pilgrimage_id, $pilgrimage_post_id)
     {

--- a/app/Models/Character.php
+++ b/app/Models/Character.php
@@ -12,6 +12,26 @@ class Character extends Model
     // 参照させたいcharactersを指定
     protected $table = 'characters';
 
+    // 登場人物の検索処理
+    public function fetchCharacters($search)
+    {
+        $characters = Character::orderBy('id', 'ASC')->where(function ($query) use ($search) {
+            // キーワード検索がなされた場合
+            if ($search) {
+                // 検索語のスペースを半角に統一
+                $search_split = mb_convert_kana($search, 's');
+                // 半角スペースで単語ごとに分割して配列にする
+                $search_array = preg_split('/[\s]+/', $search_split);
+                foreach ($search_array as $search_word) {
+                    $query->where(function ($query) use ($search_word) {
+                        $query->where('name', 'LIKE', "%{$search_word}%");
+                    });
+                }
+            }
+        })->paginate(5);
+        return $characters;
+    }
+
     // Workに対するリレーション 1対多の関係
     public function work()
     {

--- a/app/Models/CharacterPost.php
+++ b/app/Models/CharacterPost.php
@@ -31,6 +31,28 @@ class CharacterPost extends Model
         'created_at' => 'datetime:Y/m/d H:i',
     ];
 
+    // 登場人物投稿の検索処理
+    public function fetchCharacterPosts($character_id, $search)
+    {
+        // 指定したidの登場人物の投稿のみを表示
+        $character_posts = CharacterPost::where('character_id', $character_id)->orderBy('id', 'DESC')->where(function ($query) use ($search) {
+            // キーワード検索がなされた場合
+            if ($search) {
+                // 検索語のスペースを半角に統一
+                $search_split = mb_convert_kana($search, 's');
+                // 半角スペースで単語ごとに分割して配列にする
+                $search_array = preg_split('/[\s]+/', $search_split);
+                foreach ($search_array as $search_word) {
+                    $query->where(function ($query) use ($search_word) {
+                        $query->where('post_title', 'LIKE', "%{$search_word}%")
+                            ->orWhere('body', 'LIKE', "%{$search_word}%");
+                    });
+                }
+            }
+        })->paginate(5);
+        return $character_posts;
+    }
+
     // Characterに対するリレーション 1対1の関係
     public function character()
     {

--- a/app/Models/Music.php
+++ b/app/Models/Music.php
@@ -12,6 +12,26 @@ class Music extends Model
     // 参照させたいmusicを指定
     protected $table = 'music';
 
+    // 音楽の検索処理
+    public function fetchMusic($search)
+    {
+        $music = Music::orderBy('id', 'ASC')->where(function ($query) use ($search) {
+            // キーワード検索がなされた場合
+            if ($search) {
+                // 検索語のスペースを半角に統一
+                $search_split = mb_convert_kana($search, 's');
+                // 半角スペースで単語ごとに分割して配列にする
+                $search_array = preg_split('/[\s]+/', $search_split);
+                foreach ($search_array as $search_word) {
+                    $query->where(function ($query) use ($search_word) {
+                        $query->where('name', 'LIKE', "%{$search_word}%");
+                    });
+                }
+            }
+        })->paginate(5);
+        return $music;
+    }
+
     // Workに対するリレーション 1対多の関係
     public function work()
     {

--- a/app/Models/MusicPost.php
+++ b/app/Models/MusicPost.php
@@ -27,6 +27,28 @@ class MusicPost extends Model
         'created_at' => 'datetime:Y/m/d H:i',
     ];
 
+    // 音楽投稿の検索処理
+    public function fetchMusicPosts($music_id, $search)
+    {
+        // 指定したidの音楽の投稿のみを表示
+        $music_posts = MusicPost::where('music_id', $music_id)->orderBy('id', 'DESC')->where(function ($query) use ($search) {
+            // キーワード検索がなされた場合
+            if ($search) {
+                // 検索語のスペースを半角に統一
+                $search_split = mb_convert_kana($search, 's');
+                // 半角スペースで単語ごとに分割して配列にする
+                $search_array = preg_split('/[\s]+/', $search_split);
+                foreach ($search_array as $search_word) {
+                    $query->where(function ($query) use ($search_word) {
+                        $query->where('post_title', 'LIKE', "%{$search_word}%")
+                            ->orWhere('body', 'LIKE', "%{$search_word}%");
+                    });
+                }
+            }
+        })->paginate(5);
+        return $music_posts;
+    }
+
     // Musicに対するリレーション 1対1の関係
     public function music()
     {

--- a/app/Models/Work.php
+++ b/app/Models/Work.php
@@ -12,6 +12,26 @@ class Work extends Model
     // 参照させたいworksを指定
     protected $table = 'works';
 
+    // 作品の検索処理
+    public function fetchWorks($search)
+    {
+        $works = Work::orderBy('id', 'ASC')->where(function ($query) use ($search) {
+            // キーワード検索がなされた場合
+            if ($search) {
+                // 検索語のスペースを半角に統一
+                $search_split = mb_convert_kana($search, 's');
+                // 半角スペースで単語ごとに分割して配列にする
+                $search_array = preg_split('/[\s]+/', $search_split);
+                foreach ($search_array as $search_word) {
+                    $query->where(function ($query) use ($search_word) {
+                        $query->where('name', 'LIKE', "%{$search_word}%");
+                    });
+                }
+            }
+        })->paginate(5);
+        return $works;
+    }
+
     // WorkReviewに対するリレーション 1対1の関係
     public function workreview()
     {

--- a/app/Models/Work.php
+++ b/app/Models/Work.php
@@ -15,20 +15,61 @@ class Work extends Model
     // 作品の検索処理
     public function fetchWorks($search)
     {
-        $works = Work::orderBy('id', 'ASC')->where(function ($query) use ($search) {
-            // キーワード検索がなされた場合
-            if ($search) {
-                // 検索語のスペースを半角に統一
-                $search_split = mb_convert_kana($search, 's');
-                // 半角スペースで単語ごとに分割して配列にする
-                $search_array = preg_split('/[\s]+/', $search_split);
-                foreach ($search_array as $search_word) {
-                    $query->where(function ($query) use ($search_word) {
-                        $query->where('name', 'LIKE', "%{$search_word}%");
-                    });
+        $works = Work::orderBy('id', 'ASC')
+            ->with(['creator', 'animePilgrimages', 'characters', 'characters.voiceArtist', 'music', 'music.singer', 'workStories'])
+            ->where(function ($query) use ($search) {
+                // キーワード検索がなされた場合
+                if ($search) {
+                    // 検索語のスペースを半角に統一
+                    $search_split = mb_convert_kana($search, 's');
+                    // 半角スペースで単語ごとに分割して配列にする
+                    $search_array = preg_split('/[\s]+/', $search_split);
+                    foreach ($search_array as $search_word) {
+                        // 自身のカラムでの検索
+                        $query->where(function ($query) use ($search_word) {
+                            $query->where('name', 'LIKE', "%{$search_word}%");
+                        });
+
+                        // リレーション先のCreatorsテーブルのカラムでの検索
+                        $query->orWhereHas('creator', function ($creatorQuery) use ($search_word) {
+                            $creatorQuery->where('name', 'like', '%' . $search_word . '%');
+                        });
+
+                        // リレーション先のanime_pilgrimagesテーブルのカラムでの検索
+                        $query->orWhereHas('animePilgrimages', function ($animePilgrimageQuery) use ($search_word) {
+                            $animePilgrimageQuery->where('name', 'like', '%' . $search_word . '%')
+                                ->orWhere('place', 'LIKE', "%{$search_word}%");
+                        });
+
+                        // リレーション先のCharactersテーブルのカラムでの検索
+                        $query->orWhereHas('characters', function ($characterQuery) use ($search_word) {
+                            $characterQuery->where('name', 'like', '%' . $search_word . '%');
+
+                            // リレーション先のvoice_artistsテーブルのカラムでの検索
+                            $characterQuery->orWhereHas('voiceArtist', function ($voiceArtistQuery) use ($search_word) {
+                                $voiceArtistQuery->where('name', 'LIKE', "%{$search_word}%");
+                            });
+                        });
+
+                        // リレーション先のMusicsテーブルのカラムでの検索
+                        $query->orWhereHas('music', function ($musicQuery) use ($search_word) {
+                            $musicQuery->where('name', 'like', '%' . $search_word . '%');
+
+                            // リレーション先のsingersテーブルのカラムでの検索
+                            $musicQuery->orWhereHas('singer', function ($singerQuery) use ($search_word) {
+                                $singerQuery->where('name', 'LIKE', "%{$search_word}%");
+                            });
+                        });
+
+                        // リレーション先のWork_storiesテーブルのカラムでの検索
+                        $query->orWhereHas('workStories', function ($workStoryQuery) use ($search_word) {
+                            $workStoryQuery->where('sub_title', 'like', '%' . $search_word . '%')
+                                ->orWhere('episode', 'like', '%' . $search_word . '%')
+                                ->orWhere('body', 'like', '%' . $search_word . '%');
+                        });
+                    }
                 }
-            }
-        })->paginate(5);
+            })->paginate(5);
         return $works;
     }
 

--- a/app/Models/WorkReview.php
+++ b/app/Models/WorkReview.php
@@ -29,6 +29,28 @@ class WorkReview extends Model
         'created_at' => 'datetime:Y/m/d H:i',
     ];
 
+    // 作品投稿の検索処理
+    public function fetchWorkReviews($work_id, $search)
+    {
+        // 指定したidのアニメの投稿のみを表示
+        $work_reviews = WorkReview::where('work_id', $work_id)->orderBy('id', 'ASC')->where(function ($query) use ($search) {
+            // キーワード検索がなされた場合
+            if ($search) {
+                // 検索語のスペースを半角に統一
+                $search_split = mb_convert_kana($search, 's');
+                // 半角スペースで単語ごとに分割して配列にする
+                $search_array = preg_split('/[\s]+/', $search_split);
+                foreach ($search_array as $search_word) {
+                    $query->where(function ($query) use ($search_word) {
+                        $query->where('post_title', 'LIKE', "%{$search_word}%")
+                            ->orWhere('body', 'LIKE', "%{$search_word}%");
+                    });
+                }
+            }
+        })->paginate(5);
+        return $work_reviews;
+    }
+
     // created_atで降順に並べたあと、limitで件数制限をかける
     public function getPaginateByLimit($work_id, int $limit_count = 5)
     {

--- a/app/Models/WorkStory.php
+++ b/app/Models/WorkStory.php
@@ -12,6 +12,29 @@ class WorkStory extends Model
     // 参照させたいwork_storiesを指定
     protected $table = 'work_stories';
 
+    // あらすじの検索処理
+    public function fetchWorkStories($search, $work_id)
+    {
+        $work_stories = WorkStory::where('work_id', '=', $work_id)->orderBy('id', 'ASC')->where(function ($query) use ($search) {
+
+            // キーワード検索がなされた場合
+            if ($search) {
+                // 検索語のスペースを半角に統一
+                $search_split = mb_convert_kana($search, 's');
+                // 半角スペースで単語ごとに分割して配列にする
+                $search_array = preg_split('/[\s]+/', $search_split);
+                foreach ($search_array as $search_word) {
+                    $query->where(function ($query) use ($search_word) {
+                        $query->where('episode', 'LIKE', "%{$search_word}%")
+                            ->orWhere('sub_title', 'LIKE', "%{$search_word}%")
+                            ->orWhere('body', 'LIKE', "%{$search_word}%");
+                    });
+                }
+            }
+        })->paginate(20);
+        return $work_stories;
+    }
+
     // Workに対するリレーション 1対多の関係
     public function work()
     {

--- a/app/Models/WorkStoryPost.php
+++ b/app/Models/WorkStoryPost.php
@@ -30,6 +30,28 @@ class WorkStoryPost extends Model
         'created_at' => 'datetime:Y/m/d H:i',
     ];
 
+    // あらすじ投稿の検索処理
+    public function fetchWorkStoryPosts($work_story_id, $search)
+    {
+        // 指定したidのあらすじの投稿のみを表示
+        $work_story_posts = WorkStoryPost::where('sub_title_id', $work_story_id)->orderBy('id', 'DESC')->where(function ($query) use ($search) {
+            // キーワード検索がなされた場合
+            if ($search) {
+                // 検索語のスペースを半角に統一
+                $search_split = mb_convert_kana($search, 's');
+                // 半角スペースで単語ごとに分割して配列にする
+                $search_array = preg_split('/[\s]+/', $search_split);
+                foreach ($search_array as $search_word) {
+                    $query->where(function ($query) use ($search_word) {
+                        $query->where('post_title', 'LIKE', "%{$search_word}%")
+                            ->orWhere('body', 'LIKE', "%{$search_word}%");
+                    });
+                }
+            }
+        })->paginate(5);
+        return $work_story_posts;
+    }
+
     // あらすじidと投稿idを指定して、投稿の詳細表示を行う
     public function getDetailPost($work_story_id, $work_story_post_id)
     {

--- a/resources/views/works/index.blade.php
+++ b/resources/views/works/index.blade.php
@@ -1,36 +1,27 @@
 <x-app-layout>
     <div class="container mx-auto py-8">
         <h1 class="text-3xl font-bold text-center mb-6">作品一覧</h1>
-        
+
         <!-- 検索機能 -->
         <div class="flex justify-center mb-6">
             <form action="{{ route('works.index') }}" method="GET" class="flex items-center space-x-2">
-                <input 
-                    type="text" 
-                    id="search" 
-                    name="search" 
-                    value="{{ request('search') }}" 
-                    placeholder="キーワードを検索" 
-                    aria-label="検索..." 
-                    class="px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring focus:ring-blue-200"
-                >
-                <input 
-                    type="submit" 
-                    value="検索" 
-                    class="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-400"
-                >
+                <input type="text" id="search" name="search" value="{{ request('search') }}" placeholder="キーワードを検索"
+                    aria-label="検索..."
+                    class="px-4 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring focus:ring-blue-200">
+                <input type="submit" value="検索"
+                    class="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-400">
             </form>
             <div class="ml-4">
-                <a 
-                    href="{{ route('works.index') }}" 
-                    class="text-blue-500 hover:underline focus:outline-none"
-                >キャンセル</a>
+                <a href="{{ route('works.index') }}" class="text-blue-500 hover:underline focus:outline-none">キャンセル</a>
             </div>
+        </div>
+        <div>
+            <p>あらすじ、制作会社、登場人物、声優、音楽名、歌手、聖地など何でも検索してみましょう！</p>
         </div>
 
         <!-- 作品リスト -->
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            @if($works->isEmpty())
+            @if ($works->isEmpty())
                 <h2 class="col-span-full text-center text-gray-500 text-xl">結果がありません。</h2>
             @else
                 @foreach ($works as $work)


### PR DESCRIPTION
### MVCを意識し、検索に関わる記述をコントローラーからモデルに移す

- #29 
- #86

・各一覧画面における検索の記述を、コントローラーからモデルに移す
・作品一覧における検索のみ、リレーション先のデータも検索できるように修正
（制作会社、登場人物、声優、音楽、歌手、聖地、あらすじなど）
・他の検索にも同様にリレーション先のデータを検索できるようにするが、先に登場人物と聖地のテーブルの関係見直しを行う