### PR TITLE
Feat：登場人物テーブルの見直し

### DIFF
--- a/app/Models/Character.php
+++ b/app/Models/Character.php
@@ -35,7 +35,7 @@ class Character extends Model
     // Workに対するリレーション 多対多の関係
     public function works()
     {
-        return $this->belongsTo(Work::class, 'character_work', 'character_id', 'work_id');
+        return $this->belongsToMany(Work::class, 'character_work', 'character_id', 'work_id');
     }
 
     // VoiceArtistに対するリレーション 1対多の関係

--- a/app/Models/Character.php
+++ b/app/Models/Character.php
@@ -32,10 +32,10 @@ class Character extends Model
         return $characters;
     }
 
-    // Workに対するリレーション 1対多の関係
-    public function work()
+    // Workに対するリレーション 多対多の関係
+    public function works()
     {
-        return $this->belongsTo(Work::class, 'work_id', 'id');
+        return $this->belongsTo(Work::class, 'character_work', 'character_id', 'work_id');
     }
 
     // VoiceArtistに対するリレーション 1対多の関係

--- a/app/Models/Work.php
+++ b/app/Models/Work.php
@@ -88,7 +88,7 @@ class Work extends Model
     // Characterに対するリレーション 1対多の関係
     public function characters()
     {
-        return $this->hasMany(Character::class, 'work_id', 'id');
+        return $this->hasMany(Character::class, 'character_work', 'work_id', 'character_id');
     }
 
     // Creatorに対するリレーション 1対多の関係

--- a/app/Models/Work.php
+++ b/app/Models/Work.php
@@ -85,10 +85,10 @@ class Work extends Model
         return $this->hasMany(AnimePilgrimage::class, 'work_id', 'id');
     }
 
-    // Characterに対するリレーション 1対多の関係
+    // Characterに対するリレーション 多対多の関係
     public function characters()
     {
-        return $this->hasMany(Character::class, 'character_work', 'work_id', 'character_id');
+        return $this->belongsToMany(Character::class, 'character_work', 'work_id', 'character_id');
     }
 
     // Creatorに対するリレーション 1対多の関係

--- a/database/migrations/2024_12_07_123341_create_character_work_table.php
+++ b/database/migrations/2024_12_07_123341_create_character_work_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('character_work', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('work_id')->constrained('works')->onDelete('cascade');
+            $table->foreignId('character_id')->constrained('characters')->onDelete('cascade');
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('character_work');
+    }
+};

--- a/database/migrations/2024_12_07_131951_drop_column_work_id.php
+++ b/database/migrations/2024_12_07_131951_drop_column_work_id.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('characters', function (Blueprint $table) {
+            // 外部キー制約を削除
+            $table->dropForeign(['work_id']);
+            // カラムを削除
+            $table->dropColumn('work_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('characters', function (Blueprint $table) {
+            $table->foreignId('work_id')->constrained('works')->onDelete('cascade');
+        });
+    }
+};

--- a/database/seeders/Character_WorkSeeder.php
+++ b/database/seeders/Character_WorkSeeder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use DateTime;
+
+class Character_WorkSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        DB::table('character_work')->insert([
+            'work_id' => 1,
+            'character_id' => 4,
+            'created_at' => new DateTime(),
+        ]);
+        DB::table('character_work')->insert([
+            'work_id' => 2,
+            'character_id' => 1,
+            'created_at' => new DateTime(),
+        ]);
+        DB::table('character_work')->insert([
+            'work_id' => 6,
+            'character_id' => 1,
+            'created_at' => new DateTime(),
+        ]);
+        DB::table('character_work')->insert([
+            'work_id' => 5,
+            'character_id' => 5,
+            'created_at' => new DateTime(),
+        ]);
+        DB::table('character_work')->insert([
+            'work_id' => 1,
+            'character_id' => 6,
+            'created_at' => new DateTime(),
+        ]);
+        DB::table('character_work')->insert([
+            'work_id' => 3,
+            'character_id' => 3,
+            'created_at' => new DateTime(),
+        ]);
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -44,6 +44,7 @@ class DatabaseSeeder extends Seeder
             Character_Post_Like_Seeder::class,
             Character_Post_Categories_Seeder::class,
             Character_Post_Category_Seeder::class,
+            Character_WorkSeeder::class
         ]);
     }
 }

--- a/resources/views/characters/index.blade.php
+++ b/resources/views/characters/index.blade.php
@@ -11,28 +11,31 @@
         </div>
     </div>
     <div class='characters'>
-        @if($characters->isEmpty())
-        <h2 class='no_result'>結果がありません。</h2>
+        @if ($characters->isEmpty())
+            <h2 class='no_result'>結果がありません。</h2>
         @else
-        @foreach ($characters as $character)
-        <div class='character'>
-            <h2 class='name'>
-                <a href="{{ route('characters.show', ['character_id' => $character->id]) }}">
-                    {{ $character->name }}
-                </a>
-            </h2>
-            <p class='work'>
-                <a href="{{ route('works.show', ['work' => $character->work->id]) }}">
-                    {{ $character->work->name }}
-                </a>
-            </p>
-            <p class='voice_artist'>
-                <a href="{{ route('voice_artist.show', ['voice_artist_id' => $character->voiceArtist->id]) }}">
-                    CV:{{ $character->voiceArtist->name }}
-                </a>
-            </p>
-        </div>
-        @endforeach
+            @foreach ($characters as $character)
+                <div class='character'>
+                    <h2 class='name'>
+                        <a href="{{ route('characters.show', ['character_id' => $character->id]) }}">
+                            {{ $character->name }}
+                        </a>
+                    </h2>
+                    <p class='work'>
+                        {{-- 関連する登場作品の数だけ繰り返す --}}
+                        @foreach ($character->works as $character_work)
+                            <a href="{{ route('works.show', ['work' => $character_work->id]) }}">
+                                {{ $character_work->name }}
+                            </a>
+                        @endforeach
+                    </p>
+                    <p class='voice_artist'>
+                        <a href="{{ route('voice_artist.show', ['voice_artist_id' => $character->voiceArtist->id]) }}">
+                            CV:{{ $character->voiceArtist->name }}
+                        </a>
+                    </p>
+                </div>
+            @endforeach
         @endif
     </div>
     <div class='paginate'>

--- a/resources/views/characters/show.blade.php
+++ b/resources/views/characters/show.blade.php
@@ -12,9 +12,12 @@
             </a>
             <h3>登場作品</h3>
             <div class='work'>
-                <a href="{{ route('works.show', ['work' => $character->work->id]) }}">
-                    {{ $character->work->name }}
-                </a>
+                {{-- 関連する登場作品の数だけ繰り返す --}}
+                @foreach ($character->works as $character_work)
+                    <a href="{{ route('works.show', ['work' => $character_work->id]) }}">
+                        {{ $character_work->name }}
+                    </a>
+                @endforeach
             </div>
             <h3>pixivへのリンク</h3>
             <p>{{ $character->wiki_link }}</p>


### PR DESCRIPTION
### 登場人物テーブルの見直し

- #54 

・作品と登場人物の関係を1対多から多対多に変更
・それに伴って中間テーブルのcharacter_workを作成
・リレーション名も変更し、blade.phpの記述を修正
・charactersテーブルから不要になったwork_idを削除

・登場人物に対して、複数の作品が登録できるようになった
![image](https://github.com/user-attachments/assets/d8b2b0a4-6a2a-4220-a474-0a3153e71df8)
