### PR TITLE
Feat：聖地テーブルの見直し

### DIFF
--- a/app/Models/AnimePilgrimage.php
+++ b/app/Models/AnimePilgrimage.php
@@ -38,10 +38,10 @@ class AnimePilgrimage extends Model
         return $pilgrimages;
     }
 
-    // Workに対するリレーション 1対多の関係
-    public function work()
+    // Workに対するリレーション 多対多の関係
+    public function works()
     {
-        return $this->belongsTo(Work::class, 'work_id', 'id');
+        return $this->belongsToMany(Work::class, 'anime_pilgrimage_work', 'anime_pilgrimage_id', 'work_id');
     }
 
     // Prefectureに対するリレーション 1対多の関係

--- a/app/Models/Work.php
+++ b/app/Models/Work.php
@@ -79,10 +79,10 @@ class Work extends Model
         return $this->belongsTo(WorkReview::class);
     }
 
-    // AnimePilgrimageに対するリレーション 1対多の関係
+    // AnimePilgrimageに対するリレーション 多対多の関係
     public function animePilgrimages()
     {
-        return $this->hasMany(AnimePilgrimage::class, 'work_id', 'id');
+        return $this->belongsToMany(AnimePilgrimage::class, 'anime_pilgrimage_work', 'work_id', 'anime_pilgrimage_id');
     }
 
     // Characterに対するリレーション 多対多の関係

--- a/database/migrations/2024_12_07_131950_create_anime_pilgrimage_work_table.php
+++ b/database/migrations/2024_12_07_131950_create_anime_pilgrimage_work_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('anime_pilgrimage_work', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('work_id')->constrained('works')->onDelete('cascade');
+            $table->foreignId('anime_pilgrimage_id')->constrained('anime_pilgrimages')->onDelete('cascade');
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('anime_pilgrimage_work');
+    }
+};

--- a/database/migrations/2024_12_07_142650_drop_column_work_id.php
+++ b/database/migrations/2024_12_07_142650_drop_column_work_id.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('anime_pilgrimages', function (Blueprint $table) {
+            // 外部キー制約を削除
+            $table->dropForeign(['work_id']);
+            // カラムを削除
+            $table->dropColumn('work_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('anime_pilgrimages', function (Blueprint $table) {
+            $table->foreignId('work_id')->constrained('works')->onDelete('cascade');
+        });
+    }
+};

--- a/database/seeders/Anime_Pilgrimage_WorkSeeder.php
+++ b/database/seeders/Anime_Pilgrimage_WorkSeeder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use DateTime;
+
+class Anime_Pilgrimage_WorkSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        DB::table('anime_pilgrimage_work')->insert([
+            'work_id' => 2,
+            'anime_pilgrimage_id' => 1,
+            'created_at' => new DateTime(),
+        ]);
+        DB::table('anime_pilgrimage_work')->insert([
+            'work_id' => 2,
+            'anime_pilgrimage_id' => 2,
+            'created_at' => new DateTime(),
+        ]);
+        DB::table('anime_pilgrimage_work')->insert([
+            'work_id' => 3,
+            'anime_pilgrimage_id' => 3,
+            'created_at' => new DateTime(),
+        ]);
+        DB::table('anime_pilgrimage_work')->insert([
+            'work_id' => 4,
+            'anime_pilgrimage_id' => 3,
+            'created_at' => new DateTime(),
+        ]);
+        DB::table('anime_pilgrimage_work')->insert([
+            'work_id' => 5,
+            'anime_pilgrimage_id' => 4,
+            'created_at' => new DateTime(),
+        ]);
+        DB::table('anime_pilgrimage_work')->insert([
+            'work_id' => 5,
+            'anime_pilgrimage_id' => 5,
+            'created_at' => new DateTime(),
+        ]);
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -44,7 +44,8 @@ class DatabaseSeeder extends Seeder
             Character_Post_Like_Seeder::class,
             Character_Post_Categories_Seeder::class,
             Character_Post_Category_Seeder::class,
-            Character_WorkSeeder::class
+            Character_WorkSeeder::class,
+            Anime_Pilgrimage_WorkSeeder::class
         ]);
     }
 }

--- a/resources/views/pilgrimages/index.blade.php
+++ b/resources/views/pilgrimages/index.blade.php
@@ -5,18 +5,19 @@
         <form action="{{ route('pilgrimages.index') }}" method="GET">
             <div class=keword_serch>
                 <p>聖地検索</p>
-                <input type="text" name="search" value="{{ request('search') }}" placeholder="キーワードを検索" aria-label="検索...">
+                <input type="text" name="search" value="{{ request('search') }}" placeholder="キーワードを検索"
+                    aria-label="検索...">
                 <input type="submit" value="検索">
             </div>
             <div class=prefecture_serch>
                 <p>県名検索</p>
                 <select name="prefecture_search" class="form-control" value="{{ request('prefecture_search') }}">
-                  <option value="">未選択</option>
-                  @foreach($prefectures as $id => $prefecture_name)
-                  <option value="{{ $id }}" @if($prefecture_search == $id) selected @endif>
-                    {{ $prefecture_name }}
-                  </option>  
-                  @endforeach
+                    <option value="">未選択</option>
+                    @foreach ($prefectures as $id => $prefecture_name)
+                        <option value="{{ $id }}" @if ($prefecture_search == $id) selected @endif>
+                            {{ $prefecture_name }}
+                        </option>
+                    @endforeach
                 </select>
             </div>
         </form>
@@ -25,26 +26,29 @@
         </div>
     </div>
     <div class='pilgrimages'>
-        @if($pilgrimages->isEmpty())
-        <h2 class='no_result'>結果がありません。</h2>
+        @if ($pilgrimages->isEmpty())
+            <h2 class='no_result'>結果がありません。</h2>
         @else
-        @foreach ($pilgrimages as $pilgrimage)
-        <div class='pilgrimage'>
-            <h2 class='name'>
-                <a href="{{ route('pilgrimages.show', ['pilgrimage_id' => $pilgrimage->id]) }}">
-                    {{ $pilgrimage->name }}
-                </a>
-            </h2>
-            <p class='work'>
-                <a href="{{ route('works.show', ['work' => $pilgrimage->work->id]) }}">
-                    {{ $pilgrimage->work->name }}
-                </a>
-            </p>
-            <p class='place'>
-                {{ $pilgrimage->place }}
-            </p>
-        </div>
-        @endforeach
+            @foreach ($pilgrimages as $pilgrimage)
+                <div class='pilgrimage'>
+                    <h2 class='name'>
+                        <a href="{{ route('pilgrimages.show', ['pilgrimage_id' => $pilgrimage->id]) }}">
+                            {{ $pilgrimage->name }}
+                        </a>
+                    </h2>
+                    <p class='work'>
+                        {{-- 関連する作品の数だけ繰り返す --}}
+                        @foreach ($pilgrimage->works as $pilgrimage_work)
+                            <a href="{{ route('works.show', ['work' => $pilgrimage_work->id]) }}">
+                                {{ $pilgrimage_work->name }}
+                            </a>
+                        @endforeach
+                    </p>
+                    <p class='place'>
+                        {{ $pilgrimage->place }}
+                    </p>
+                </div>
+            @endforeach
         @endif
     </div>
     <div class='paginate'>

--- a/resources/views/pilgrimages/show.blade.php
+++ b/resources/views/pilgrimages/show.blade.php
@@ -8,9 +8,12 @@
             <p>{{ $pilgrimage->name }}</p>
             <div class='work'>
                 <h3>登場作品</h3>
-                <a href="{{ route('works.show', ['work' => $pilgrimage->work->id]) }}">
-                    {{ $pilgrimage->work->name }}
-                </a>
+                {{-- 関連する作品の数だけ繰り返す --}}
+                @foreach ($pilgrimage->works as $pilgrimage_work)
+                    <a href="{{ route('works.show', ['work' => $pilgrimage_work->id]) }}">
+                        {{ $pilgrimage_work->name }}
+                    </a>
+                @endforeach
             </div>
             <h3>Google Mapsへのリンク</h3>
             <p>{{ $pilgrimage->map_link }}</p>


### PR DESCRIPTION
### 聖地テーブルの見直し

- #54 

・作品と聖地の関係を1対多から多対多に変更
・それに伴って中間テーブルのanime_pilgrimage_workを作成
・リレーション名も変更し、blade.phpの記述を修正
・anime_pilgrimagesテーブルから不要になったwork_idを削除

・聖地に対して、複数の作品が登録できるようになった
![image](https://github.com/user-attachments/assets/bacd0950-ad44-4aab-8121-0100ec559c2c)
