### PR TITLE
Feat：リレーション先のデータも検索可能にする

### DIFF
--- a/app/Models/AnimePilgrimage.php
+++ b/app/Models/AnimePilgrimage.php
@@ -15,26 +15,45 @@ class AnimePilgrimage extends Model
     // 聖地の検索処理
     public function fetchAnimePilgrimages($search, $prefecture_search)
     {
-        $pilgrimages = AnimePilgrimage::orderBy('id', 'ASC')->where(function ($query) use ($search, $prefecture_search) {
-            // キーワード検索がなされた場合
-            if ($search) {
-                // 検索語のスペースを半角に統一
-                $search_split = mb_convert_kana($search, 's');
-                // 半角スペースで単語ごとに分割して配列にする
-                $search_array = preg_split('/[\s]+/', $search_split);
-                foreach ($search_array as $search_word) {
-                    $query->where(function ($query) use ($search_word) {
-                        $query->where('name', 'LIKE', "%{$search_word}%")
-                            ->orWhere('place', 'LIKE', "%{$search_word}%");
-                    });
-                }
-            }
+        $pilgrimages = AnimePilgrimage::orderBy('id', 'ASC')
+            ->with(['works', 'works.characters', 'animePilgrimagePosts'])
+            ->where(function ($query) use ($search, $prefecture_search) {
+                // キーワード検索がなされた場合
+                if ($search) {
+                    // 検索語のスペースを半角に統一
+                    $search_split = mb_convert_kana($search, 's');
+                    // 半角スペースで単語ごとに分割して配列にする
+                    $search_array = preg_split('/[\s]+/', $search_split);
+                    foreach ($search_array as $search_word) {
+                        // 自身のカラムでの検索
+                        $query->where(function ($query) use ($search_word) {
+                            $query->where('name', 'LIKE', "%{$search_word}%")
+                                ->orWhere('place', 'LIKE', "%{$search_word}%");
+                        });
 
-            // 県名検索がなされた場合
-            if ($prefecture_search) {
-                $query->where('prefecture_id', $prefecture_search);
-            }
-        })->paginate(5);
+                        // リレーション先のWorksテーブルのカラムでの検索
+                        $query->orWhereHas('works', function ($workQuery) use ($search_word) {
+                            $workQuery->where('name', 'LIKE', "%{$search_word}%")
+                                ->orWhere('term', 'like', '%' . $search_word . '%');
+
+                            // リレーション先のCharactersテーブルのカラムでの検索
+                            $workQuery->orWhereHas('characters', function ($characterQuery) use ($search_word) {
+                                $characterQuery->where('name', 'like', '%' . $search_word . '%');
+                            });
+                        });
+
+                        // リレーション先のAnimePilgrimagePostsテーブルのカラムでの検索
+                        $query->orWhereHas('animePilgrimagePosts', function ($pilgrimagePostQuery) use ($search_word) {
+                            $pilgrimagePostQuery->where('scene', 'LIKE', "%{$search_word}%");
+                        });
+                    }
+                }
+
+                // 県名検索がなされた場合
+                if ($prefecture_search) {
+                    $query->where('prefecture_id', $prefecture_search);
+                }
+            })->paginate(5);
         return $pilgrimages;
     }
 
@@ -50,9 +69,9 @@ class AnimePilgrimage extends Model
         return $this->belongsTo(Prefecture::class, 'prefecture_id', 'id');
     }
 
-    // AnimePilgrimagePostに対するリレーション 1対1の関係
-    public function animePilgrimagePost()
+    // AnimePilgrimagePostに対するリレーション 1対多の関係
+    public function animePilgrimagePosts()
     {
-        return $this->hasOne(AnimePilgrimagePost::class, 'id', 'anime_pilgrimage_id');
+        return $this->hasMany(AnimePilgrimagePost::class, 'anime_pilgrimage_id',  'id');
     }
 }

--- a/app/Models/CharacterPost.php
+++ b/app/Models/CharacterPost.php
@@ -35,21 +35,29 @@ class CharacterPost extends Model
     public function fetchCharacterPosts($character_id, $search)
     {
         // 指定したidの登場人物の投稿のみを表示
-        $character_posts = CharacterPost::where('character_id', $character_id)->orderBy('id', 'DESC')->where(function ($query) use ($search) {
-            // キーワード検索がなされた場合
-            if ($search) {
-                // 検索語のスペースを半角に統一
-                $search_split = mb_convert_kana($search, 's');
-                // 半角スペースで単語ごとに分割して配列にする
-                $search_array = preg_split('/[\s]+/', $search_split);
-                foreach ($search_array as $search_word) {
-                    $query->where(function ($query) use ($search_word) {
-                        $query->where('post_title', 'LIKE', "%{$search_word}%")
-                            ->orWhere('body', 'LIKE', "%{$search_word}%");
-                    });
+        $character_posts = CharacterPost::where('character_id', $character_id)->orderBy('id', 'DESC')
+            ->with(['user'])
+            ->where(function ($query) use ($search) {
+                // キーワード検索がなされた場合
+                if ($search) {
+                    // 検索語のスペースを半角に統一
+                    $search_split = mb_convert_kana($search, 's');
+                    // 半角スペースで単語ごとに分割して配列にする
+                    $search_array = preg_split('/[\s]+/', $search_split);
+                    foreach ($search_array as $search_word) {
+                        // 自身のカラムでの検索
+                        $query->where(function ($query) use ($search_word) {
+                            $query->where('post_title', 'LIKE', "%{$search_word}%")
+                                ->orWhere('body', 'LIKE', "%{$search_word}%");
+                        });
+
+                        // リレーション先のUsersテーブルのカラムでの検索
+                        $query->orWhereHas('user', function ($userQuery) use ($search_word) {
+                            $userQuery->where('name', 'like', '%' . $search_word . '%');
+                        });
+                    }
                 }
-            }
-        })->paginate(5);
+            })->paginate(5);
         return $character_posts;
     }
 

--- a/app/Models/Music.php
+++ b/app/Models/Music.php
@@ -15,20 +15,50 @@ class Music extends Model
     // 音楽の検索処理
     public function fetchMusic($search)
     {
-        $music = Music::orderBy('id', 'ASC')->where(function ($query) use ($search) {
-            // キーワード検索がなされた場合
-            if ($search) {
-                // 検索語のスペースを半角に統一
-                $search_split = mb_convert_kana($search, 's');
-                // 半角スペースで単語ごとに分割して配列にする
-                $search_array = preg_split('/[\s]+/', $search_split);
-                foreach ($search_array as $search_word) {
-                    $query->where(function ($query) use ($search_word) {
-                        $query->where('name', 'LIKE', "%{$search_word}%");
-                    });
+        $music = Music::orderBy('id', 'ASC')
+            ->with(['work', 'work.creator', 'singer', 'composer', 'lyricWriter'])
+            ->where(function ($query) use ($search) {
+                // キーワード検索がなされた場合
+                if ($search) {
+                    // 検索語のスペースを半角に統一
+                    $search_split = mb_convert_kana($search, 's');
+                    // 半角スペースで単語ごとに分割して配列にする
+                    $search_array = preg_split('/[\s]+/', $search_split);
+                    foreach ($search_array as $search_word) {
+
+                        // 自身のカラムでの検索
+                        $query->where(function ($query) use ($search_word) {
+                            $query->where('name', 'LIKE', "%{$search_word}%");
+                        });
+
+                        // リレーション先のWorksテーブルのカラムでの検索
+                        $query->orWhereHas('work', function ($workQuery) use ($search_word) {
+                            $workQuery->where('name', 'LIKE', "%{$search_word}%")
+                                ->orWhere('term', 'like', '%' . $search_word . '%');
+
+                            // リレーション先のCreatorsテーブルのカラムでの検索
+                            $workQuery->orWhereHas('creator', function ($creatorQuery) use ($search_word) {
+                                $creatorQuery->where('name', 'like', '%' . $search_word . '%');
+                            });
+                        });
+
+                        // リレーション先のsingersテーブルのカラムでの検索
+                        $query->orWhereHas('singer', function ($singerQuery) use ($search_word) {
+                            $singerQuery->where('name', 'LIKE', "%{$search_word}%");
+                        });
+
+                        // リレーション先のcomposersテーブルのカラムでの検索
+                        $query->orWhereHas('composer', function ($composerQuery) use ($search_word) {
+                            $composerQuery->where('name', 'LIKE', "%{$search_word}%");
+                        });
+
+                        // リレーション先のlyric_writersテーブルのカラムでの検索
+                        $query->orWhereHas('lyricWriter', function ($lyricWriterQuery) use ($search_word) {
+                            $lyricWriterQuery->where('name', 'LIKE', "%{$search_word}%");
+                        });
+                    }
                 }
-            }
-        })->paginate(5);
+            })->paginate(5);
         return $music;
     }
 

--- a/app/Models/MusicPost.php
+++ b/app/Models/MusicPost.php
@@ -31,21 +31,29 @@ class MusicPost extends Model
     public function fetchMusicPosts($music_id, $search)
     {
         // 指定したidの音楽の投稿のみを表示
-        $music_posts = MusicPost::where('music_id', $music_id)->orderBy('id', 'DESC')->where(function ($query) use ($search) {
-            // キーワード検索がなされた場合
-            if ($search) {
-                // 検索語のスペースを半角に統一
-                $search_split = mb_convert_kana($search, 's');
-                // 半角スペースで単語ごとに分割して配列にする
-                $search_array = preg_split('/[\s]+/', $search_split);
-                foreach ($search_array as $search_word) {
-                    $query->where(function ($query) use ($search_word) {
-                        $query->where('post_title', 'LIKE', "%{$search_word}%")
-                            ->orWhere('body', 'LIKE', "%{$search_word}%");
-                    });
+        $music_posts = MusicPost::where('music_id', $music_id)->orderBy('id', 'DESC')
+            ->with(['user'])
+            ->where(function ($query) use ($search) {
+                // キーワード検索がなされた場合
+                if ($search) {
+                    // 検索語のスペースを半角に統一
+                    $search_split = mb_convert_kana($search, 's');
+                    // 半角スペースで単語ごとに分割して配列にする
+                    $search_array = preg_split('/[\s]+/', $search_split);
+                    foreach ($search_array as $search_word) {
+                        // 自身のカラムでの検索
+                        $query->where(function ($query) use ($search_word) {
+                            $query->where('post_title', 'LIKE', "%{$search_word}%")
+                                ->orWhere('body', 'LIKE', "%{$search_word}%");
+                        });
+
+                        // リレーション先のUsersテーブルのカラムでの検索
+                        $query->orWhereHas('user', function ($userQuery) use ($search_word) {
+                            $userQuery->where('name', 'like', '%' . $search_word . '%');
+                        });
+                    }
                 }
-            }
-        })->paginate(5);
+            })->paginate(5);
         return $music_posts;
     }
 

--- a/app/Models/WorkReview.php
+++ b/app/Models/WorkReview.php
@@ -33,21 +33,29 @@ class WorkReview extends Model
     public function fetchWorkReviews($work_id, $search)
     {
         // 指定したidのアニメの投稿のみを表示
-        $work_reviews = WorkReview::where('work_id', $work_id)->orderBy('id', 'ASC')->where(function ($query) use ($search) {
-            // キーワード検索がなされた場合
-            if ($search) {
-                // 検索語のスペースを半角に統一
-                $search_split = mb_convert_kana($search, 's');
-                // 半角スペースで単語ごとに分割して配列にする
-                $search_array = preg_split('/[\s]+/', $search_split);
-                foreach ($search_array as $search_word) {
-                    $query->where(function ($query) use ($search_word) {
-                        $query->where('post_title', 'LIKE', "%{$search_word}%")
-                            ->orWhere('body', 'LIKE', "%{$search_word}%");
-                    });
+        $work_reviews = WorkReview::where('work_id', $work_id)->orderBy('id', 'ASC')
+            ->with(['user'])
+            ->where(function ($query) use ($search) {
+                // キーワード検索がなされた場合
+                if ($search) {
+                    // 検索語のスペースを半角に統一
+                    $search_split = mb_convert_kana($search, 's');
+                    // 半角スペースで単語ごとに分割して配列にする
+                    $search_array = preg_split('/[\s]+/', $search_split);
+                    foreach ($search_array as $search_word) {
+                        // 自身のカラムでの検索
+                        $query->where(function ($query) use ($search_word) {
+                            $query->where('post_title', 'LIKE', "%{$search_word}%")
+                                ->orWhere('body', 'LIKE', "%{$search_word}%");
+                        });
+
+                        // リレーション先のUsersテーブルのカラムでの検索
+                        $query->orWhereHas('user', function ($userQuery) use ($search_word) {
+                            $userQuery->where('name', 'like', '%' . $search_word . '%');
+                        });
+                    }
                 }
-            }
-        })->paginate(5);
+            })->paginate(5);
         return $work_reviews;
     }
 

--- a/app/Models/WorkStoryPost.php
+++ b/app/Models/WorkStoryPost.php
@@ -34,21 +34,29 @@ class WorkStoryPost extends Model
     public function fetchWorkStoryPosts($work_story_id, $search)
     {
         // 指定したidのあらすじの投稿のみを表示
-        $work_story_posts = WorkStoryPost::where('sub_title_id', $work_story_id)->orderBy('id', 'DESC')->where(function ($query) use ($search) {
-            // キーワード検索がなされた場合
-            if ($search) {
-                // 検索語のスペースを半角に統一
-                $search_split = mb_convert_kana($search, 's');
-                // 半角スペースで単語ごとに分割して配列にする
-                $search_array = preg_split('/[\s]+/', $search_split);
-                foreach ($search_array as $search_word) {
-                    $query->where(function ($query) use ($search_word) {
-                        $query->where('post_title', 'LIKE', "%{$search_word}%")
-                            ->orWhere('body', 'LIKE', "%{$search_word}%");
-                    });
+        $work_story_posts = WorkStoryPost::where('sub_title_id', $work_story_id)->orderBy('id', 'DESC')
+            ->with(['user'])
+            ->where(function ($query) use ($search) {
+                // キーワード検索がなされた場合
+                if ($search) {
+                    // 検索語のスペースを半角に統一
+                    $search_split = mb_convert_kana($search, 's');
+                    // 半角スペースで単語ごとに分割して配列にする
+                    $search_array = preg_split('/[\s]+/', $search_split);
+                    foreach ($search_array as $search_word) {
+                        // 自身のカラムでの検索
+                        $query->where(function ($query) use ($search_word) {
+                            $query->where('post_title', 'LIKE', "%{$search_word}%")
+                                ->orWhere('body', 'LIKE', "%{$search_word}%");
+                        });
+
+                        // リレーション先のUsersテーブルのカラムでの検索
+                        $query->orWhereHas('user', function ($userQuery) use ($search_word) {
+                            $userQuery->where('name', 'like', '%' . $search_word . '%');
+                        });
+                    }
                 }
-            }
-        })->paginate(5);
+            })->paginate(5);
         return $work_story_posts;
     }
 

--- a/resources/views/character_posts/index.blade.php
+++ b/resources/views/character_posts/index.blade.php
@@ -36,6 +36,7 @@
                             <a
                                 href="{{ route('character_posts.show', ['character_id' => $character_post->character_id, 'character_post_id' => $character_post->id]) }}">{{ $character_post->post_title }}</a>
                         </h2>
+                        <p>{{ $character_post->user->name }}</p>
                         <div class="like">
                             <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
                             <button id="like_button" data-character-id="{{ $character_post->character_id }}"

--- a/resources/views/characters/index.blade.php
+++ b/resources/views/characters/index.blade.php
@@ -10,6 +10,9 @@
             <a href="{{ route('characters.index') }}">キャンセル</a>
         </div>
     </div>
+    <div>
+        <p>人物名、作品名、声優、制作会社など何でも検索してみましょう！</p>
+    </div>
     <div class='characters'>
         @if ($characters->isEmpty())
             <h2 class='no_result'>結果がありません。</h2>

--- a/resources/views/music/index.blade.php
+++ b/resources/views/music/index.blade.php
@@ -10,30 +10,33 @@
             <a href="{{ route('music.index') }}">キャンセル</a>
         </div>
     </div>
+    <div>
+        <p>楽曲名、歌手、作曲者、作詞者、作品名、制作会社など何でも検索してみましょう！</p>
+    </div>
     <div class='music_collection'>
-        @if($music->isEmpty())
-        <h2 class='no_result'>結果がありません。</h2>
+        @if ($music->isEmpty())
+            <h2 class='no_result'>結果がありません。</h2>
         @else
-        @foreach ($music as $music_model)
-        <div class='music'>
-            <h2 class='name'>
-                <a href="{{ route('music.show', ['music_id' => $music_model->id]) }}">
-                    {{ $music_model->name }}
-                </a>
-            </h2>
-            <p class='work'>
-                <a href="{{ route('works.show', ['work' => $music_model->work_id]) }}">
-                    {{ $music_model->work->name }}
-                </a>
-            </p>
-            <p class='singer'>
-                歌手:
-                <a href="{{ route('singer.show', ['singer_id' => $music_model->singer_id]) }}">
-                    {{ $music_model->singer->name }}
-                </a>
-            </p>
-        </div>
-        @endforeach
+            @foreach ($music as $music_model)
+                <div class='music'>
+                    <h2 class='name'>
+                        <a href="{{ route('music.show', ['music_id' => $music_model->id]) }}">
+                            {{ $music_model->name }}
+                        </a>
+                    </h2>
+                    <p class='work'>
+                        <a href="{{ route('works.show', ['work' => $music_model->work_id]) }}">
+                            {{ $music_model->work->name }}
+                        </a>
+                    </p>
+                    <p class='singer'>
+                        歌手:
+                        <a href="{{ route('singer.show', ['singer_id' => $music_model->singer_id]) }}">
+                            {{ $music_model->singer->name }}
+                        </a>
+                    </p>
+                </div>
+            @endforeach
         @endif
     </div>
     <div class='paginate'>

--- a/resources/views/pilgrimages/index.blade.php
+++ b/resources/views/pilgrimages/index.blade.php
@@ -25,6 +25,9 @@
             <a href="{{ route('pilgrimages.index') }}">キャンセル</a>
         </div>
     </div>
+    <div>
+        <p>聖地名、シーン、住所、作品名、関連人物名など何でも検索してみましょう！</p>
+    </div>
     <div class='pilgrimages'>
         @if ($pilgrimages->isEmpty())
             <h2 class='no_result'>結果がありません。</h2>

--- a/resources/views/work_stories/index.blade.php
+++ b/resources/views/work_stories/index.blade.php
@@ -10,22 +10,26 @@
             <a href="{{ route('work_stories.index', ['work_id' => $work_story_model->work_id]) }}">キャンセル</a>
         </div>
     </div>
+    <div>
+        <p>あらすじ、話数、内容など何でも検索してみましょう！</p>
+    </div>
     <div class='work_stories'>
-        @if($work_stories->isEmpty())
-        <h2 class='no_result'>結果がありません。</h2>
+        @if ($work_stories->isEmpty())
+            <h2 class='no_result'>結果がありません。</h2>
         @else
-        @foreach ($work_stories as $work_story)
-        <div class='work_story'>
-            <h2 class='episode'>
-                    {{ $work_story->episode }}
-            </h2>
-            <p class='sub_title'>
-                <a href="{{ route('work_stories.show', ['work_id' => $work_story->work_id, 'work_story_id' => $work_story->id]) }}">
-                    {{ $work_story->sub_title }}
-                </a>
-            </p>
-        </div>
-        @endforeach
+            @foreach ($work_stories as $work_story)
+                <div class='work_story'>
+                    <h2 class='episode'>
+                        {{ $work_story->episode }}
+                    </h2>
+                    <p class='sub_title'>
+                        <a
+                            href="{{ route('work_stories.show', ['work_id' => $work_story->work_id, 'work_story_id' => $work_story->id]) }}">
+                            {{ $work_story->sub_title }}
+                        </a>
+                    </p>
+                </div>
+            @endforeach
         @endif
     </div>
     <div class='paginate'>


### PR DESCRIPTION
### リレーション先のデータも検索可能にする

- #29

・音楽、人物、聖地における検索に、リレーション先のデータも検索できるように修正
（制作会社、登場人物、声優、音楽、歌手、聖地、あらすじなど）
・また各投稿の検索で、投稿者名でも検索できるように修正