### PR TITLE
【ログイン管理】未ログイン時のログイン訴求表示のベースづくり＋気になる登録の訴求表示

### DIFF
--- a/app/Enums/LoginPromptActionType.php
+++ b/app/Enums/LoginPromptActionType.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Enums;
+
+enum LoginPromptActionType: string
+{
+    case Like = 'いいね';
+    case Comment = 'コメント';
+    case Interested = '気になる';
+    case UserInformation = 'ユーザー情報';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Like => 'いいねする',
+            self::Comment => 'コメントする',
+            self::Interested => '気になる登録する',
+            self::UserInformation => 'ユーザー情報を閲覧する',
+        };
+    }
+}

--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -7,11 +7,8 @@ use Illuminate\Http\Request;
 
 class Authenticate extends Middleware
 {
-    /**
-     * Get the path the user should be redirected to when they are not authenticated.
-     */
     protected function redirectTo(Request $request): ?string
     {
-        return $request->expectsJson() ? null : route('login');
+        return url()->previous() . '?login_required=1';
     }
 }

--- a/app/View/Components/Molecules/Dialog/LoginDialog.php
+++ b/app/View/Components/Molecules/Dialog/LoginDialog.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\View\Components\Molecules\Dialog;
+
+use Illuminate\View\Component;
+
+class LoginDialog extends Component
+{
+    public function render()
+    {
+        return view('components.molecules.dialog.login-dialog');
+    }
+}

--- a/public/js/interested_user.js
+++ b/public/js/interested_user.js
@@ -14,6 +14,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
         //「気になる」登録ボタンクリックによる非同期処理
         button.addEventListener('click', async function () {
+
+            // ログイン状態を確認
+            if (!window.checkLoginAndShowDialog(this)) return;
+
             const targetType = button.getAttribute('data-type');
             const targetFirstId = button.getAttribute('data-first-id');
             let path = '';

--- a/public/js/login_dialog.js
+++ b/public/js/login_dialog.js
@@ -39,3 +39,15 @@ function checkLoginAndShowDialog(element) {
     return true;
 }
 
+document.addEventListener('DOMContentLoaded', () => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('login_required') === '1') {
+        showLoginDialog('この操作を行う');
+
+        params.delete('login_required');
+
+        const newUrl = window.location.pathname + (params.toString() ? '?' + params.toString() : '');
+        window.history.replaceState({}, '', newUrl);
+    }
+});
+

--- a/public/js/login_dialog.js
+++ b/public/js/login_dialog.js
@@ -1,0 +1,41 @@
+function showLoginDialog(messageText) {
+    const dialog = document.getElementById('login-dialog');
+    const messageParagraph = dialog ? dialog.querySelector('p') : null;
+
+    if (dialog) {
+        if (messageParagraph) {
+            messageParagraph.textContent = `${messageText}にはログインが必要です。`;
+        }
+
+        dialog.classList.remove('hidden');
+        dialog.classList.add('flex');
+
+        // クローズボタンのイベントリスナーを設定
+        const closeButton = document.getElementById('close-login-dialog');
+        if (closeButton) {
+            closeButton.onclick = () => {
+                dialog.classList.add('hidden');
+                dialog.classList.remove('flex');
+            };
+        }
+
+        // モーダルの外側をクリックで閉じる
+        dialog.onclick = (e) => {
+            if (e.target === dialog) {
+                dialog.classList.add('hidden');
+                dialog.classList.remove('flex');
+            }
+        };
+    }
+}
+
+function checkLoginAndShowDialog(element) {
+    if (window.App && !window.App.userLoggedIn) {
+        const actionText = element.getAttribute('data-login-required-action');
+        if (!window.showLoginDialog) return false;
+        showLoginDialog(actionText);
+        return false;
+    }
+    return true;
+}
+

--- a/resources/views/components/molecules/button/interested.blade.php
+++ b/resources/views/components/molecules/button/interested.blade.php
@@ -4,6 +4,7 @@
     </div>
     <button id="interested_button" data-type="{{ $type }}" data-first-id="{{ $root->id }}"
         {{ $isMultiple ? 'data-second-id=' . $root->work_id : 'data-second-id=' . null }} type="submit"
+        data-login-required-action="{{ \App\Enums\LoginPromptActionType::Interested->label() }}"
         class="px-1 text-lg hover:bg-gray-200 transition 
         {{ $root->users->contains(auth()->user()) ? 'text-yellow-400' : 'text-gray-400 hover:text-gray-600' }}">
         {{ $root->users->contains(auth()->user()) ? '★' : '☆' }}

--- a/resources/views/components/molecules/dialog/login-dialog.blade.php
+++ b/resources/views/components/molecules/dialog/login-dialog.blade.php
@@ -1,0 +1,19 @@
+<!-- TODO: ログインダイアログのデザインは今後改修予定 -->
+<div id="login-dialog" class="fixed inset-0 bg-gray-600 bg-opacity-50 hidden items-center justify-center z-50">
+    <div class="bg-white rounded-lg shadow-xl p-6 m-4 max-w-sm w-full relative">
+        <button id="close-login-dialog"
+            class="absolute top-3 right-3 text-gray-500 hover:text-gray-700 text-2xl font-bold">&times;</button>
+        <h3 class="text-lg font-semibold text-center mb-4">ログインが必要です</h3>
+        <p class="text-gray-700 text-center mb-6"></p>
+        <div class="flex flex-col items-center gap-6">
+            <a href="{{ route('login') }}"
+                class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
+                ログインする
+            </a>
+            <a href="{{ route('register') }}"
+                class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline">
+                会員登録する
+            </a>
+        </div>
+    </div>
+</div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -19,18 +19,23 @@
     <link rel="stylesheet" href="/css/cropper.css" />
 
     <!-- Scripts -->
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
     <script>
         window.Lang = {!! json_encode([
             'messages' => trans('messages'),
             'common' => trans('common'),
             'validation' => trans('validation'),
         ]) !!};
-    </script>
-    <!-- categoryColors を全ページに適用 -->
-    <script>
+
         window.categoryColors = {!! json_encode($categoryColors) !!};
+
+        window.App = window.App || {};
+        window.App.userLoggedIn = @auth true
+        @else
+            false
+        @endauth ;
     </script>
+
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
 </head>
 
 <body class="font-sans antialiased">
@@ -52,8 +57,11 @@
             <!-- Lightbox JS -->
             <script src="/js/lightbox-plus-jquery.min.js"></script>
             <script src="/js/cropper.js"></script>
+            <script src="/js/login_dialog.js"></script>
         </main>
     </div>
+
+    <x-molecules.dialog.login-dialog />
 </body>
 
 </html>

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -12,6 +12,14 @@
     <link rel="preconnect" href="https://fonts.bunny.net">
     <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
 
+    <script>
+        window.Lang = {!! json_encode([
+            'messages' => trans('messages'),
+            'common' => trans('common'),
+            'validation' => trans('validation'),
+        ]) !!};
+    </script>
+
     <!-- Scripts -->
     @vite(['resources/css/app.css', 'resources/js/app.js'])
 </head>

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -18,6 +18,12 @@
             'common' => trans('common'),
             'validation' => trans('validation'),
         ]) !!};
+
+        window.App = window.App || {};
+        window.App.userLoggedIn = @auth true
+        @else
+            false
+        @endauth ;
     </script>
 
     <!-- Scripts -->
@@ -36,7 +42,10 @@
             {{ $slot }}
         </div>
     </div>
+    <x-molecules.dialog.login-dialog />
+
     <script src="{{ asset('/js/count_character.js') }}"></script>
+    <script src="/js/login_dialog.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## このPRで行ったこと

- SSIA

## このPRによってできること

- issueのリンク
  - #40  

## なぜこのような実装をしたか

- [fix:会員登録時にcountCharacterを実行できるようにする](https://github.com/Masaki1152/AniConnect/commit/65fbcb680a0d8004c35f4a10985f66d776afc23e)
  -  会員登録ボタン押下時にcount_character.jsを読み込んでいたが、window.Lang.validationがうまくよみこまれていなかった
  - そこでguest.blade.phpで読み込むように修正
 
- [feature:ログイン訴求を表示するためのベースづくりを行う](https://github.com/Masaki1152/AniConnect/commit/e02593c0d18085636594e40d010c151420c9d757)
  -  まずは気になるボタンやフォローボタンなどjsを介して処理を行う場合、未ログインかどうかを確認してログイン訴求の表示を行うようにした
  - この際、どのボタンを押したのかを明確にするためにボタンの種類によってEnumを作成した
  - ログイン訴求用にコンポーネントを作成したが、デザイン名は今後改修予定

- [feature:リロードを伴うログイン訴求の表示を可能にする](https://github.com/Masaki1152/AniConnect/commit/3de69acd3afa0cbc53c795f425059b5bca5aff14)
  -  リロードを伴う場合は、web.phpのmiddleware(['auth'])の表記で、Authenticate.phpによるログイン画面への自動遷移が行われていたため、そこで未ログインの場合はクエリを一時的に追加してjsのshowLoginDialogを実行するようにした
  - showLoginDialogの実行後はすみやかに追加したクエリを削除し、「?login_required=1?login_required=1」のようにならないようにした
 
- [feature:気になる登録を押した際にログイン訴求を表示](https://github.com/Masaki1152/AniConnect/commit/dd0943b65d54db18392b3c7b0e1be79e361c1a9d)
  -  コンポーネント化を進めていたため、わずかな差分でログイン訴求を表示可能

## 動作エビデンス

- 気になるボタン（js使用）と登録メンバーボタン（リロード含む）を押下時にログイン訴求が表示される
- 実際に訴求のログインボタンや会員登録ボタンの挙動も理想通りであることを確認

https://github.com/user-attachments/assets/390b6103-b379-489e-acdf-9c8d436ae9f3


