### PR TITLE
【エンハンス】コメント内のコメントボタンといいねボタンのコンポーネントを作成する

### DIFF
--- a/app/View/Components/Molecules/Button/LikeCommentButton.php
+++ b/app/View/Components/Molecules/Button/LikeCommentButton.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\View\Components\Molecules\Button;
+
+use Illuminate\View\Component;
+
+class CommentLikeButton extends Component
+{
+    public $comment;
+    public $baseRoute;
+
+    public function __construct($comment, $baseRoute)
+    {
+        $this->comment = $comment;
+        $this->baseRoute = $baseRoute;
+    }
+
+    public function render()
+    {
+        return view('components.molecules.button.comment-like-button');
+    }
+}

--- a/app/View/Components/Molecules/Button/ShowCommentFormButton.php
+++ b/app/View/Components/Molecules/Button/ShowCommentFormButton.php
@@ -6,6 +6,12 @@ use Illuminate\View\Component;
 
 class ShowCommentFormButton extends Component
 {
+    public $comment;
+
+    public function __construct($comment)
+    {
+        $this->comment = $comment;
+    }
 
     public function render()
     {

--- a/resources/views/components/molecules/button/like-comment-button.blade.php
+++ b/resources/views/components/molecules/button/like-comment-button.blade.php
@@ -1,0 +1,16 @@
+<div class='comment-like flex items-center gap-2'>
+    <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
+    <button id="comment-like_button-{{ $comment->id }}" data-comment-id="{{ $comment->id }}"
+        onclick="toggleLike({{ $comment->id }}, 'comment-like_button-{{ $comment->id }}', 'comment-like_count-{{ $comment->id }}', '{{ $baseRoute }}s')"
+        class="comment-like_button px-2 py-1 bg-blue-500 text-white rounded-lg shadow-md hover:bg-blue-600">
+        {{ $comment->users->contains(auth()->user()) ? __('common.unlike_action') : __('common.like_action') }}
+    </button>
+    <div class="comment-like_user">
+        <a href="{{ route($baseRoute . '_comment.like.index', ['comment_id' => $comment->id]) }}"
+            class="text-lg font-medium text-gray-700">
+            <p id="comment-like_count-{{ $comment->id }}">
+                {{ $comment->users->count() }}件
+            </p>
+        </a>
+    </div>
+</div>

--- a/resources/views/components/molecules/button/show-comment-form-button.blade.php
+++ b/resources/views/components/molecules/button/show-comment-form-button.blade.php
@@ -1,8 +1,17 @@
-<div class='content_fotter_comment'>
-    <button id='toggleComments' type='button'
+@if ($comment)
+    <button id='toggleChildComments-{{ $comment->id }}' type='button'
         class="px-2 py-1 bg-blue-500 text-white rounded-lg shadow-md hover:bg-blue-600"
-        onclick="toggleCommentForm()">{{ __('common.comment') }}</button>
-    <button id='closeComments' type='button'
+        onclick="toggleChildCommentForm({{ $comment->id }})">{{ __('common.comment') }}</button>
+    <button id='closeChildComments-{{ $comment->id }}' type='button'
         class="px-2 py-1 bg-gray-300 text-gray-700 rounded-lg shadow-md hover:bg-gray-400 hidden"
-        onclick="toggleCommentForm()">{{ __('common.close') }}</button>
-</div>
+        onclick="toggleChildCommentForm({{ $comment->id }})">{{ __('common.close') }}</button>
+@else
+    <div class='content_fotter_comment'>
+        <button id='toggleComments' type='button'
+            class="px-2 py-1 bg-blue-500 text-white rounded-lg shadow-md hover:bg-blue-600"
+            onclick="toggleCommentForm()">{{ __('common.comment') }}</button>
+        <button id='closeComments' type='button'
+            class="px-2 py-1 bg-gray-300 text-gray-700 rounded-lg shadow-md hover:bg-gray-400 hidden"
+            onclick="toggleCommentForm()">{{ __('common.close') }}</button>
+    </div>
+@endif

--- a/resources/views/posts/anime_pilgrimage_posts/show.blade.php
+++ b/resources/views/posts/anime_pilgrimage_posts/show.blade.php
@@ -118,7 +118,7 @@
                         </div>
                     </div>
                     <div class='flex gap-4 items-center justify-end'>
-                        <x-molecules.button.show-comment-form-button />
+                        <x-molecules.button.show-comment-form-button :comment="null" />
                         <x-molecules.button.like-post-button type="pilgrimage" :post="$pilgrimage_post" />
                     </div>
                     <!-- コメント作成フォーム -->

--- a/resources/views/posts/character_posts/show.blade.php
+++ b/resources/views/posts/character_posts/show.blade.php
@@ -108,7 +108,7 @@
                         </div>
                     </div>
                     <div class='flex gap-4 items-center justify-end'>
-                        <x-molecules.button.show-comment-form-button />
+                        <x-molecules.button.show-comment-form-button :comment="null" />
                         <x-molecules.button.like-post-button type="character" :post="$character_post" />
                     </div>
                     <!-- コメント作成フォーム -->

--- a/resources/views/posts/music_posts/show.blade.php
+++ b/resources/views/posts/music_posts/show.blade.php
@@ -108,7 +108,7 @@
                         </div>
                     </div>
                     <div class='flex gap-4 items-center justify-end'>
-                        <x-molecules.button.show-comment-form-button />
+                        <x-molecules.button.show-comment-form-button :comment="null" />
                         <x-molecules.button.like-post-button type="music" :post="$music_post" />
                     </div>
                     <!-- コメント作成フォーム -->

--- a/resources/views/posts/work_posts/show.blade.php
+++ b/resources/views/posts/work_posts/show.blade.php
@@ -108,7 +108,7 @@
                         </div>
                     </div>
                     <div class='flex gap-4 items-center justify-end'>
-                        <x-molecules.button.show-comment-form-button />
+                        <x-molecules.button.show-comment-form-button :comment="null" />
                         <x-molecules.button.like-post-button type="work" :post="$work_post" />
                     </div>
                     <!-- コメント作成フォーム -->

--- a/resources/views/posts/work_story_posts/show.blade.php
+++ b/resources/views/posts/work_story_posts/show.blade.php
@@ -116,7 +116,7 @@
                         </div>
                     </div>
                     <div class='flex gap-4 items-center justify-end'>
-                        <x-molecules.button.show-comment-form-button />
+                        <x-molecules.button.show-comment-form-button :comment="null" />
                         <x-molecules.button.like-post-button type="work_story" :post="$work_story_post" />
                     </div>
                     <!-- コメント作成フォーム -->

--- a/resources/views/user_interactions/comments/input_comment.blade.php
+++ b/resources/views/user_interactions/comments/input_comment.blade.php
@@ -84,29 +84,9 @@
         </div>
         <div class='flex items-center gap-4'>
             <!-- コメントを追加したい場合 -->
-            <button id='toggleChildComments-{{ $comment->id }}' type='button'
-                class="px-2 py-1 bg-blue-500 text-white rounded-lg shadow-md hover:bg-blue-600"
-                onclick="toggleChildCommentForm({{ $comment->id }})">コメントする</button>
-            <button id='closeChildComments-{{ $comment->id }}' type='button'
-                class="px-2 py-1 bg-gray-300 text-gray-700 rounded-lg shadow-md hover:bg-gray-400 hidden"
-                onclick="toggleChildCommentForm({{ $comment->id }})">閉じる</button>
+            <x-molecules.button.show-comment-form-button :comment="$comment" />
             <!-- いいねボタンといいね件数 -->
-            <div class='comment-like flex items-center gap-2'>
-                <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
-                <button id="comment-like_button-{{ $comment->id }}" data-comment-id="{{ $comment->id }}"
-                    onclick="toggleLike({{ $comment->id }}, 'comment-like_button-{{ $comment->id }}', 'comment-like_count-{{ $comment->id }}', '{{ $baseRoute }}s')"
-                    class="comment-like_button px-2 py-1 bg-blue-500 text-white rounded-lg shadow-md hover:bg-blue-600">
-                    {{ $comment->users->contains(auth()->user()) ? 'いいね取り消し' : 'いいね' }}
-                </button>
-                <div class="comment-like_user">
-                    <a href="{{ route($baseRoute . '_comment.like.index', ['comment_id' => $comment->id]) }}"
-                        class="text-lg font-medium text-gray-700">
-                        <p id="comment-like_count-{{ $comment->id }}">
-                            {{ $comment->users->count() }}件
-                        </p>
-                    </a>
-                </div>
-            </div>
+            <x-molecules.button.like-comment-button :comment="$comment" :baseRoute="$baseRoute" />
         </div>
     </div>
     <!-- 子コメント作成フォーム -->

--- a/resources/views/user_interactions/notifications/show.blade.php
+++ b/resources/views/user_interactions/notifications/show.blade.php
@@ -64,7 +64,7 @@
                         </div>
                     </div>
                     <div class='flex gap-4 items-center justify-end'>
-                        <x-molecules.button.show-comment-form-button />
+                        <x-molecules.button.show-comment-form-button :comment="null" />
                         <x-molecules.button.like-post-button type="notification" :post="$notification" />
                     </div>
                     <!-- コメント作成フォーム -->


### PR DESCRIPTION
## このPRで行ったこと

- SSIA

## このPRによってできること

- #131

## なぜこのような実装をしたか

- [feature:コメント内のいいねボタンのコンポーネントを作成](https://github.com/Masaki1152/AniConnect/commit/e6949eb5f37f231b312d7ed6407371fa26861794)
  -  コメント内のいいねボタンのコンポーネント化のため、viewの作成や文言の追加を行った
- [feature:ShowCommentFormButtonをコメント内のボタンにも使えるように改修](https://github.com/Masaki1152/AniConnect/commit/724d7ea2b4f71567ccf4a4e10908cbc6ad9b7b61)
  -  コメント内のコメントボタンは、以前作成した投稿内のコメントボタンとほとんど同じ仕様だったので、新しく作成せず既存のShowCommentFormButtonを改修することにした
- [feature:コンポーネントを各画面に反映](https://github.com/Masaki1152/AniConnect/commit/2e9b52362a208f1cb3151502f349bee81dda5a05)
  -  コンポーネントを各項目のコメントに反映した

## 影響範囲

- お知らせ詳細のコメント
- 作品感想詳細のコメント
- あらすじ感想詳細のコメント
- 登場人物感想詳細のコメント
- 音楽感想詳細のコメント
- 聖地感想詳細のコメント

## 動作エビデンス


https://github.com/user-attachments/assets/f2cdd38a-4bc3-4c4d-970a-983a0f642efb


