### PR TITLE
【ログイン】未ログイン時にコメントボタンといいねボタン押下でログイン訴求を表示

### DIFF
--- a/app/Enums/LoginPromptActionType.php
+++ b/app/Enums/LoginPromptActionType.php
@@ -7,7 +7,6 @@ enum LoginPromptActionType: string
     case Like = 'いいね';
     case Comment = 'コメント';
     case Interested = '気になる';
-    case UserInformation = 'ユーザー情報';
 
     public function label(): string
     {
@@ -15,7 +14,6 @@ enum LoginPromptActionType: string
             self::Like => 'いいねする',
             self::Comment => 'コメントする',
             self::Interested => '気になる登録する',
-            self::UserInformation => 'ユーザー情報を閲覧する',
         };
     }
 }

--- a/public/js/comments/add_comment.js
+++ b/public/js/comments/add_comment.js
@@ -1,5 +1,9 @@
 // 投稿のコメントフォームの表示/非表示を切り替える関数
-function toggleCommentForm() {
+function toggleCommentForm(buttonElement) {
+
+    // ログイン状態を確認
+    if (!window.checkLoginAndShowDialog(buttonElement)) return;
+
     const toggleCommentButton = document.getElementById('toggleComments');
     const closeCommentButton = document.getElementById('closeComments');
     const addCommentBlock = document.getElementById('addCommentBlock');
@@ -15,7 +19,11 @@ function toggleCommentForm() {
 }
 
 // 各コメントのコメントフォームの表示/非表示を切り替える関数
-function toggleChildCommentForm(replyId) {
+function toggleChildCommentForm(buttonElement, replyId) {
+
+    // ログイン状態を確認
+    if (!window.checkLoginAndShowDialog(buttonElement)) return;
+
     const addChildCommentBlock = document.getElementById(`addChildCommentBlock-${replyId}`);
     const toggleChildCommentButton = document.getElementById(`toggleChildComments-${replyId}`);
     const closeChildCommentButtton = document.getElementById(`closeChildComments-${replyId}`);

--- a/public/js/comments/like_comment.js
+++ b/public/js/comments/like_comment.js
@@ -1,5 +1,9 @@
 // いいね処理を関数として定義
-async function toggleLike(commentId, buttonId, userCountId, baseRoute) {
+async function toggleLike(buttonElement, commentId, buttonId, userCountId, baseRoute) {
+
+    // ログイン状態を確認
+    if (!window.checkLoginAndShowDialog(buttonElement)) return;
+
     const button = document.getElementById(buttonId);
     const userCount = document.getElementById(userCountId);
     try {

--- a/public/js/like_post.js
+++ b/public/js/like_post.js
@@ -14,6 +14,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
         //いいねボタンクリックによる非同期処理
         button.addEventListener('click', async function () {
+
+            // ログイン状態を確認
+            if (!window.checkLoginAndShowDialog(this)) return;
+
             const url = handleLikeAction(button);
             try {
                 const response = await fetch(url, {

--- a/resources/views/components/molecules/button/like-comment-button.blade.php
+++ b/resources/views/components/molecules/button/like-comment-button.blade.php
@@ -1,7 +1,8 @@
 <div class='comment-like flex items-center gap-2'>
     <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
     <button id="comment-like_button-{{ $comment->id }}" data-comment-id="{{ $comment->id }}"
-        onclick="toggleLike({{ $comment->id }}, 'comment-like_button-{{ $comment->id }}', 'comment-like_count-{{ $comment->id }}', '{{ $baseRoute }}s')"
+        data-login-required-action="{{ \App\Enums\LoginPromptActionType::Like->label() }}"
+        onclick="toggleLike(this, {{ $comment->id }}, 'comment-like_button-{{ $comment->id }}', 'comment-like_count-{{ $comment->id }}', '{{ $baseRoute }}s')"
         class="comment-like_button px-2 py-1 bg-blue-500 text-white rounded-lg shadow-md hover:bg-blue-600">
         {{ $comment->users->contains(auth()->user()) ? __('common.unlike_action') : __('common.like_action') }}
     </button>

--- a/resources/views/components/molecules/button/like-post-button.blade.php
+++ b/resources/views/components/molecules/button/like-post-button.blade.php
@@ -1,6 +1,7 @@
 <div class="like">
     <!-- ボタンの見た目は後のデザイン作成の際に設定する予定 -->
     <button id="like_button" type="submit"
+        data-login-required-action="{{ \App\Enums\LoginPromptActionType::Like->label() }}"
         @foreach ($dataTypeAttributes as $key => $value)
         data-{{ $key }}="{{ $value }}" @endforeach>
         {{ $post->users->contains(auth()->user()) ? __('common.unlike_action') : __('common.like_action') }}

--- a/resources/views/components/molecules/button/show-comment-form-button.blade.php
+++ b/resources/views/components/molecules/button/show-comment-form-button.blade.php
@@ -1,17 +1,19 @@
 @if ($comment)
     <button id='toggleChildComments-{{ $comment->id }}' type='button'
+        data-login-required-action="{{ \App\Enums\LoginPromptActionType::Comment->label() }}"
         class="px-2 py-1 bg-blue-500 text-white rounded-lg shadow-md hover:bg-blue-600"
-        onclick="toggleChildCommentForm({{ $comment->id }})">{{ __('common.comment') }}</button>
+        onclick="toggleChildCommentForm(this, {{ $comment->id }})">{{ __('common.comment') }}</button>
     <button id='closeChildComments-{{ $comment->id }}' type='button'
         class="px-2 py-1 bg-gray-300 text-gray-700 rounded-lg shadow-md hover:bg-gray-400 hidden"
-        onclick="toggleChildCommentForm({{ $comment->id }})">{{ __('common.close') }}</button>
+        onclick="toggleChildCommentForm(this, {{ $comment->id }})">{{ __('common.close') }}</button>
 @else
     <div class='content_fotter_comment'>
         <button id='toggleComments' type='button'
+            data-login-required-action="{{ \App\Enums\LoginPromptActionType::Comment->label() }}"
             class="px-2 py-1 bg-blue-500 text-white rounded-lg shadow-md hover:bg-blue-600"
-            onclick="toggleCommentForm()">{{ __('common.comment') }}</button>
+            onclick="toggleCommentForm(this)">{{ __('common.comment') }}</button>
         <button id='closeComments' type='button'
             class="px-2 py-1 bg-gray-300 text-gray-700 rounded-lg shadow-md hover:bg-gray-400 hidden"
-            onclick="toggleCommentForm()">{{ __('common.close') }}</button>
+            onclick="toggleCommentForm(this)">{{ __('common.close') }}</button>
     </div>
 @endif


### PR DESCRIPTION
## このPRで行ったこと

- SSIA

## このPRによってできること

- issueのリンク
  - #40  

## なぜこのような実装をしたか

- [refactore:LoginPromptActionから不要な要素の削除](https://github.com/Masaki1152/AniConnect/commit/80ec144fa82b39dff8d19d42b1c359a5c885f614)
  -  ユーザー情報の閲覧は未ログイン時のログイン訴求（フロント）では行わないためユーザー情報を削除 
- [feature:未ログイン時、いいねボタン押下でログイン訴求を行う](https://github.com/Masaki1152/AniConnect/commit/3f8f008958542fa9708c4ccd51af3dc43cb76a49)
- [feature:未ログイン時、コメント内のコメントボタン押下でログイン訴求を行う](https://github.com/Masaki1152/AniConnect/commit/190a64e4b7e07d5a8f135d6b0e537827d0679e84)
- [feature:未ログイン時、コメント内のいいねボタン押下でログイン訴求を行う](https://github.com/Masaki1152/AniConnect/commit/08b5d3865082322d4822c3bc9243ea01d9e08758)
  -  コンポーネント化を進めていたため、各ボタンに対してわずかな差分でログイン訴求を表示可能
  - コメント内のコメントボタンといいねボタンは、checkLoginAndShowDialogの引数にbuttonElementを渡すように修正することで、元々のthisがwindowを取得しようとする問題を解決した

## 動作エビデンス

- いいねボタンやコメントするボタン（js使用）押下時にログイン訴求が表示される
- いいねやコメントなど押下したボタンによってログイン訴求の文言が異なることも確認

https://github.com/user-attachments/assets/87c7921a-1cca-4ca8-9029-f1d570130e35

