### PR TITLE
デプロイ用に作品、あらすじ、登場人物のSeederに画像とコピーライトの追加

### DIFF
--- a/database/seeders/CharacterSeeder.php
+++ b/database/seeders/CharacterSeeder.php
@@ -9,15 +9,14 @@ use DateTime;
 
 class CharacterSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     */
     public function run(): void
     {
         DB::table('characters')->insert([
             'work_id' => 2,
             'voice_artist_id' => 1,
             'name' => '北条沙都子',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752625948/%E5%8C%97%E6%9D%A1%E6%B2%99%E9%83%BD%E5%AD%90_tuqxye.png',
+            'copyright' => '©2020竜騎士07／ひぐらしのなく頃に製作委員会',
             'wiki_link' => 'https://dic.pixiv.net/a/%E5%8C%97%E6%9D%A1%E6%B2%99%E9%83%BD%E5%AD%90',
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
@@ -26,6 +25,8 @@ class CharacterSeeder extends Seeder
             'work_id' => 6,
             'voice_artist_id' => 3,
             'name' => 'フランチェスカ・ルッキーニ',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752625947/%E3%83%AB%E3%83%83%E3%82%AD%E3%83%BC%E3%83%8B_wy9ti4.png',
+            'copyright' => '@2010 第501統合戦闘航空団',
             'wiki_link' => 'https://dic.pixiv.net/a/%E3%83%95%E3%83%A9%E3%83%B3%E3%83%81%E3%82%A7%E3%82%B9%E3%82%AB%E3%83%BB%E3%83%AB%E3%83%83%E3%82%AD%E3%83%BC%E3%83%8B',
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
@@ -34,6 +35,8 @@ class CharacterSeeder extends Seeder
             'work_id' => 6,
             'voice_artist_id' => 2,
             'name' => 'リゼ',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752625946/%E3%83%AA%E3%82%BC_htn5fz.png',
+            'copyright' => '© Koi・芳文社／ご注文はBLOOM製作委員会ですか？',
             'wiki_link' => 'https://dic.pixiv.net/a/%E5%A4%A9%E3%80%85%E5%BA%A7%E7%90%86%E4%B8%96',
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
@@ -42,6 +45,8 @@ class CharacterSeeder extends Seeder
             'work_id' => 1,
             'voice_artist_id' => 5,
             'name' => '美樹さやか',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752625947/%E7%BE%8E%E6%A8%B9%E3%81%95%E3%82%84%E3%81%8B_eff1eq.png',
+            'copyright' => '©Magica Quartet／Aniplex・Madoka Partners・MBS',
             'wiki_link' => 'https://dic.pixiv.net/a/%E7%BE%8E%E6%A0%91%E3%81%95%E3%82%84%E3%81%8B',
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
@@ -50,6 +55,8 @@ class CharacterSeeder extends Seeder
             'work_id' => 5,
             'voice_artist_id' => 6,
             'name' => 'アルトリア・ペンドラゴン',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752625946/%E3%82%A2%E3%83%AB%E3%83%88%E3%83%AA%E3%82%A2%E3%83%9A%E3%83%B3%E3%83%89%E3%83%A9%E3%82%B4%E3%83%B3_ycvx6d.png',
+            'copyright' => '©Nitroplus／TYPE-MOON・ufotable・FZPC',
             'wiki_link' => 'https://dic.pixiv.net/a/%E3%82%A2%E3%83%AB%E3%83%88%E3%83%AA%E3%82%A2%E3%83%BB%E3%83%9A%E3%83%B3%E3%83%89%E3%83%A9%E3%82%B4%E3%83%B3',
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
@@ -58,6 +65,8 @@ class CharacterSeeder extends Seeder
             'work_id' => 1,
             'voice_artist_id' => 4,
             'name' => 'キュゥべえ',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752625946/%E3%82%AD%E3%83%A5%E3%82%A5%E3%81%B9%E3%81%88_x9yzf9.png',
+            'copyright' => '©Magica Quartet／Aniplex・Madoka Partners・MBS',
             'wiki_link' => 'https://dic.pixiv.net/a/%E3%82%AD%E3%83%A5%E3%82%A5%E3%81%B9%E3%81%88',
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),

--- a/database/seeders/MusicSeeder.php
+++ b/database/seeders/MusicSeeder.php
@@ -9,9 +9,6 @@ use DateTime;
 
 class MusicSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     */
     public function run(): void
     {
         DB::table('music')->insert([
@@ -86,6 +83,5 @@ class MusicSeeder extends Seeder
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
         ]);
-
     }
 }

--- a/database/seeders/WorkSeeder.php
+++ b/database/seeders/WorkSeeder.php
@@ -9,15 +9,13 @@ use DateTime;
 
 class WorkSeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     */
     public function run(): void
     {
         DB::table('works')->insert([
             'creator_id' => 2,
             'name' => '魔法少女まどか☆マギカ',
-            'image' => '',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752621621/まどマギ_nzgvlq.jpg',
+            'copyright' => '©Magica Quartet／Aniplex・Madoka Partners・MBS',
             'term' => '2011年1月7日 - 4月22日',
             'official_site_link' => 'https://10th.madoka-magica.com/',
             'wiki_link' => 'https://ja.wikipedia.org/wiki/%E9%AD%94%E6%B3%95%E5%B0%91%E5%A5%B3%E3%81%BE%E3%81%A9%E3%81%8B%E2%98%86%E3%83%9E%E3%82%AE%E3%82%AB',
@@ -28,7 +26,8 @@ class WorkSeeder extends Seeder
         DB::table('works')->insert([
             'creator_id' => 1,
             'name' => 'ひぐらしのなく頃に',
-            'image' => '',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752622476/%E3%81%B2%E3%81%90%E3%82%89%E3%81%971%E6%9C%9F_b057xk.jpg',
+            'copyright' => '©2006竜騎士０７／ひぐらしのなく頃に製作委員会・創通',
             'term' => '2006年4月 - 9月',
             'official_site_link' => 'http://www.oyashirosama.com/web/top/',
             'wiki_link' => 'https://ja.wikipedia.org/wiki/%E3%81%B2%E3%81%90%E3%82%89%E3%81%97%E3%81%AE%E3%81%AA%E3%81%8F%E9%A0%83%E3%81%AB_(%E3%82%A2%E3%83%8B%E3%83%A1)',
@@ -39,7 +38,8 @@ class WorkSeeder extends Seeder
         DB::table('works')->insert([
             'creator_id' => 4,
             'name' => 'ラブライブ!（1期）',
-            'image' => '',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752622245/%E3%83%A9%E3%83%96%E3%83%A9%E3%82%A4%E3%83%961%E6%9C%9F_rj4wjt.jpg',
+            'copyright' => '©2013 プロジェクトラブライブ！',
             'term' => '2013年1月6日 - 3月31日',
             'official_site_link' => 'https://www.lovelive-anime.jp/otonokizaka/',
             'wiki_link' => 'https://ja.wikipedia.org/wiki/%E3%83%A9%E3%83%96%E3%83%A9%E3%82%A4%E3%83%96!_(%E3%83%86%E3%83%AC%E3%83%93%E3%82%A2%E3%83%8B%E3%83%A1)',
@@ -50,7 +50,8 @@ class WorkSeeder extends Seeder
         DB::table('works')->insert([
             'creator_id' => 4,
             'name' => 'ラブライブ!（2期）',
-            'image' => '',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752622405/%E3%83%A9%E3%83%96%E3%83%A9%E3%82%A4%E3%83%962%E6%9C%9F_obmorx.jpg',
+            'copyright' => '©2013 プロジェクトラブライブ！',
             'term' => '2014年4月6日 - 6月29日',
             'official_site_link' => 'https://www.lovelive-anime.jp/otonokizaka/',
             'wiki_link' => 'https://ja.wikipedia.org/wiki/%E3%83%A9%E3%83%96%E3%83%A9%E3%82%A4%E3%83%96!_(%E3%83%86%E3%83%AC%E3%83%93%E3%82%A2%E3%83%8B%E3%83%A1)',
@@ -61,7 +62,8 @@ class WorkSeeder extends Seeder
         DB::table('works')->insert([
             'creator_id' => 3,
             'name' => 'Fate/Zero',
-            'image' => '',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752622146/FateZero_fqyxky.jpg',
+            'copyright' => '©Nitroplus／TYPE-MOON・ufotable・FZPC',
             'term' => '2011年10月 - 12月 2012年4月 - 6月',
             'official_site_link' => 'https://www.fate-zero.jp/',
             'wiki_link' => 'https://ja.wikipedia.org/wiki/Fate/Zero',
@@ -72,7 +74,8 @@ class WorkSeeder extends Seeder
         DB::table('works')->insert([
             'creator_id' => 1,
             'name' => 'ひぐらしのなく頃に業',
-            'image' => '',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752621696/%E3%81%B2%E3%81%90%E3%82%89%E3%81%97%E6%A5%AD_b20jft.jpg',
+            'copyright' => '©2020竜騎士07／ひぐらしのなく頃に製作委員会',
             'term' => '2020年10月1日 - 2021年3月19日',
             'official_site_link' => 'https://higurashianime.com/',
             'wiki_link' => 'https://ja.wikipedia.org/wiki/%E3%81%B2%E3%81%90%E3%82%89%E3%81%97%E3%81%AE%E3%81%AA%E3%81%8F%E9%A0%83%E3%81%AB_(%E3%82%A2%E3%83%8B%E3%83%A1)',
@@ -80,6 +83,5 @@ class WorkSeeder extends Seeder
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
         ]);
-
     }
 }

--- a/database/seeders/Work_StorySeeder.php
+++ b/database/seeders/Work_StorySeeder.php
@@ -9,9 +9,6 @@ use DateTime;
 
 class Work_StorySeeder extends Seeder
 {
-    /**
-     * Run the database seeds.
-     */
     public function run(): void
     {
         DB::table('work_stories')->insert([
@@ -29,6 +26,8 @@ class Work_StorySeeder extends Seeder
 まどかが夢で見た少女と瓜二つの容姿をした少女。
 
 偶然の一致に戸惑うまどかに、ほむらは意味深な言葉を投げかけるのだった・・・。',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752623977/%E3%81%BE%E3%81%A9%E3%83%9E%E3%82%AE1%E8%A9%B1_a85ipz.png',
+            'copyright' => '©Magica Quartet／Aniplex・Madoka Partners・MBS',
             'official_link' => 'https://www.madoka-magica.com/tv/story/01.html',
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
@@ -49,6 +48,8 @@ class Work_StorySeeder extends Seeder
 
 どんな望みをも叶えるチャンスと、その先に待つ過酷な使命。
 悩む二人に、マミは「自分の魔女退治に付き合わないか」と提案をするのだった。',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752623978/%E3%81%BE%E3%81%A9%E3%83%9E%E3%82%AE2%E8%A9%B1_yr6iqe.png',
+            'copyright' => '©Magica Quartet／Aniplex・Madoka Partners・MBS',
             'official_link' => 'https://www.madoka-magica.com/tv/story/02.html',
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
@@ -69,6 +70,8 @@ class Work_StorySeeder extends Seeder
 恭介の見舞いに行ったとさやかと付き添いのまどかは、
 その帰り道、偶然にも病院の駐輪場で孵化しかけたグリーフシードを発見する。
 放置すれば、大惨事になりかねない事態に、さやかはキュゥべえと共に見張りを、まどかはマミを助けに呼びに走るのだった。',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752623977/%E3%81%BE%E3%81%A9%E3%83%9E%E3%82%AE3%E8%A9%B1_lfifvi.png',
+            'copyright' => '©Magica Quartet／Aniplex・Madoka Partners・MBS',
             'official_link' => 'https://www.madoka-magica.com/tv/story/03.html',
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
@@ -86,6 +89,8 @@ class Work_StorySeeder extends Seeder
 夕日の中、並んで歩く二人。
 
 魔法少女としての死ぬことの現実を語るほむらに、まどかは切ないほど優しい言葉をかけるのだった。',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752623977/%E3%81%BE%E3%81%A9%E3%83%9E%E3%82%AE4%E8%A9%B1_ocwcyn.png',
+            'copyright' => '©Magica Quartet／Aniplex・Madoka Partners・MBS',
             'official_link' => 'https://www.madoka-magica.com/tv/story/04.html',
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
@@ -105,6 +110,8 @@ class Work_StorySeeder extends Seeder
 その光景を見たさやかは、至福の喜びをかみ締める。
 
 一方展望台には、そんな病院屋上でのさやかの動向をうかがう杏子の姿があった。',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752623979/%E3%81%BE%E3%81%A9%E3%83%9E%E3%82%AE5%E8%A9%B1_sg6d5n.png',
+            'copyright' => '©Magica Quartet／Aniplex・Madoka Partners・MBS',
             'official_link' => 'https://www.madoka-magica.com/tv/story/05.html',
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
@@ -125,6 +132,8 @@ class Work_StorySeeder extends Seeder
 
 そんな二人のやりとりの一方、
 ゲームセンターでは、とある目的のため、ほむらは杏子と接触するのだった。',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752623984/%E3%81%BE%E3%81%A9%E3%83%9E%E3%82%AE6%E8%A9%B1_c69nqd.png',
+            'copyright' => '©Magica Quartet／Aniplex・Madoka Partners・MBS',
             'official_link' => 'https://www.madoka-magica.com/tv/story/06.html',
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
@@ -141,6 +150,8 @@ class Work_StorySeeder extends Seeder
 
 そこで杏子の口から語られたのは、自身が魔法少女となった理由。
 果たして彼女の真意とは――',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752623984/%E3%81%BE%E3%81%A9%E3%83%9E%E3%82%AE7%E8%A9%B1_k9kwob.png',
+            'copyright' => '©Magica Quartet／Aniplex・Madoka Partners・MBS',
             'official_link' => 'https://www.madoka-magica.com/tv/story/07.html',
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
@@ -159,6 +170,8 @@ class Work_StorySeeder extends Seeder
 雨の中をはしりながら、自己嫌悪に悔し泣きをするさやか――
 
 彼女のソウルジェムは、黒く黒く濁っていくのであった。',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752623984/%E3%81%BE%E3%81%A9%E3%83%9E%E3%82%AE8%E8%A9%B1_ios6ro.png',
+            'copyright' => '©Magica Quartet／Aniplex・Madoka Partners・MBS',
             'official_link' => 'https://www.madoka-magica.com/tv/story/08.html',
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
@@ -178,6 +191,8 @@ class Work_StorySeeder extends Seeder
 その日の深夜、杏子の元に現れたのはキュゥべえ。
 キュゥべえとさやかの身体を元に戻すことについて話す杏子は、その会話の中で一縷の可能性を見出す。
 翌朝、杏子は仁美と登校途中のまどかをテレパシーで呼び出し、驚きの提案をするのだった。',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752623984/%E3%81%BE%E3%81%A9%E3%83%9E%E3%82%AE9%E8%A9%B1_a7mxd7.png',
+            'copyright' => '©Magica Quartet／Aniplex・Madoka Partners・MBS',
             'official_link' => 'https://www.madoka-magica.com/tv/story/09.html',
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
@@ -197,6 +212,8 @@ class Work_StorySeeder extends Seeder
 長らくの入院生活により、学力も体力も他の生徒に劣る彼女は、
 劣等感に肩を落として帰宅する途中、ふとしたことで魔女の結界に迷いこんでしまう。
 彼女の絶対絶命のピンチに現れたのは、二人の魔法少女だった。',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752623976/%E3%81%BE%E3%81%A9%E3%83%9E%E3%82%AE10%E8%A9%B1_ic1jci.png',
+            'copyright' => '©Magica Quartet／Aniplex・Madoka Partners・MBS',
             'official_link' => 'https://www.madoka-magica.com/tv/story/10.html',
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
@@ -211,6 +228,8 @@ class Work_StorySeeder extends Seeder
 さやか達の死について冷たい口調で語るその姿に、さすがのまどかも怒りを感じる。
 そんなまどかの態度が理解できないキュゥべえは、
 自分たちと人類がこれまで共に歩んできた歴史を語るのだった。',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752623977/%E3%81%BE%E3%81%A9%E3%83%9E%E3%82%AE11%E8%A9%B1_pypmgm.png',
+            'copyright' => '©Magica Quartet／Aniplex・Madoka Partners・MBS',
             'official_link' => 'https://www.madoka-magica.com/tv/story/11.html',
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
@@ -226,7 +245,31 @@ class Work_StorySeeder extends Seeder
 
 魔法少女となる者の運命を全て知った彼女は、
 果たして何を願い、どんな決断を下すのか？',
-            'official_link' => 'https://www.madoka-magica.com/tv/story/12.html',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752623977/%E3%81%BE%E3%81%A9%E3%83%9E%E3%82%AE12%E8%A9%B1_pmyyxr.png',
+            'copyright' => '©Magica Quartet／Aniplex・Madoka Partners・MBS',
+            'official_link' => 'https://www.madoka-magica.com/tv/story/?id=ep12',
+            'created_at' => new DateTime(),
+            'updated_at' => new DateTime(),
+        ]);
+        DB::table('work_stories')->insert([
+            'work_id' => 1,
+            'episode' => '鬼隠し編　其の壱',
+            'sub_title' => 'ハジマリ',
+            'body' => '『あの時うるさい程に鳴いていたひぐらしは、
+　今にして思えば、
+　これから始まる全ての事を
+　教えようとしていたのかもしれない…
+　これからおこる全ての事を…』
+
+
+…昭和58年初夏。
+
+山奥の寒村・雛見沢村にて、前原圭一はごくありふれた毎日を過ごしていた。都会から引っ越してきたばかりの圭一だったが、毎朝一緒に登校してくれるレナや、ゲームに真剣に興じる魅音・沙都子・梨花ら仲良しグループのおかげで、楽しい日常を築き始めていた。
+
+そんなある日、圭一は偶然会ったカメラマンの男性から、村にまつわる怪死事件の存在を知る…',
+            'image' => 'https://res.cloudinary.com/dnumegejl/image/upload/v1752623977/%E3%81%B2%E3%81%90%E3%82%89%E3%81%971%E6%9C%9F1%E8%A9%B1_v3ldbo.png',
+            'copyright' => '©2006竜騎士０７／ひぐらしのなく頃に製作委員会・創通',
+            'official_link' => 'http://www.oyashirosama.com/web/story/onikakushi.htm#1',
             'created_at' => new DateTime(),
             'updated_at' => new DateTime(),
         ]);

--- a/resources/views/entities/characters/index.blade.php
+++ b/resources/views/entities/characters/index.blade.php
@@ -123,6 +123,14 @@
                             CV:{{ $character->voiceArtist->name }}
                         </a>
                     </p>
+                    @if ($character->image)
+                        <div
+                            class="relative w-full max-w-md aspect-[4/3] overflow-hidden rounded-md border border-gray-300">
+                            <img src="{{ $character->image }}" alt="画像が読み込めません。"
+                                class="absolute inset-0 w-full h-full object-cover">
+                        </div>
+                        <p>{{ $character->copyright }}</p>
+                    @endif
                     <x-molecules.evaluation.star-num-detail :starNum="$character->average_star_num" :postNum="$character->post_num" />
                     <x-molecules.button.interested type="characters" :root="$character"
                         path="characters.interested.index" :prop="['character_id' => $character->id]" isMultiple="false" />

--- a/resources/views/entities/work_stories/index.blade.php
+++ b/resources/views/entities/work_stories/index.blade.php
@@ -114,6 +114,14 @@
                             <p>カテゴリー情報がありません。</p>
                         @endif
                     </h5>
+                    @if ($work_story->image)
+                        <div
+                            class="relative w-full max-w-md aspect-[4/3] overflow-hidden rounded-md border border-gray-300">
+                            <img src="{{ $work_story->image }}" alt="画像が読み込めません。"
+                                class="absolute inset-0 w-full h-full object-cover">
+                        </div>
+                        <p>{{ $work_story->copyright }}</p>
+                    @endif
                     <x-molecules.evaluation.star-num-detail :starNum="$work_story->average_star_num" :postNum="$work_story->post_num" />
                     <x-molecules.button.interested type="workStories" :root="$work_story"
                         path="work_stories.interested.index" :prop="['work_id' => $work_story->work_id, 'work_story_id' => $work_story->id]" isMultiple="true" />

--- a/resources/views/entities/works/index.blade.php
+++ b/resources/views/entities/works/index.blade.php
@@ -115,6 +115,14 @@
                                 <p>カテゴリー情報がありません。</p>
                             @endif
                         </h5>
+                        @if ($work->image)
+                            <div
+                                class="relative w-full max-w-md aspect-[3/4] overflow-hidden rounded-md border border-gray-300">
+                                <img src="{{ $work->image }}" alt="画像が読み込めません。"
+                                    class="absolute inset-0 w-full h-full object-cover">
+                            </div>
+                            <p>{{ $work->copyright }}</p>
+                        @endif
                         <x-molecules.evaluation.star-num-detail :starNum="$work->average_star_num" :postNum="$work->post_num" />
                         <p class="text-gray-600">{{ $work->term }}</p>
                         <x-molecules.button.interested type="works" :root="$work" path="work.interested.index"


### PR DESCRIPTION
## このPRで行ったこと

- SSIA

## このPRによってできること

- デプロイ時に、画像とコピーライトを登録する必要がなくなる
- [メモ] 音楽と聖地はアニメ画像に比べて著作権が厳しそうなため、[アフィリエイトを用いた方法](https://www.xserver.ne.jp/blog/about-moshimo-affiliate/)等、他のやり方を探す

## 参考リンク

- [アニメブログの画像引用で違法と言われない著作権法のポイント](https://kato19.blogspot.com/2015/05/cyosakukenanime.html)
  - このサイトを参考に著作権を表示するようにした 

## 影響範囲

- AP-04-01 作品一覧
- AP-04-05 あらすじ一覧
- AP-05-01 登場人物一覧

## 動作エビデンス

|作品一覧|あらすじ一覧|登場人物一覧|
|---|---|---|
|<img width="1615" height="944" alt="image" src="https://github.com/user-attachments/assets/2e1e121c-9286-41e4-b84e-34fb10900e84" />|<img width="1164" height="860" alt="image" src="https://github.com/user-attachments/assets/0df2ab62-e940-491a-855e-e68618e6b551" />|<img width="1336" height="936" alt="image" src="https://github.com/user-attachments/assets/667dd657-a50b-447a-a955-d2dce9132378" />|
