### PR TITLE
【テーブルバグ改修】音楽と聖地のカラムにnullableを追加

### DIFF
--- a/database/migrations/2025_01_05_214307_add_image_column_to_music_table.php
+++ b/database/migrations/2025_01_05_214307_add_image_column_to_music_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('music', function (Blueprint $table) {
-            $table->string('image')->after('name');
+            $table->string('image')->after('name')->nullable();
         });
     }
 

--- a/database/migrations/2025_05_02_203135_add_copyright_column_to_pilgrimages_table.php
+++ b/database/migrations/2025_05_02_203135_add_copyright_column_to_pilgrimages_table.php
@@ -9,7 +9,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('anime_pilgrimages', function (Blueprint $table) {
-            $table->string('image')->after('place');
+            $table->string('image')->after('place')->nullable();
             $table->string('copyright')->after('image')->nullable();
         });
     }


### PR DESCRIPTION
## このPRで行ったこと

- SSIA

## このPRによってできること

- デプロイにおいて、テーブルの更新が無事行えるようになる

## なぜこのような実装をしたか

- 音楽と聖地のテーブルにおいて、nullableが設定されておらず、Seederでもデータを渡していなかったため、エラーが起きてしまった
- そこでnullを許容するようにした
