### PR TITLE
【レイアウト】AP-01-01 メイン画面の紹介部分と最新のお知らせのレイアウト作成

### DIFF
--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -67,7 +67,7 @@ class Notification extends Model
     {
         $recentNotifications = Notification::orderBy('created_at', 'desc')
             ->orderBy('id', 'DESC')
-            ->take(5)
+            ->take(4)
             ->get();
         return $recentNotifications;
     }

--- a/resources/lang/ja/entity.php
+++ b/resources/lang/ja/entity.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    // AP-01-01 メイン画面
+    'main.introduction_title' => 'アニメの全てが集う、新しい交流の場 AniConnect',
+    'main.introduction_description' => 'AniConnect（アニコネクト）は、作品の感想から聖地まで、アニメに関するあらゆる情報と交流が一箇所で完結する
+コミュニティです。<br>
+煩わしい検索なしに推しを深く掘り下げ、共通の趣味を持つ仲間とも簡単につながれます。<br>
+あなたの「好き」が、きっと何かとつながる。
+アニメをもっと深く楽しめる体験がここに。',
+    'main.introduction_detail' => 'もっとAniConnectについて知る！',
+];

--- a/resources/lang/ja/entity.php
+++ b/resources/lang/ja/entity.php
@@ -9,4 +9,6 @@ return [
 あなたの「好き」が、きっと何かとつながる。
 アニメをもっと深く楽しめる体験がここに。',
     'main.introduction_detail' => 'もっとAniConnectについて知る！',
+    'main.notification_title' => '最新のお知らせ',
+    'main.notification_detail' => 'もっとお知らせを見る！',
 ];

--- a/resources/views/main/index.blade.php
+++ b/resources/views/main/index.blade.php
@@ -1,16 +1,16 @@
 <x-app-layout>
-    <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Main') }}
-        </h2>
-    </x-slot>
-
-    <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900">
-                    {{ __("You're logged in!") }}
-                    <p>メイン画面</p>
+    <div class="py-10">
+        <div class="w-full max-w-[960px] mx-auto px-4 lg:px-0">
+            <div class="bg-white main-content px-4 flex-col gap-6">
+                <div class="introduction">
+                    <h2 class="text-2xl font-bold text-textColor">{{ __('entity.main.introduction_title') }}</h2>
+                    <p class="mt-4 text-base font-medium text-textColor border-2 border-mainColor px-6 py-3 rounded-xl">
+                        {!! __('entity.main.introduction_description') !!}</p>
+                    <div class="mt-2 flex justify-end">
+                        <a href="{{ route('notifications.index') }}" class="text-xs text-linkColor hover:underline">
+                            {{ __('entity.main.introduction_detail') }}
+                        </a>
+                    </div>
                 </div>
                 <div class="notifications">
                     <h2>お知らせ</h2>

--- a/resources/views/main/index.blade.php
+++ b/resources/views/main/index.blade.php
@@ -13,16 +13,31 @@
                     </div>
                 </div>
                 <div class="notifications">
-                    <h2>お知らせ</h2>
-                    <ul>
+                    <h2 class="text-[22px] font-bold text-textColor">{{ __('entity.main.notification_title') }}</h2>
+                    <div
+                        class="notification_list mt-4 lg:mx-14 border-2 border-mainColor p-4 rounded-xl divide-y divide-mainColor">
                         @foreach ($notifications as $notification)
-                            <li><a
-                                    href="{{ route('notifications.show', ['notification_id' => $notification->id]) }}">{{ $notification->title }}</a>
-                            </li>
-                            <li>{{ $notification->created_at->format('Y/m/d H:i') }}</li>
+                            <div class="flex flex-wrap items-center gap-2 py-2">
+                                <p class="text-xs text-textColor">
+                                    {{ $notification->created_at->format('Y/m/d') }}
+                                </p>
+                                <a href="{{ route('notifications.show', ['notification_id' => $notification->id]) }}"
+                                    class="ml-4 text-xs text-textColor">{{ $notification->title }}
+                                </a>
+                                @foreach ($notification->categories as $category)
+                                    <span class="text-xs text-white px-2 py-1 rounded-full"
+                                        style="background-color: {{ getCategoryColor($category->name) }};">
+                                        {{ $category->name }}
+                                    </span>
+                                @endforeach
+                            </div>
                         @endforeach
-                    </ul>
-                    <a href="{{ route('notifications.index') }}">お知らせ一覧へ</a>
+                    </div>
+                    <div class="mt-2 flex justify-end">
+                        <a href="{{ route('notifications.index') }}" class="text-xs text-linkColor hover:underline">
+                            {{ __('entity.main.notification_detail') }}
+                        </a>
+                    </div>
                 </div>
             </div>
         </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,6 +28,7 @@ export default {
                 accentColorHover: '#E75428',
                 activeBorderBlue: '#1DA1F2',
                 activeTextDark: '#000000',
+                linkColor: '#0000EE',
             },
             screens: {
                 // ヘッダー用 header_custom


### PR DESCRIPTION
## このPRで行ったこと

- SSIA

## このPRによってできること

- #84

## 参考リンク

- [figma](https://www.figma.com/design/Lj9JfRH9o8GTwuYk5fufBC/Aniconnect?node-id=154-158&t=Q1GwaG4nalWK1Vwq-0)

## なぜこのような実装をしたか

- [feature:メイン画面の紹介部分のレイアウトを作成](https://github.com/Masaki1152/AniConnect/commit/c6419829e9488d393846d53f441cf81891a5e9b4)
  -  メイン画面上部の紹介部分を作成
  - 紹介部分用の文言を追加（[文言管理シート](https://docs.google.com/spreadsheets/d/14dOopMUXiOFD89ERaZwE1EUqKab4xkgLTNonRC1XnG8/edit?gid=0#gid=0&range=D165)）
  - 以後、画面固有の文言はentityファイルに追加していく
  - リンク用のColorをtailwind.config.cssに追加
- [feature:メイン画面の最新のお知らせのレイアウトを作成](https://github.com/Masaki1152/AniConnect/commit/f1789e52f89119b5a21b26a61dc5eea950baa9e5)
  -  お知らせの表示を作成
  - figma通りに4件取得してくるようにNotificationModelを変更

## 影響範囲

- AP-01-01 メイン画面

## 動作エビデンス

|パソコン表示|モバイル表示|
|---|---|
||変更後の画像を貼る|
