### PR TITLE
【レイアウト】AP-01-01 メイン画面の人気上昇中作品表示のレイアウト作成

### DIFF
--- a/app/Http/Controllers/Main/MainController.php
+++ b/app/Http/Controllers/Main/MainController.php
@@ -4,16 +4,41 @@ namespace App\Http\Controllers\Main;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use App\Models\Work;
+use App\Models\Character;
 use App\Models\Notification;
+use Illuminate\Support\Facades\Cache;
 
 
 class MainController extends Controller
 {
     // メイン画面の表示
-    public function index(Notification $notification)
+    public function index(Work $work, Character $character, Notification $notification)
     {
-        // 最新のお知らせ５件の取得
+        // 人気上位の作品を取得
+        $topPopularityWorks = Cache::get('top_popular_works');
+        // キャッシュが見つからない場合
+        if (!$topPopularityWorks) {
+            $sufficientPostsWorks = $work->fetchSufficientPostNumWorks();
+            // updateTopPopularityWorksを実行して人気度の高い作品を再計算
+            $work->updateTopPopularityItems($sufficientPostsWorks, 'workPosts', 'top_popular_works');
+            // 再度キャッシュから人気度の高い作品を取得
+            $topPopularityWorks = Cache::get('top_popular_works');
+        }
+
+        // 人気上位の登場人物を取得
+        $topPopularityCharacters = Cache::get('top_popular_characters');
+        // キャッシュが見つからない場合
+        if (!$topPopularityCharacters) {
+            $sufficientPostsCharacters = $character->fetchSufficientPostNumCharacters();
+            // updateTopPopularityItemsを実行して人気度の高い登場人物を再計算
+            $character->updateTopPopularityItems($sufficientPostsCharacters, 'CharacterPosts', 'top_popular_characters');
+            // 再度キャッシュから人気度の高い登場人物を取得
+            $topPopularityCharacters = Cache::get('top_popular_characters');
+        }
+
+        // 最新のお知らせ4件の取得
         $notifications = $notification->getRecentNotifications();
-        return view('main.index', compact('notifications'));
+        return view('main.index', compact('notifications', 'topPopularityWorks', 'topPopularityCharacters'));
     }
 }

--- a/resources/lang/ja/common.php
+++ b/resources/lang/ja/common.php
@@ -80,6 +80,8 @@ return [
     'wiki_link' => 'Wikipediaのリンク',
     'twitter_link' => 'Twitterのリンク',
     'target_edit' => '「:target」の編集',
+    // 人気度
+    'updated_at' => '最終更新：',
     // コメント
     'comment' => 'コメントする',
 ];

--- a/resources/lang/ja/entity.php
+++ b/resources/lang/ja/entity.php
@@ -9,6 +9,9 @@ return [
 あなたの「好き」が、きっと何かとつながる。
 アニメをもっと深く楽しめる体験がここに。',
     'main.introduction_detail' => 'もっとAniConnectについて知る！',
+    'main.popularity_title' => '現在、人気急上昇中',
+    'main.popularity_work_department' => '作品部門',
+    'main.popularity_work_detail' => '作品一覧を見てみる！',
     'main.notification_title' => '最新のお知らせ',
     'main.notification_detail' => 'もっとお知らせを見る！',
 ];

--- a/resources/views/components/molecules/evaluation/star-num-detail.blade.php
+++ b/resources/views/components/molecules/evaluation/star-num-detail.blade.php
@@ -1,11 +1,13 @@
 @if ($starNum == 9.9)
     <p class="text-sm text-gray-500">評価数が足りません</p>
 @else
-    <div class="content mt-2">
-        <p class="flex items-center text-lg font-semibold text-gray-800 gap-1 leading-none">
-            <span>{{ __('common.evaluation_colon') }} {{ $starNum }}</span>
-            <span class="text-sm text-gray-500">（{{ $postNum }}件の評価）</span>
-        </p>
+    <div class="content">
+        @if ($postNum !== null)
+            <p class="flex items-center text-lg font-semibold text-gray-800 gap-1 leading-none">
+                <span>{{ __('common.evaluation_colon') }} {{ $starNum }}</span>
+                <span class="text-sm text-gray-500">（{{ $postNum }}件の評価）</span>
+            </p>
+        @endif
         <div class="relative flex">
             @for ($i = 1; $i <= 5; $i++)
                 <div class="relative w-6 h-6">

--- a/resources/views/main/index.blade.php
+++ b/resources/views/main/index.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <div class="py-10">
         <div class="w-full max-w-[960px] mx-auto px-4 lg:px-0">
-            <div class="bg-white main-content px-4 flex-col gap-6">
+            <div class="bg-white main-content px-4 flex flex-col gap-6">
                 <div class="introduction">
                     <h2 class="text-2xl font-bold text-textColor">{{ __('entity.main.introduction_title') }}</h2>
                     <p class="mt-4 text-base font-medium text-textColor border-2 border-mainColor px-6 py-3 rounded-xl">
@@ -10,6 +10,49 @@
                         <a href="{{ route('notifications.index') }}" class="text-xs text-linkColor hover:underline">
                             {{ __('entity.main.introduction_detail') }}
                         </a>
+                    </div>
+                </div>
+                <div class="popularity">
+                    <div class="flex gap-4 items-end">
+                        <h2 class="text-[22px] font-bold text-textColor">{{ __('entity.main.popularity_title') }}</h2>
+                        <p class="mb-1 text-xs text-subTextColor">
+                            {{ __('common.updated_at') . (count($topPopularityWorks) > 0 ? $topPopularityWorks[0]['item']->updated_at->format('Y/m/d H:i') : 'N/A') }}
+                        </p>
+                    </div>
+                    <div class="mt-4 border-2 border-mainColor rounded-xl lg:mx-14">
+                        <div class="px-[124px]">
+                            <h3
+                                class="mt-1 text-base font-semibold text-textColor text-center border-b-2 border-mainColor">
+                                {{ __('entity.main.popularity_work_department') }}
+                            </h3>
+                            <div class="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-[72px] justify-items-center mt-3">
+                                @foreach ($topPopularityWorks as $topPopularityWork)
+                                    <div class="data-cell flex flex-col items-center w-[160px]">
+                                        <a href="{{ route('works.show', ['work' => $topPopularityWork['item']->id]) }}"
+                                            class="mb-1 text-base text-textColor text-center h-[24px] leading-tight overflow-hidden break-words hover:underline">
+                                            {{ $topPopularityWork['item']->name }}
+                                        </a>
+                                        <x-molecules.evaluation.star-num-detail :starNum="$topPopularityWork['item']->average_star_num" :postNum="null" />
+                                        @if ($topPopularityWork['item']->image)
+                                            <div
+                                                class="mt-1 mb-0 relative w-[123px] h-[164px] overflow-hidden border border-gray-300">
+                                                <img src="{{ $topPopularityWork['item']->image }}" alt="画像が読み込めません。"
+                                                    class="w-full h-full object-cover">
+                                            </div>
+                                            <p
+                                                class="text-xs text-subTextColor mt-px leading-none text-center break-words whitespace-pre-wrap">
+                                                {{ $topPopularityWork['item']->copyright }}</p>
+                                        @endif
+                                    </div>
+                                @endforeach
+                            </div>
+                        </div>
+                        <div class="flex justify-end">
+                            <a href="{{ route('works.index') }}"
+                                class="my-2 mr-[56px] text-xs text-linkColor hover:underline">
+                                {{ __('entity.main.popularity_work_detail') }}
+                            </a>
+                        </div>
                     </div>
                 </div>
                 <div class="notifications">
@@ -33,7 +76,7 @@
                             </div>
                         @endforeach
                     </div>
-                    <div class="mt-2 flex justify-end">
+                    <div class="mt-2 lg:mx-14 flex justify-end">
                         <a href="{{ route('notifications.index') }}" class="text-xs text-linkColor hover:underline">
                             {{ __('entity.main.notification_detail') }}
                         </a>


### PR DESCRIPTION
## このPRで行ったこと

- SSIA

## このPRによってできること

- #84

## 参考リンク
- [figma](https://www.figma.com/design/Lj9JfRH9o8GTwuYk5fufBC/Aniconnect?node-id=154-158&t=Q1GwaG4nalWK1Vwq-0)

## なぜこのような実装をしたか

- [fix:post_numがnullの時は星のみの表示にする](https://github.com/Masaki1152/AniConnect/commit/4961a5567802b966ec6fc32a9e6836e751d26f80)
  -  元々、星による評価のコンポーネントは作品などへの感想投稿数を取得して表示していたが、今回の画面では不要であったため、post_numがnullかどうかで表示を切り替えるようにした
- [feature:メイン画面で人気な作品や登場人物を取得できるようにする](https://github.com/Masaki1152/AniConnect/commit/33ab4d07d951e39af2a9c34fa4b545980c676761)
  -  ロジックの部分
  - 作品一覧などと同様に人気上位3作品を取得する
  - 登場人物一覧の表示は次回のPRで行う
- [feature:メイン画面に人気上昇中作品表示のレイアウトを作成](https://github.com/Masaki1152/AniConnect/commit/59ef6e6f1534007a7766356323567c1ba7cb7a26)
  -  レスポンシブデザインにも対応
  - 今後、登場人物一覧や音楽一覧などの人気上位も表示するため、カルーセルを実装予定

## 影響範囲

- AP-01-01 メイン画面

## 動作エビデンス

|パソコン用|モバイル用|
|---|---|
|<img width="1408" height="899" alt="image" src="https://github.com/user-attachments/assets/7d25d5ba-044e-47e5-ad7b-e721a7efec8f" />|<img width="490" height="903" alt="image" src="https://github.com/user-attachments/assets/dd56aea7-3720-490b-a4d6-f15163d0ca54" />|
