### PR TITLE
【メインバグ改修】AP-01-01 メイン画面の人気急上昇セクションのレイアウト崩れ修正

### DIFF
--- a/resources/lang/ja/entity.php
+++ b/resources/lang/ja/entity.php
@@ -9,7 +9,7 @@ return [
 あなたの「好き」が、きっと何かとつながる。
 アニメをもっと深く楽しめる体験がここに。',
     'main.introduction_detail' => 'もっとAniConnectについて知る！',
-    'main.popularity_title' => '現在、人気急上昇中',
+    'main.popularity_title' => '人気上昇中',
     'main.popularity_work_department' => '作品部門',
     'main.popularity_work_detail' => '作品一覧を見てみる！',
     'main.notification_title' => '最新のお知らせ',

--- a/resources/views/main/index.blade.php
+++ b/resources/views/main/index.blade.php
@@ -20,7 +20,7 @@
                         </p>
                     </div>
                     <div class="mt-4 border-2 border-mainColor rounded-xl lg:mx-14">
-                        <div class="px-[124px]">
+                        <div class="sm:px-[124px] px-[40px]">
                             <h3
                                 class="mt-1 text-base font-semibold text-textColor text-center border-b-2 border-mainColor">
                                 {{ __('entity.main.popularity_work_department') }}

--- a/resources/views/main/index.blade.php
+++ b/resources/views/main/index.blade.php
@@ -49,7 +49,7 @@
                         </div>
                         <div class="flex justify-end">
                             <a href="{{ route('works.index') }}"
-                                class="my-2 mr-[56px] text-xs text-linkColor hover:underline">
+                                class="my-2 sm:mr-[56px] mr-[40px] text-xs text-linkColor hover:underline">
                                 {{ __('entity.main.popularity_work_detail') }}
                             </a>
                         </div>

--- a/resources/views/main/index.blade.php
+++ b/resources/views/main/index.blade.php
@@ -27,7 +27,8 @@
                             </h3>
                             <div class="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-[72px] justify-items-center mt-3">
                                 @foreach ($topPopularityWorks as $topPopularityWork)
-                                    <div class="data-cell flex flex-col items-center w-[160px]">
+                                    <div
+                                        class="data-cell flex flex-col items-center w-[160px] h-full min-h-[280px] justify-start">
                                         <a href="{{ route('works.show', ['work' => $topPopularityWork['item']->id]) }}"
                                             class="mb-1 text-base text-textColor text-center h-[24px] leading-tight overflow-hidden break-words hover:underline">
                                             {{ $topPopularityWork['item']->name }}
@@ -39,8 +40,7 @@
                                                 <img src="{{ $topPopularityWork['item']->image }}" alt="画像が読み込めません。"
                                                     class="w-full h-full object-cover">
                                             </div>
-                                            <p
-                                                class="text-xs text-subTextColor mt-px leading-none text-center break-words whitespace-pre-wrap">
+                                            <p class="mt-1 text-xs text-subTextColor">
                                                 {{ $topPopularityWork['item']->copyright }}</p>
                                         @endif
                                     </div>

--- a/resources/views/main/index.blade.php
+++ b/resources/views/main/index.blade.php
@@ -30,8 +30,8 @@
                                     <div
                                         class="data-cell flex flex-col items-center w-[160px] h-full min-h-[280px] justify-start">
                                         <a href="{{ route('works.show', ['work' => $topPopularityWork['item']->id]) }}"
-                                            class="mb-1 text-base text-textColor text-center h-[24px] leading-tight overflow-hidden break-words hover:underline">
-                                            {{ $topPopularityWork['item']->name }}
+                                            class="mb-1 flex items-center justify-center text-base text-textColor text-center h-[40px] overflow-hidden leading-tight hover:underline">
+                                            <span class="line-clamp-2">{{ $topPopularityWork['item']->name }}</span>
                                         </a>
                                         <x-molecules.evaluation.star-num-detail :starNum="$topPopularityWork['item']->average_star_num" :postNum="null" />
                                         @if ($topPopularityWork['item']->image)

--- a/resources/views/main/index.blade.php
+++ b/resources/views/main/index.blade.php
@@ -13,7 +13,7 @@
                     </div>
                 </div>
                 <div class="popularity">
-                    <div class="flex gap-4 items-end">
+                    <div class="flex lg:gap-4 gap-2 items-end">
                         <h2 class="text-[22px] font-bold text-textColor">{{ __('entity.main.popularity_title') }}</h2>
                         <p class="mb-1 text-xs text-subTextColor">
                             {{ __('common.updated_at') . (count($topPopularityWorks) > 0 ? $topPopularityWorks[0]['item']->updated_at->format('Y/m/d H:i') : 'N/A') }}


### PR DESCRIPTION
## このPRで行ったこと
- SSIA

## このPRによってできること

- #197

## 参考リンク

- [AP-01-01 メイン画面のfigma](https://www.figma.com/design/Lj9JfRH9o8GTwuYk5fufBC/Aniconnect?node-id=154-158&t=QWcEYDg3WEDLeFgx-0)

## なぜこのような実装をしたか

- 前提
  - レスポンシブデザイン対応にするため、幅が最小のAndroid(360px)を想定 ([参考](https://www.takizawa-design.jp/knowledge/smartphone-site-pcsite-difference/))

- [fix:画像とコピーライトの隙間が大きいのを修正](https://github.com/Masaki1152/AniConnect/commit/1518da1a33eb6eb657026a1844be0fc300885112)
  -  隙間を埋めるため、不必要なwhitespace-pre-wrapを削除
  - コピーライト等長い場合でも各作品の高さを統一するためにmin-h-[280px]を追加
- [fix:スマートフォンで確認したときに作品名が長いと途切れるのを修正](https://github.com/Masaki1152/AniConnect/commit/eb11eeef587e43cc2d61c248417def3d4c2e1db0)
  -  長い作品名の場合、2行目までは折り返し、3点リーダーで表示するようにした
  - 一方で、作品名が1行の場合、垂直方向に中心に来るようにした
- [fix:スマートフォンにて「現在、人気急上昇中」と最終更新の折り返し方がおかしいのを修正](https://github.com/Masaki1152/AniConnect/commit/b6e50ab779d108ab29f88b13de72d532f2b8c59e)
  -  「現在、人気急上昇中」を簡潔に「人気上昇中」に変更
  - 幅がlg以上は「人気上昇中」と最終更新の間の余白を16px、lg未満の時は8pxになるように修正
- [fix:「作品一覧を見てみる！」ボタンが画像のすぐ下に来て上の画像との区別がしづらいのを修正](https://github.com/Masaki1152/AniConnect/commit/458e2e962810aca9e910c29bde94d333d32ed747)
  -  幅がsm以上はボタン右の余白を56px、sm未満の時は40pxになるように修正
- [fix:「作品部門」の文字が勝手に改行されて2行で表示されるのを修正](https://github.com/Masaki1152/AniConnect/commit/f0f20803c2c40df5e4354b8e21ac129beb29f0df)
  -  幅がsm以上は該当のテキストの左右の余白を124px、sm未満の時は40pxになるように修正

## 影響範囲

- AP-01-01 メイン画面

## 動作エビデンス
このPRによって起きたUIの変更や挙動をエビデンスとして貼り付ける

|変更前|変更後|
|---|---|
|変更前の画像を貼る|変更後の画像を貼る|
