### PR TITLE
【Routing】works.showにて、パラメーターをworkからwork_idに変更

### DIFF
--- a/app/Http/Controllers/Work/WorkController.php
+++ b/app/Http/Controllers/Work/WorkController.php
@@ -79,8 +79,10 @@ class WorkController extends Controller
     }
 
     // 詳細な作品情報を表示する
-    public function show(Work $work)
+    public function show($work_id)
     {
+        $work = Work::find($work_id);
+
         $categories = [];
         // カテゴリーの情報を取得する
         foreach ([$work->category_top_1, $work->category_top_2, $work->category_top_3] as $categoryId) {

--- a/resources/views/admin/relatedParty/creators/show.blade.php
+++ b/resources/views/admin/relatedParty/creators/show.blade.php
@@ -37,7 +37,7 @@
                 @else
                     @foreach ($creator->works as $work)
                         <div class='work_name'>
-                            <a href="{{ route('works.show', ['work' => $work->id]) }}">
+                            <a href="{{ route('works.show', ['work_id' => $work->id]) }}">
                                 {{ $work->name }}
                             </a>
                         </div>

--- a/resources/views/entities/characters/index.blade.php
+++ b/resources/views/entities/characters/index.blade.php
@@ -113,7 +113,7 @@
                     <p class='work'>
                         {{-- 関連する登場作品の数だけ繰り返す --}}
                         @foreach ($character->works as $character_work)
-                            <a href="{{ route('works.show', ['work' => $character_work->id]) }}">
+                            <a href="{{ route('works.show', ['work_id' => $character_work->id]) }}">
                                 {{ $character_work->name }}
                             </a>
                         @endforeach

--- a/resources/views/entities/characters/show.blade.php
+++ b/resources/views/entities/characters/show.blade.php
@@ -30,7 +30,7 @@
             <div class='work'>
                 {{-- 関連する登場作品の数だけ繰り返す --}}
                 @foreach ($character->works as $character_work)
-                    <a href="{{ route('works.show', ['work' => $character_work->id]) }}">
+                    <a href="{{ route('works.show', ['work_id' => $character_work->id]) }}">
                         {{ $character_work->name }}
                     </a>
                 @endforeach

--- a/resources/views/entities/music/index.blade.php
+++ b/resources/views/entities/music/index.blade.php
@@ -111,7 +111,7 @@
                         @endif
                     </h5>
                     <p class='work'>
-                        <a href="{{ route('works.show', ['work' => $music_object->work_id]) }}">
+                        <a href="{{ route('works.show', ['work_id' => $music_object->work_id]) }}">
                             {{ $music_object->work->name }}
                         </a>
                     </p>

--- a/resources/views/entities/music/show.blade.php
+++ b/resources/views/entities/music/show.blade.php
@@ -30,7 +30,7 @@
             </h5>
             <div class='work'>
                 <h3>登場作品</h3>
-                <a href="{{ route('works.show', ['work' => $music->work_id]) }}">
+                <a href="{{ route('works.show', ['work_id' => $music->work_id]) }}">
                     {{ $music->work->name }}
                 </a>
             </div>

--- a/resources/views/entities/pilgrimages/index.blade.php
+++ b/resources/views/entities/pilgrimages/index.blade.php
@@ -145,7 +145,7 @@
                     <p class='work'>
                         {{-- 関連する作品の数だけ繰り返す --}}
                         @foreach ($pilgrimage->works as $pilgrimage_work)
-                            <a href="{{ route('works.show', ['work' => $pilgrimage_work->id]) }}">
+                            <a href="{{ route('works.show', ['work_id' => $pilgrimage_work->id]) }}">
                                 {{ $pilgrimage_work->name }}
                             </a>
                         @endforeach

--- a/resources/views/entities/pilgrimages/show.blade.php
+++ b/resources/views/entities/pilgrimages/show.blade.php
@@ -26,7 +26,7 @@
                 <h3>登場作品</h3>
                 {{-- 関連する作品の数だけ繰り返す --}}
                 @foreach ($pilgrimage->works as $pilgrimage_work)
-                    <a href="{{ route('works.show', ['work' => $pilgrimage_work->id]) }}">
+                    <a href="{{ route('works.show', ['work_id' => $pilgrimage_work->id]) }}">
                         {{ $pilgrimage_work->name }}
                     </a>
                 @endforeach

--- a/resources/views/entities/related_party/creators/show.blade.php
+++ b/resources/views/entities/related_party/creators/show.blade.php
@@ -10,16 +10,16 @@
             <p>{{ $creator->wiki_link }}</p>
             <div class='works'>
                 <h3>作品一覧</h3>
-                @if($creator->works->isEmpty())
-                <h3 class='no_work'>結果がありません。</h3>
+                @if ($creator->works->isEmpty())
+                    <h3 class='no_work'>結果がありません。</h3>
                 @else
-                @foreach ($creator->works as $work)
-                <div class='work_name'>
-                    <a href="{{ route('works.show', ['work' => $work->id]) }}">
-                        {{ $work->name }}
-                    </a>
-                </div>
-                @endforeach
+                    @foreach ($creator->works as $work)
+                        <div class='work_name'>
+                            <a href="{{ route('works.show', ['work_id' => $work->id]) }}">
+                                {{ $work->name }}
+                            </a>
+                        </div>
+                    @endforeach
                 @endif
             </div>
         </div>

--- a/resources/views/entities/works/index.blade.php
+++ b/resources/views/entities/works/index.blade.php
@@ -98,7 +98,7 @@
                 @foreach ($works as $work)
                     <div class="p-6 border border-gray-200 rounded-lg shadow-sm">
                         <h2 class="text-xl font-semibold mb-2 text-blue-600">
-                            <a href="{{ route('works.show', ['work' => $work->id]) }}" class="hover:underline">
+                            <a href="{{ route('works.show', ['work_id' => $work->id]) }}" class="hover:underline">
                                 {{ $work->name }}
                             </a>
                         </h2>

--- a/resources/views/main/index.blade.php
+++ b/resources/views/main/index.blade.php
@@ -29,7 +29,7 @@
                                 @foreach ($topPopularityWorks as $topPopularityWork)
                                     <div
                                         class="data-cell flex flex-col items-center w-[160px] h-full min-h-[280px] justify-start">
-                                        <a href="{{ route('works.show', ['work' => $topPopularityWork['item']->id]) }}"
+                                        <a href="{{ route('works.show', ['work_id' => $topPopularityWork['item']->id]) }}"
                                             class="mb-1 flex items-center justify-center text-base text-textColor text-center h-[40px] overflow-hidden leading-tight hover:underline">
                                             <span class="line-clamp-2">{{ $topPopularityWork['item']->name }}</span>
                                         </a>

--- a/resources/views/posts/character_posts/index.blade.php
+++ b/resources/views/posts/character_posts/index.blade.php
@@ -100,7 +100,7 @@
                             <p class='work'>
                                 {{-- 関連する登場作品の数だけ繰り返す --}}
                                 @foreach ($character->works as $character_work)
-                                    <a href="{{ route('works.show', ['work' => $character_work->id]) }}">
+                                    <a href="{{ route('works.show', ['work_id' => $character_work->id]) }}">
                                         {{ $character_work->name }}
                                     </a>
                                 @endforeach

--- a/resources/views/posts/work_posts/show.blade.php
+++ b/resources/views/posts/work_posts/show.blade.php
@@ -17,7 +17,7 @@
         <div class="lg:col-span-2 space-y-6">
             <div class="text-lg font-semibold">
                 「
-                <a href="{{ route('works.show', ['work' => $work_post->work_id]) }}"
+                <a href="{{ route('works.show', ['work_id' => $work_post->work_id]) }}"
                     class="text-blue-500 hover:text-blue-700 underline">
                     {{ $work_post->work->name }}
                 </a>

--- a/resources/views/posts/work_story_posts/show.blade.php
+++ b/resources/views/posts/work_story_posts/show.blade.php
@@ -17,7 +17,7 @@
         <div class="lg:col-span-2 space-y-6">
             <div class="text-lg font-semibold">
                 「
-                <a href="{{ route('works.show', ['work' => $work_story_post->work_id]) }}"
+                <a href="{{ route('works.show', ['work_id' => $work_story_post->work_id]) }}"
                     class="text-blue-500 hover:text-blue-700 underline">
                     {{ $work_story_post->workStory->work->name }}
                 </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -206,7 +206,7 @@ Route::controller(WorkController::class)->group(function () {
     // 作品一覧の表示
     Route::get('/works', 'index')->name('works.index');
     // 各作品の詳細表示
-    Route::get('/works/{work}', 'show')->name('works.show');
+    Route::get('/works/{work_id}', 'show')->name('works.show');
 
     Route::middleware(['auth'])->group(function () {
         // 各作品の「気になる」ボタン押下で「気になる」登録をする処理


### PR DESCRIPTION
## このPRで行ったこと

- SSIA

## このPRによってできること

- characters.showのパラメーター名は「character_id」、music.showのパラメーターは「music_id」にもかかわらず、works.showのパラメーターだけ「work」であったため、コンポーネント用に「work_id」に統一

## なぜこのような実装をしたか

- [fix:works.showにて、パラメーターをworkからwork_idに変更](https://github.com/Masaki1152/AniConnect/commit/e40f4f5c338c5d85a18a37476969c91db54e5dae)
  -  characters.showのパラメーター名は「character_id」、music.showのパラメーターは「music_id」にもかかわらず、works.showのパラメーターだけ「work」であったため、コンポーネント用に「work_id」に統一
  - WorkControllerのshowメソッドでも、明示的に$work_idでしたデータを取得するように変更


## 影響範囲

- AP-04-02 作品詳細に遷移するすべての画面（全て遷移を確認済み）
