### PR TITLE
【メイン】AP-01-01 メイン画面の人気急上昇セクションの表示（スマートフォンでの表示用レイアウトの作成）

### DIFF
--- a/app/Http/Controllers/Main/MainController.php
+++ b/app/Http/Controllers/Main/MainController.php
@@ -11,10 +11,12 @@ use App\Models\Music;
 use App\Models\AnimePilgrimage;
 use App\Models\Notification;
 use Illuminate\Support\Facades\Cache;
-
+use App\Traits\CommonFunction;
 
 class MainController extends Controller
 {
+    use CommonFunction;
+
     // メイン画面の表示
     public function index(Work $work, WorkStory $workStory, Character $character, Music $music, AnimePilgrimage $animePilgrimage, Notification $notification)
     {
@@ -28,6 +30,7 @@ class MainController extends Controller
             // 再度キャッシュから人気度の高い作品を取得
             $topPopularityWorks = Cache::get('top_popular_works');
         }
+        $topPopularityWorks = $this->addTypeToItem($topPopularityWorks, 'work');
 
         // 人気上位のあらすじを取得(毎度作品ごとに異なるためforgetを行う)
         Cache::forget('top_popular_work_stories');
@@ -36,6 +39,7 @@ class MainController extends Controller
         $workStory->updateTopPopularityItems($sufficientPostsWorkStories, 'workStoryPosts', 'top_popular_work_stories');
         // キャッシュから人気度の高い作品を取得
         $topPopularityWorkStories = Cache::get('top_popular_work_stories');
+        $topPopularityWorkStories = $this->addTypeToItem($topPopularityWorkStories, 'work_story');
 
         // 人気上位の登場人物を取得
         $topPopularityCharacters = Cache::get('top_popular_characters');
@@ -47,6 +51,7 @@ class MainController extends Controller
             // 再度キャッシュから人気度の高い登場人物を取得
             $topPopularityCharacters = Cache::get('top_popular_characters');
         }
+        $topPopularityCharacters = $this->addTypeToItem($topPopularityCharacters, 'character');
 
         // 人気上位の音楽を取得
         $topPopularityMusic = Cache::get('top_popular_music');
@@ -58,6 +63,7 @@ class MainController extends Controller
             // 再度キャッシュから人気度の高い音楽を取得
             $topPopularityMusic = Cache::get('top_popular_music');
         }
+        $topPopularityMusic = $this->addTypeToItem($topPopularityMusic, 'music');
 
         // 人気上位の聖地を取得
         $topPopularityPilgrimages = Cache::get('top_popular_pilgrimages');
@@ -69,6 +75,7 @@ class MainController extends Controller
             // 再度キャッシュから人気度の高い作品を取得
             $topPopularityPilgrimages = Cache::get('top_popular_pilgrimages');
         }
+        $topPopularityPilgrimages = $this->addTypeToItem($topPopularityPilgrimages, 'pilgrimage');
 
         // 最新のお知らせ4件の取得
         $notifications = $notification->getRecentNotifications();

--- a/app/Traits/CommonFunction.php
+++ b/app/Traits/CommonFunction.php
@@ -116,4 +116,13 @@ trait CommonFunction
         // 該当しない場合はnull
         return null;
     }
+
+    // 各項目の人気アイテムにタイプを渡す
+    public function addTypeToItem($items, $type)
+    {
+        foreach ($items as &$item) {
+            $item['itemType'] = $type;
+        }
+        return $items;
+    }
 }

--- a/app/View/Components/Molecules/Cell/PopularItem.php
+++ b/app/View/Components/Molecules/Cell/PopularItem.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\View\Components\Molecules\Cell;
+
+use Illuminate\View\Component;
+
+class PopularItem extends Component
+{
+    public $popularItem;
+    public $itemType;
+    public $imageAspect;
+
+    public function __construct($popularItem)
+    {
+        $this->popularItem = $popularItem;
+        $this->itemType = $popularItem['itemType'];
+
+        $vertical = "aspect-[3/4]";
+        $horizontal = "aspect-[4/3]";
+        $square = "aspect-square";
+        switch ($this->itemType) {
+            case "work":
+                $this->imageAspect = $vertical;
+                break;
+            case "work_story":
+            case "character":
+            case "pilgrimage":
+                $this->imageAspect = $horizontal;
+                break;
+            case "music":
+                $this->imageAspect = $square;
+                break;
+        }
+    }
+
+    public function render()
+    {
+        return view('components.molecules.cell.popular-item');
+    }
+}

--- a/app/View/Components/Organisms/PopularItemCaroucel.php
+++ b/app/View/Components/Organisms/PopularItemCaroucel.php
@@ -11,6 +11,7 @@ class PopularItemCaroucel extends Component
     public $topPopularityCharacters;
     public $topPopularityMusic;
     public $topPopularityPilgrimages;
+    public $allPopularItems;
 
     public function __construct($topPopularityWorks, $topPopularityWorkStories, $topPopularityCharacters, $topPopularityMusic, $topPopularityPilgrimages)
     {
@@ -19,6 +20,12 @@ class PopularItemCaroucel extends Component
         $this->topPopularityCharacters = $topPopularityCharacters;
         $this->topPopularityMusic = $topPopularityMusic;
         $this->topPopularityPilgrimages = $topPopularityPilgrimages;
+
+        $this->allPopularItems = array_merge(
+            $topPopularityWorks,
+            $topPopularityWorkStories,
+            $topPopularityCharacters
+        );
     }
 
     public function render()

--- a/app/View/Components/Organisms/PopularThreeItemsSection.php
+++ b/app/View/Components/Organisms/PopularThreeItemsSection.php
@@ -10,27 +10,10 @@ class PopularThreeItemsSection extends Component
     public $itemType;
     public $imageAspect;
 
-    public function __construct($popularItems, $itemType)
+    public function __construct($popularItems)
     {
         $this->popularItems = $popularItems;
-        $this->itemType = $itemType;
-
-        $vertical = "w-[123px] h-[164px]";
-        $horizontal = "w-[164px] h-[123px]";
-        $square = "w-[123px] h-[123px]";
-        switch ($itemType) {
-            case "work":
-                $this->imageAspect = $vertical;
-                break;
-            case "work_story":
-            case "character":
-            case "pilgrimage":
-                $this->imageAspect = $horizontal;
-                break;
-            case "music":
-                $this->imageAspect = $square;
-                break;
-        }
+        $this->itemType = $popularItems[0]['itemType'];
     }
 
     public function render()

--- a/public/js/popular_carousel.js
+++ b/public/js/popular_carousel.js
@@ -1,16 +1,65 @@
 import Swiper from 'https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.mjs';
 
-const swiper = new Swiper('.swiper', {
+const desktopSwiper = new Swiper('.swiper-desktop', {
     loop: true,
     autoplay: {
         delay: 10000,
     },
     navigation: {
-        nextEl: '.swiper-button-next',
-        prevEl: '.swiper-button-prev',
+        nextEl: '.swiper-desktop .swiper-button-next',
+        prevEl: '.swiper-desktop .swiper-button-prev',
     },
     pagination: {
-        el: '.swiper-pagination',
+        el: '.swiper-desktop .swiper-pagination',
         clickable: true,
+    },
+});
+
+const mobileSwiper = new Swiper('.swiper-mobile', {
+    autoplay: {
+        delay: 5000,
+    },
+    spaceBetween: 8,
+    navigation: {
+        nextEl: '.swiper-mobile .swiper-button-next',
+        prevEl: '.swiper-mobile .swiper-button-prev',
+    },
+    breakpoints: {
+        0: {
+            slidesPerView: 1.7,
+        },
+        380: {
+            slidesPerView: 1.8,
+        },
+        420: {
+            slidesPerView: 2,
+        },
+        460: {
+            slidesPerView: 2.2,
+        },
+        500: {
+            slidesPerView: 2.4,
+        },
+        540: {
+            slidesPerView: 2.6,
+        },
+        580: {
+            slidesPerView: 2.8,
+        },
+        620: {
+            slidesPerView: 3,
+        },
+        660: {
+            slidesPerView: 3.2,
+        },
+        700: {
+            slidesPerView: 3.4,
+        },
+        740: {
+            slidesPerView: 3.6,
+        },
+        780: {
+            slidesPerView: 3.8,
+        },
     },
 });

--- a/resources/views/components/molecules/cell/popular-item.blade.php
+++ b/resources/views/components/molecules/cell/popular-item.blade.php
@@ -1,0 +1,43 @@
+<h3 class="my-1 text-base font-semibold text-textColor text-center border-b-2 border-mainColor md:hidden">
+    {{ __('entity.main.popularity_' . $itemType . '_department') }}
+</h3>
+<!-- あらすじの表示 -->
+@if ($popularItem['itemType'] == 'work_story')
+    <a href="{{ route('work_stories.show', ['work_id' => $popularItem['item']->work_id, $popularItem['itemType'] . '_id' => $popularItem['item']->id]) }}"
+        class="mb-3 flex items-center justify-center text-base text-textColor text-center h-[40px] overflow-hidden leading-tight hover:underline">
+        <span class="line-clamp-2">「{{ $popularItem['item']->sub_title }}」</span>
+    </a>
+    <a href="{{ route('works.show', ['work_id' => $popularItem['item']->work_id]) }}"
+        class="mb-1 flex items-center justify-center text-xs text-subTextColor text-center h-4 overflow-hidden leading-tight hover:underline">
+        <span class="line-clamp-1">{{ $popularItem['item']->work->name }}</span>
+    </a>
+    <p class="mb-1 flex items-center justify-center text-xs text-subTextColor text-center h-4 overflow-hidden">
+        {{ $popularItem['item']->episode . ' ' . __('entity.episode_in_work') }}</p>
+@else
+    <a href="{{ route($popularItem['itemType'] . 's.show', [$popularItem['itemType'] . '_id' => $popularItem['item']->id]) }}"
+        class="mb-1 flex items-center justify-center text-base text-textColor text-center h-[40px] overflow-hidden leading-tight hover:underline">
+        <span class="line-clamp-2">{{ $popularItem['item']->name }}</span>
+    </a>
+    @if ($popularItem['itemType'] == 'character')
+        <p class="mb-1 flex items-center justify-center text-xs text-subTextColor text-center h-4">
+            {{ __('entity.main.character_in_work') }}</p>
+        <a href="{{ route('works.show', ['work_id' => $popularItem['item']->works->first()->id]) }}"
+            class="mb-1 flex items-center justify-center text-xs text-subTextColor text-center h-4 overflow-hidden leading-tight hover:underline">
+            <span class="line-clamp-1">{{ $popularItem['item']->works->first()->name }}</span>
+        </a>
+    @endif
+@endif
+<div class="flex justify-center">
+    <x-molecules.evaluation.star-num-detail :starNum="$popularItem['item']->average_star_num" :postNum="null" />
+</div>
+@if ($popularItem['item']->image)
+    <div class="flex flex-col items-center justify-center">
+        <div class="mt-2 w-[112px] md:w-[123px] {{ $imageAspect }} overflow-hidden border border-gray-300">
+            <img src="{{ $popularItem['item']->image }}" alt="{{ __('common.not_reloaded_images') }}"
+                class="w-full h-full object-cover">
+        </div>
+        <div class="mt-1 text-[8px] md:text-xs text-subTextColor">
+            {{ $popularItem['item']->copyright }}
+        </div>
+    </div>
+@endif

--- a/resources/views/components/organisms/popular-item-caroucel.blade.php
+++ b/resources/views/components/organisms/popular-item-caroucel.blade.php
@@ -1,16 +1,32 @@
-<div class="swiper">
+<div class="swiper swiper-desktop hidden md:block">
     <div class="swiper-wrapper">
         <div class="swiper-slide mb-4">
-            <x-organisms.popular-three-items-section :popularItems="$topPopularityWorks" itemType="work" />
+            <x-organisms.popular-three-items-section :popularItems="$topPopularityWorks" />
         </div>
         <div class="swiper-slide">
-            <x-organisms.popular-three-items-section :popularItems="$topPopularityWorkStories" itemType="work_story" />
+            <x-organisms.popular-three-items-section :popularItems="$topPopularityWorkStories" />
         </div>
         <div class="swiper-slide">
-            <x-organisms.popular-three-items-section :popularItems="$topPopularityCharacters" itemType="character" />
+            <x-organisms.popular-three-items-section :popularItems="$topPopularityCharacters" />
         </div>
     </div>
     <x-atom.swiper-button-prev />
     <x-atom.swiper-button-next />
     <div class="swiper-pagination"></div>
+</div>
+<!-- モバイルでの表示 -->
+<div class="swiper swiper-mobile md:hidden">
+    <div class="swiper-wrapper">
+        @foreach ($allPopularItems as $popularItem)
+            <div class="swiper-slide mb-6">
+                <div
+                    class="data-cell flex flex-col items-center w-[160px] min-h-[310px] border-2 border-mainColor rounded-xl p-2">
+                    <x-molecules.cell.popular-item :popularItem="$popularItem" />
+                </div>
+            </div>
+        @endforeach
+        <x-atom.swiper-button-prev />
+        <x-atom.swiper-button-next />
+        <div class="swiper-pagination"></div>
+    </div>
 </div>

--- a/resources/views/components/organisms/popular-three-items-section.blade.php
+++ b/resources/views/components/organisms/popular-three-items-section.blade.php
@@ -5,42 +5,7 @@
     <div class="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-[72px] justify-items-center mt-3">
         @foreach ($popularItems as $popularItem)
             <div class="data-cell flex flex-col items-center w-[160px] h-full min-h-[280px] justify-start">
-                <!-- あらすじの表示 -->
-                @if ($itemType == 'work_story')
-                    <a href="{{ route('work_stories.show', ['work_id' => $popularItem['item']->work_id, $itemType . '_id' => $popularItem['item']->id]) }}"
-                        class="mb-3 flex items-center justify-center text-base text-textColor text-center h-[40px] overflow-hidden leading-tight hover:underline">
-                        <span class="line-clamp-2">「{{ $popularItem['item']->sub_title }}」</span>
-                    </a>
-                    <a href="{{ route('works.show', ['work_id' => $popularItem['item']->work_id]) }}"
-                        class="mb-1 flex items-center justify-center text-xs text-subTextColor text-center h-4 overflow-hidden leading-tight hover:underline">
-                        <span class="line-clamp-1">{{ $popularItem['item']->work->name }}</span>
-                    </a>
-                    <p
-                        class="mb-1 flex items-center justify-center text-xs text-subTextColor text-center h-4 overflow-hidden">
-                        {{ $popularItem['item']->episode . ' ' . __('entity.episode_in_work') }}</p>
-                @else
-                    <a href="{{ route($itemType . 's.show', [$itemType . '_id' => $popularItem['item']->id]) }}"
-                        class="mb-1 flex items-center justify-center text-base text-textColor text-center h-[40px] overflow-hidden leading-tight hover:underline">
-                        <span class="line-clamp-2">{{ $popularItem['item']->name }}</span>
-                    </a>
-                    @if ($itemType == 'character')
-                        <p class="mb-1 flex items-center justify-center text-xs text-subTextColor text-center h-4">
-                            {{ __('entity.main.character_in_work') }}</p>
-                        <a href="{{ route('works.show', ['work_id' => $popularItem['item']->works->first()->id]) }}"
-                            class="mb-1 flex items-center justify-center text-xs text-subTextColor text-center h-4 overflow-hidden leading-tight hover:underline">
-                            <span class="line-clamp-1">{{ $popularItem['item']->works->first()->name }}</span>
-                        </a>
-                    @endif
-                @endif
-                <x-molecules.evaluation.star-num-detail :starNum="$popularItem['item']->average_star_num" :postNum="null" />
-                @if ($popularItem['item']->image)
-                    <div class="mt-2 flex items-center justify-center overflow-hidden border border-gray-300">
-                        <img src="{{ $popularItem['item']->image }}" alt="{{ __('common.not_reloaded_images') }}"
-                            class="object-cover {{ $imageAspect }}">
-                    </div>
-                    <p class="mt-1 text-xs text-subTextColor">
-                        {{ $popularItem['item']->copyright }}</p>
-                @endif
+                <x-molecules.cell.popular-item :popularItem="$popularItem" :imageAspect="$imageAspect" />
             </div>
         @endforeach
     </div>

--- a/resources/views/main/index.blade.php
+++ b/resources/views/main/index.blade.php
@@ -19,7 +19,7 @@
                             {{ __('common.updated_at') . (count($topPopularityWorks) > 0 ? $topPopularityWorks[0]['item']->updated_at->format('Y/m/d H:i') : 'N/A') }}
                         </p>
                     </div>
-                    <div class="mt-4 border-2 border-mainColor rounded-xl lg:mx-14">
+                    <div class="mt-4 md:border-2 border-mainColor rounded-xl lg:mx-14">
                         <x-organisms.popular-item-caroucel :topPopularityWorks="$topPopularityWorks" :topPopularityWorkStories="$topPopularityWorkStories" :topPopularityCharacters="$topPopularityCharacters"
                             :topPopularityMusic="$topPopularityMusic" :topPopularityPilgrimages="$topPopularityPilgrimages" />
                     </div>


### PR DESCRIPTION
## このPRで行ったこと

- SSIA

## このPRによってできること
- #197

## 参考リンク
- AP-01-01 メイン画面の設計書
- [AP-01-01 メイン画面のfigma](https://www.figma.com/design/Lj9JfRH9o8GTwuYk5fufBC/Aniconnect?node-id=154-158&t=QWcEYDg3WEDLeFgx-0)

## なぜこのような実装をしたか

- [feature:人気のアイテムにitemTypeのプロパティを追加](https://github.com/Masaki1152/AniConnect/commit/7d37c65b49184fd667c563fe92837bdfbc7ebcc0)
  -  各コンポーネントで、文言の切り替えや画像の縦横比切り替えのため、itemTypeを渡していたが、冗長であった
  - そこで、mainControllerでキャッシュから人気のアイテムを取得する際に各アイテムにitemTypeを付与するよう修正
  - それに伴い、コンポーネント呼び出しの際にitemTypeを渡す必要がなくなった
  - また、各アイテムにitemTypeを付与するメソッドは各アイテムで用いるためCommonFunctionに追加して共通化した
- [feature:カルーセルに表示する各アイテムのセルをコンポーネント化](https://github.com/Masaki1152/AniConnect/commit/c5636427ff5adc187e019bcc2a5112176c8bb0c8)
  -  ウェブ用の画面とモバイル用の画面でカルーセルの表示形式を変更した
  - それにより、中身の各アイテムのセルは同じためpopular-itemとしてコンポーネントとして切り出した
- [feature:レスポンシブを意識したカルーセル表示方法の修正](https://github.com/Masaki1152/AniConnect/commit/ef2cd4577114f1e5a757733639c8acd41f0193de)
  -  モバイル用画面では、表示に際して全部門を等しく表示するため、allPopularItemsとしてまとめた
  - モバイル用画面では画面幅により余白が広がりすぎるため、画面幅によって見えるアイテムのセルの枚数を細かく変更するようにpopular-carousel.jsにコードを追加

## 影響範囲
- AP-01-01 メイン画面

## 動作エビデンス

- 今回はAndroid(幅360px)、iPhone14(幅390px)をエビデンスとして用意
- 各端末のサイズについて（[参考](https://www.takizawa-design.jp/knowledge/smartphone-site-pcsite-difference/)）

|Android(360px)|iPhone14(390px)|
|---|---|
|<img width="352" height="874" alt="image" src="https://github.com/user-attachments/assets/102f80e7-503c-4714-9eb0-3314e2c640b4" />|<img width="388" height="867" alt="image" src="https://github.com/user-attachments/assets/befea36a-6363-4aea-a3e3-6a4021ced1bb" />|
