### PR TITLE
【ユーザー要望】AP-00-01 ヘッダーの固定とAP-01-01 メイン画面の人気セクションのアイテムを中央揃えにする

### DIFF
--- a/public/js/popular_carousel.js
+++ b/public/js/popular_carousel.js
@@ -20,6 +20,8 @@ const mobileSwiper = new Swiper('.swiper-mobile', {
         delay: 5000,
     },
     spaceBetween: 8,
+    centeredSlides: true,
+    loop: true,
     breakpoints: {
         0: {
             slidesPerView: 1.7,

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -43,7 +43,7 @@
     @include('layouts.navigation')
 
     <!-- Page Content -->
-    <main class="flex-grow bg-baseColor">
+    <main class="flex-grow bg-baseColor pt-16">
         {{ $slot }}
     </main>
     <x-atom.footer />

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,4 +1,4 @@
-<nav x-data="{ open: false }" class="bg-baseColor border-b-2 border-mainColor">
+<nav x-data="{ open: false }" class="fixed top-0 left-0 w-full z-50 bg-baseColor border-b-2 border-mainColor">
     <!-- Primary Navigation Menu -->
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div class="flex justify-between h-16">


### PR DESCRIPTION
## このPRで行ったこと

- SSIA

## このPRによってできること

- #197

## 参考リンク
- AP-01-01 メイン画面の設計書
- [AP-01-01 メイン画面のfigma](https://www.figma.com/design/Lj9JfRH9o8GTwuYk5fufBC/Aniconnect?node-id=154-158&t=QWcEYDg3WEDLeFgx-0)

## なぜこのような実装をしたか

- どちらもユーザー目線の意見として修正
- [fix:ヘッダーを固定する](https://github.com/Masaki1152/AniConnect/commit/3782ef87f5fa9dc7fe7090ab81d3bd3d702cb097)
  -  ヘッダーを固定することで常にログイン等の導線を確認可能になった
- [fix:カルーセル内のアイテムを中央ぞろえにする](https://github.com/Masaki1152/AniConnect/commit/1a8d9c0cb6ae680d92528c074a8a424cf8a079fd)
  - アイテムの中央揃えとループをtrueにすることにより、一般的なカルーセルの表示に近づけた 
  - なお、アイテムの中央揃えはモバイル用表示時のみである

## 影響範囲

- ヘッダーに関しては全画面
- AP-01-01 メイン画面

## 動作エビデンス

- ヘッダーが固定されている

https://github.com/user-attachments/assets/84a2f719-ef6a-478a-9854-1e3080b5b031



- セクション内のアイテムが中央揃えである

|変更前|変更後|
|---|---|
|<img width="364" height="392" alt="image" src="https://github.com/user-attachments/assets/291a6b71-d54e-4bba-b759-94bb91fff720" />|<img width="362" height="378" alt="image" src="https://github.com/user-attachments/assets/d7c8217c-197c-4021-8b59-ef038e720c6c" />|
