### PR TITLE
【ユーザーリクエスト】AP-01-01 メイン画面の人気上昇セクションの左右パディングをなくす

### DIFF
--- a/resources/js/popular_carousel.js
+++ b/resources/js/popular_carousel.js
@@ -24,40 +24,40 @@ const mobileSwiper = new Swiper('.swiper-mobile', {
     loop: true,
     breakpoints: {
         0: {
-            slidesPerView: 1.7,
+            slidesPerView: 2.1,
         },
         380: {
-            slidesPerView: 1.8,
-        },
-        420: {
-            slidesPerView: 2,
-        },
-        460: {
             slidesPerView: 2.2,
         },
-        500: {
+        420: {
             slidesPerView: 2.4,
         },
-        540: {
+        460: {
             slidesPerView: 2.6,
         },
-        580: {
+        500: {
             slidesPerView: 2.8,
         },
-        620: {
+        540: {
             slidesPerView: 3,
         },
-        660: {
+        580: {
             slidesPerView: 3.2,
         },
-        700: {
+        620: {
             slidesPerView: 3.4,
         },
-        740: {
+        660: {
             slidesPerView: 3.6,
         },
-        780: {
+        700: {
             slidesPerView: 3.8,
+        },
+        740: {
+            slidesPerView: 4,
+        },
+        780: {
+            slidesPerView: 4.2,
         },
     },
 });

--- a/resources/views/main/index.blade.php
+++ b/resources/views/main/index.blade.php
@@ -1,8 +1,8 @@
 <x-app-layout>
     <div class="py-10">
-        <div class="w-full max-w-[960px] mx-auto px-4 lg:px-0">
-            <div class="main-content px-4 flex flex-col gap-6">
-                <div class="introduction">
+        <div class="w-full max-w-[960px] mx-auto lg:px-0">
+            <div class="main-content flex flex-col gap-6">
+                <div class="introduction px-8">
                     <h2 class="text-2xl font-bold text-textColor">{{ __('entity.main.introduction_title') }}</h2>
                     <p class="mt-4 text-base font-medium text-textColor border-2 border-mainColor px-6 py-3 rounded-xl">
                         {!! __('entity.main.introduction_description') !!}</p>
@@ -12,8 +12,8 @@
                         </a>
                     </div>
                 </div>
-                <div class="popularity">
-                    <div class="flex lg:gap-4 gap-2 items-end">
+                <div class="popularity md:px-8">
+                    <div class="flex lg:gap-4 gap-2 items-end px-8 md:px-0">
                         <h2 class="text-[22px] font-bold text-textColor">{{ __('entity.main.popularity_title') }}</h2>
                         <p class="mb-1 text-xs text-subTextColor">
                             {{ __('common.updated_at') . (count($topPopularityWorks) > 0 ? $topPopularityWorks[0]['item']->updated_at->format('Y/m/d H:i') : 'N/A') }}
@@ -24,7 +24,7 @@
                             :topPopularityMusic="$topPopularityMusic" :topPopularityPilgrimages="$topPopularityPilgrimages" />
                     </div>
                 </div>
-                <div class="notifications">
+                <div class="notifications px-8">
                     <h2 class="text-[22px] font-bold text-textColor">{{ __('entity.main.notification_title') }}</h2>
                     <div
                         class="notification_list mt-4 lg:mx-14 border-2 border-mainColor p-4 rounded-xl divide-y divide-mainColor">


### PR DESCRIPTION
## このPRで行ったこと

- SSIA

## このPRによってできること

- 今まで人気上昇セクションにも左右パディングを入れていたが、圧迫感があるという声があった
- そこで、パディングをなくし、カルーセルのアイテムの見える範囲をより広くした
- これに関して、「圧迫感がなくなった」、「左右のコンテンツも見える量が増えて興味湧く感がある」というありがたい意見がもらえた

## 参考リンク
- [AP-01-01 メイン画面の設計書](https://docs.google.com/spreadsheets/d/1xKOCGkVUHs5eg1DemfNW14pzDpzDRZ-voBUVQMgtnFo/edit?gid=1465468173#gid=1465468173)
- [AP-01-01 メイン画面のfigma](https://www.figma.com/design/Lj9JfRH9o8GTwuYk5fufBC/Aniconnect?node-id=154-158&t=QWcEYDg3WEDLeFgx-0)

## なぜこのような実装をしたか

- [fix:人気上昇セクションのパディングをなくす](https://github.com/Masaki1152/AniConnect/commit/b64ad92bfd745869db341fd0b7048ff83e955f7b)
  - 今まで画面全体にパディングを適応していたが、人気上昇セクションだけなくすということで、個別にパディングを設定するように変更
- [fix:画面幅によって表示するアイテムの数を変更する](https://github.com/Masaki1152/AniConnect/commit/c47d4afa0c0323f66089f9de3dad9cd48a36ebe8)
  - パディングをなくしたことで、各アイテムをより多く表示できるようになったため、画面幅による表示枚数を変更

## 影響範囲

- AP-01-01 メイン画面

## 動作エビデンス

|変更前|変更後|
|---|---|
|<img width="430" height="951" alt="image" src="https://github.com/user-attachments/assets/6680ee92-6d11-44b6-a5a3-a76aa6e683d1" />|<img width="434" height="953" alt="image" src="https://github.com/user-attachments/assets/aa78c9f6-a9f4-481e-aac7-dd92648c08ba" />|
